### PR TITLE
refactor(ds-app)!: compose Item, ItemButton, ItemSwitch and ItemExpandable via children

### DIFF
--- a/packages/react/ds-app/src/lib/SideNavigation/SideNavigation.stories.tsx
+++ b/packages/react/ds-app/src/lib/SideNavigation/SideNavigation.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
+import { fn } from "storybook/test";
 import {
   lxdContentRoot,
   lxdFooterRoot,
@@ -11,6 +12,7 @@ import {
   withNavigationRouterProps,
   withNavLayout,
 } from "../../storybook/navigation/story-utils.js";
+import type { ContextSwitcherItem } from "./common/ContextSwitcher/types.js";
 import SideNavigation from "./SideNavigation.js";
 
 const meta: Meta<typeof SideNavigation> = {
@@ -100,4 +102,49 @@ export const Mobile: Story = {
       </div>
     ),
   ],
+};
+
+const composedContexts: ContextSwitcherItem[] = [
+  { key: "default", name: "default" },
+  { key: "staging", name: "staging", description: "Staging environment" },
+];
+
+/**
+ * Fully composed `Content` — a consumer builds the navigation region
+ * directly out of JSX (via `children`) instead of the `root` data shape,
+ * to place a `ContextSwitcher` at its "content-defined position" (SPEC.md
+ * §1.1, §4.5) above the item groups. Exercises every row variant (`Item`,
+ * `ItemButton`, `ItemSwitch`, `ItemExpandable`) and `Separator` together.
+ */
+export const ComposedContent: Story = {
+  args: {
+    applicationName: "LXD",
+    children: (
+      <>
+        <SideNavigation.ContextSwitcher
+          currentContext={composedContexts[0]}
+          contexts={composedContexts}
+          onContextChange={fn()}
+        />
+        <SideNavigation.Group label="Project">
+          <SideNavigation.Item url="/instances" icon="containers">
+            Instances
+          </SideNavigation.Item>
+          <SideNavigation.ItemExpandable heading="Networking" icon="connected">
+            <SideNavigation.Item url="/networks">Networks</SideNavigation.Item>
+            <SideNavigation.Item url="/network-acls">ACLs</SideNavigation.Item>
+          </SideNavigation.ItemExpandable>
+        </SideNavigation.Group>
+        <SideNavigation.Separator />
+        <SideNavigation.Group label="Preferences">
+          <SideNavigation.ItemSwitch icon="dark-theme" defaultChecked>
+            Dark mode
+          </SideNavigation.ItemSwitch>
+          <SideNavigation.ItemButton icon="log-out" onClick={fn()}>
+            Log out
+          </SideNavigation.ItemButton>
+        </SideNavigation.Group>
+      </>
+    ),
+  },
 };

--- a/packages/react/ds-app/src/lib/SideNavigation/SideNavigation.tests.tsx
+++ b/packages/react/ds-app/src/lib/SideNavigation/SideNavigation.tests.tsx
@@ -146,4 +146,23 @@ describe("SideNavigation", () => {
       "Settings", // footer, top-to-bottom
     ]);
   });
+
+  it("renders children as the content region's fallback when no root is given (SPEC.md §4.5)", () => {
+    render(
+      <SideNavigation>
+        <SideNavigation.Item url="/machines">Machines</SideNavigation.Item>
+      </SideNavigation>,
+    );
+    expect(screen.getByRole("link", { name: "Machines" })).toBeInTheDocument();
+  });
+
+  it("prefers root over children when both are given", () => {
+    render(
+      <SideNavigation root={root}>
+        <SideNavigation.Item url="/composed">Composed</SideNavigation.Item>
+      </SideNavigation>,
+    );
+    expect(screen.getByText("Machines")).toBeInTheDocument();
+    expect(screen.queryByText("Composed")).not.toBeInTheDocument();
+  });
 });

--- a/packages/react/ds-app/src/lib/SideNavigation/SideNavigation.tsx
+++ b/packages/react/ds-app/src/lib/SideNavigation/SideNavigation.tsx
@@ -53,6 +53,7 @@ const SideNavigation = ({
   // onExpandedChange,
   keyboardShortcut = false,
   "aria-label": ariaLabel,
+  children,
   ...props
 }: SideNavigationProps): React.ReactElement => {
   const contentId = useId();
@@ -101,7 +102,9 @@ const SideNavigation = ({
         root={root}
         LinkComponent={LinkComponent}
         currentUrl={currentUrl}
-      />
+      >
+        {children}
+      </Content>
       {(footerItems && footerItems.length > 0) || footerRoot ? (
         <Footer
           root={footerRoot}

--- a/packages/react/ds-app/src/lib/SideNavigation/common/Footer/Footer.tsx
+++ b/packages/react/ds-app/src/lib/SideNavigation/common/Footer/Footer.tsx
@@ -35,23 +35,20 @@ const renderFooterItem = (
 
   if (item.url) {
     return (
-      <Item
-        key={item.kind}
-        url={item.url}
-        label={label}
-        icon={icon}
-        slot={item.slot}
-      />
+      <Item key={item.kind} url={item.url} icon={icon} slot={item.slot}>
+        {label}
+      </Item>
     );
   }
   return (
     <ItemButton
       key={item.kind}
-      label={label}
       icon={icon}
       slot={item.slot}
       onClick={item.onClick}
-    />
+    >
+      {label}
+    </ItemButton>
   );
 };
 

--- a/packages/react/ds-app/src/lib/SideNavigation/common/Group/Group.stories.tsx
+++ b/packages/react/ds-app/src/lib/SideNavigation/common/Group/Group.stories.tsx
@@ -19,8 +19,12 @@ export const Labelled: Story = {
     label: "Hardware",
     children: (
       <>
-        <Item url="/machines" label="Machines" icon="machines" />
-        <Item url="/devices" label="Devices" icon="units" />
+        <Item url="/machines" icon="machines">
+          Machines
+        </Item>
+        <Item url="/devices" icon="units">
+          Devices
+        </Item>
       </>
     ),
   },
@@ -31,8 +35,8 @@ export const Unlabelled: Story = {
   args: {
     children: (
       <>
-        <Item url="/one" label="One" />
-        <Item url="/two" label="Two" />
+        <Item url="/one">One</Item>
+        <Item url="/two">Two</Item>
       </>
     ),
   },

--- a/packages/react/ds-app/src/lib/SideNavigation/common/Item/Item.ssr.tests.tsx
+++ b/packages/react/ds-app/src/lib/SideNavigation/common/Item/Item.ssr.tests.tsx
@@ -4,7 +4,7 @@ import Item from "./Item.js";
 
 describe("Item SSR", () => {
   it("renders without hydration errors", () => {
-    const html = renderToString(<Item url="/machines" label="Machines" />);
+    const html = renderToString(<Item url="/machines">Machines</Item>);
     expect(html).toContain("ds side-navigation-item");
     expect(html).toContain("Machines");
   });

--- a/packages/react/ds-app/src/lib/SideNavigation/common/Item/Item.stories.tsx
+++ b/packages/react/ds-app/src/lib/SideNavigation/common/Item/Item.stories.tsx
@@ -35,7 +35,7 @@ type Story = StoryObj<typeof Item>;
 export const Link: Story = {
   args: {
     url: "/machines",
-    label: "Machines",
+    children: "Machines",
   },
 };
 
@@ -43,7 +43,7 @@ export const Link: Story = {
 export const WithIcon: Story = {
   args: {
     url: "/machines",
-    label: "Machines",
+    children: "Machines",
     icon: "machines",
   },
 };
@@ -52,7 +52,7 @@ export const WithIcon: Story = {
 export const Active: Story = {
   args: {
     url: "/machines",
-    label: "Machines",
+    children: "Machines",
     active: true,
   },
 };
@@ -61,7 +61,7 @@ export const Active: Story = {
 export const Disabled: Story = {
   args: {
     url: "/networking",
-    label: "Networking",
+    children: "Networking",
     disabled: true,
   },
 };
@@ -70,7 +70,7 @@ export const Disabled: Story = {
 export const NonNavigable: Story = {
   args: {
     key: "current-user",
-    label: "Ada Lovelace",
+    children: "Ada Lovelace",
   },
 };
 
@@ -78,8 +78,21 @@ export const NonNavigable: Story = {
 export const WithSlot: Story = {
   args: {
     url: "/machines",
-    label: "Machines",
+    children: "Machines",
     icon: "machines",
     slot: <MockBadge>42</MockBadge>,
+  },
+};
+
+/** Composed (non-string) content — a consumer can pass anything, not only text. */
+export const ComposedContent: Story = {
+  args: {
+    url: "/machines",
+    icon: "machines",
+    children: (
+      <>
+        Machines <em>(42 online)</em>
+      </>
+    ),
   },
 };

--- a/packages/react/ds-app/src/lib/SideNavigation/common/Item/Item.tests.tsx
+++ b/packages/react/ds-app/src/lib/SideNavigation/common/Item/Item.tests.tsx
@@ -5,7 +5,7 @@ import Item from "./Item.js";
 
 describe("Item", () => {
   it("renders a link when url is set", () => {
-    render(<Item url="/machines" label="Machines" />);
+    render(<Item url="/machines">Machines</Item>);
     expect(screen.getByRole("link", { name: "Machines" })).toHaveAttribute(
       "href",
       "/machines",
@@ -13,19 +13,25 @@ describe("Item", () => {
   });
 
   it("renders a plain label when url is absent", () => {
-    render(<Item label="Ada Lovelace" />);
+    render(<Item>Ada Lovelace</Item>);
     expect(screen.queryByRole("link")).not.toBeInTheDocument();
     expect(screen.getByText("Ada Lovelace")).toBeInTheDocument();
   });
 
   it("marks the active item with aria-current", () => {
-    render(<Item url="/machines" label="Machines" active />);
+    render(
+      <Item url="/machines" active>
+        Machines
+      </Item>,
+    );
     expect(screen.getByRole("link")).toHaveAttribute("aria-current", "page");
   });
 
   it("omits href when disabled", () => {
     const { container } = render(
-      <Item url="/machines" label="Machines" disabled />,
+      <Item url="/machines" disabled>
+        Machines
+      </Item>,
     );
     // An <a> without href has no accessible "link" role — the disabled
     // fallback correctly renders a non-navigable element.
@@ -36,7 +42,11 @@ describe("Item", () => {
   });
 
   it("renders the trailing slot", () => {
-    render(<Item url="/machines" label="Machines" slot={<span>42</span>} />);
+    render(
+      <Item url="/machines" slot={<span>42</span>}>
+        Machines
+      </Item>,
+    );
     expect(screen.getByText("42")).toBeInTheDocument();
   });
 
@@ -49,14 +59,18 @@ describe("Item", () => {
       children?: React.ReactNode;
     }) => <a href={`#${href}`}>{children}</a>;
     render(
-      <Item url="/machines" label="Machines" LinkComponent={CustomLink} />,
+      <Item url="/machines" LinkComponent={CustomLink}>
+        Machines
+      </Item>,
     );
     expect(screen.getByRole("link")).toHaveAttribute("href", "#/machines");
   });
 
   it("applies custom className", () => {
     const { container } = render(
-      <Item url="/machines" label="Machines" className="custom-class" />,
+      <Item url="/machines" className="custom-class">
+        Machines
+      </Item>,
     );
     const el = container.firstElementChild;
     expect(el?.className).toContain("ds side-navigation-item");
@@ -64,7 +78,17 @@ describe("Item", () => {
   });
 
   it("sets title on the label as a native tooltip fallback for truncation (SPEC.md §10.17)", () => {
-    render(<Item url="/machines" label="Machines" />);
+    render(<Item url="/machines">Machines</Item>);
     expect(screen.getByText("Machines")).toHaveAttribute("title", "Machines");
+  });
+
+  it("composes rich (non-string) content without setting a title", () => {
+    render(
+      <Item url="/machines">
+        <strong>Machines</strong>
+      </Item>,
+    );
+    const strong = screen.getByText("Machines");
+    expect(strong.closest(".label")).not.toHaveAttribute("title");
   });
 });

--- a/packages/react/ds-app/src/lib/SideNavigation/common/Item/Item.tsx
+++ b/packages/react/ds-app/src/lib/SideNavigation/common/Item/Item.tsx
@@ -10,16 +10,18 @@ const componentCssClassName = "ds side-navigation-item";
  *
  * A flat leaf row, NOT recursive — an entry with children is a
  * SideNavigation.ItemExpandable instead (SPEC.md §4.3). The row is
- * `[icon] [label] [end]` over a shared grid template (so the icon aligns
+ * `[icon] [content] [end]` over a shared grid template (so the icon aligns
  * with the header logo). An item with a `url` renders as a link via
  * `LinkComponent` (default `"a"`); otherwise a non-navigable label. The end
- * slot is the optional `slot` (a badge, count, …), or nothing.
+ * slot is the optional `slot` (a badge, count, …), or nothing. Content is
+ * composed via `children`, matching `Button`'s own convention — pass
+ * anything, not only text.
  *
  * @implements ds:apps.subcomponent.side-navigation-item
  */
 const Item = ({
   url,
-  label,
+  children,
   icon,
   slot,
   disabled = false,
@@ -34,14 +36,19 @@ const Item = ({
 
   const content = (
     <>
-      {/* Start cell is always rendered (empty when no icon) so the label stays
-          in the middle column — labels align whether or not a row has an icon. */}
+      {/* Start cell is always rendered (empty when no icon) so the content
+          stays in the middle column — labels align whether or not a row has
+          an icon. */}
       <span className="start p">{icon ? <Icon icon={icon} /> : null}</span>
       {/* `title` is a progressive-enhancement fallback for the spec's
-         truncated-label tooltip (§7): the browser's own native tooltip,
-         not the custom 800ms-delay styled one — SPEC.md §10.17. */}
-      <span className="label p" title={label}>
-        {label}
+         truncated-label tooltip (§7): the browser's own native tooltip, not
+         the custom 800ms-delay styled one — SPEC.md §10.17. Only meaningful
+         when `children` is plain text (the common case). */}
+      <span
+        className="label p"
+        title={typeof children === "string" ? children : undefined}
+      >
+        {children}
       </span>
       {slot ? <span className="end slot">{slot}</span> : null}
     </>

--- a/packages/react/ds-app/src/lib/SideNavigation/common/Item/types.ts
+++ b/packages/react/ds-app/src/lib/SideNavigation/common/Item/types.ts
@@ -1,15 +1,21 @@
-import type { ComponentProps, ComponentType } from "react";
+import type { ComponentProps, ComponentType, ReactNode } from "react";
 import type { LeafNavItem, LinkComponentProps } from "../../types.js";
 
 /**
  * Props for the default SideNavigation item renderer — a flat leaf row.
  *
- * Spreads the LeafNavItem fields directly (url, key, label, disabled, icon,
- * slot, …) plus presentational extras. Always a leaf: an entry with children
- * is a SideNavigation.ItemExpandable instead (SPEC.md §4.3) — Item never
- * shows a disclosure caret.
+ * Spreads the LeafNavItem fields directly (url, key, disabled, icon, slot,
+ * …) plus presentational extras. Content is composed via `children`
+ * (matching every other DS control, e.g. `Button`) rather than a `label`
+ * string prop — the data-driven path (`NavTree`, from a `root` tree, whose
+ * authored `LeafNavItem.label` stays a plain string) passes its `label` in
+ * as `children` rather than as a same-named prop. Always a leaf: an entry
+ * with children is a SideNavigation.ItemExpandable instead (SPEC.md §4.3) —
+ * Item never shows a disclosure caret.
  */
-type OwnProps = LeafNavItem & {
+type OwnProps = Omit<LeafNavItem, "label"> & {
+  /** Item content — composed, not a string prop (matches `Button`'s own `children`-as-label convention). */
+  children?: ReactNode;
   /** Whether this item is the active (current) page. */
   active?: boolean;
   /** Component used to render navigable items. Defaults to `"a"`. */

--- a/packages/react/ds-app/src/lib/SideNavigation/common/ItemButton/ItemButton.ssr.tests.tsx
+++ b/packages/react/ds-app/src/lib/SideNavigation/common/ItemButton/ItemButton.ssr.tests.tsx
@@ -4,7 +4,7 @@ import ItemButton from "./ItemButton.js";
 
 describe("ItemButton SSR", () => {
   it("renders without hydration errors", () => {
-    const html = renderToString(<ItemButton label="Log out" />);
+    const html = renderToString(<ItemButton>Log out</ItemButton>);
     expect(html).toContain("ds side-navigation-item-button");
     expect(html).toContain("Log out");
     expect(html).toContain('type="button"');

--- a/packages/react/ds-app/src/lib/SideNavigation/common/ItemButton/ItemButton.stories.tsx
+++ b/packages/react/ds-app/src/lib/SideNavigation/common/ItemButton/ItemButton.stories.tsx
@@ -24,7 +24,7 @@ type Story = StoryObj<typeof ItemButton>;
 /** An action row — e.g. "Log out". */
 export const Default: Story = {
   args: {
-    label: "Log out",
+    children: "Log out",
     icon: "log-out",
   },
 };
@@ -40,7 +40,7 @@ export const Disabled: Story = {
 /** An action row with a trailing badge. */
 export const WithSlot: Story = {
   args: {
-    label: "Notifications",
+    children: "Notifications",
     icon: "notifications",
     slot: <span>3</span>,
   },

--- a/packages/react/ds-app/src/lib/SideNavigation/common/ItemButton/ItemButton.tests.tsx
+++ b/packages/react/ds-app/src/lib/SideNavigation/common/ItemButton/ItemButton.tests.tsx
@@ -4,29 +4,29 @@ import ItemButton from "./ItemButton.js";
 
 describe("ItemButton", () => {
   it("renders a button with the label", () => {
-    render(<ItemButton label="Log out" />);
+    render(<ItemButton>Log out</ItemButton>);
     expect(screen.getByRole("button", { name: "Log out" })).toBeInTheDocument();
   });
 
   it("calls onClick when activated", () => {
     const onClick = vi.fn();
-    render(<ItemButton label="Log out" onClick={onClick} />);
+    render(<ItemButton onClick={onClick}>Log out</ItemButton>);
     fireEvent.click(screen.getByRole("button"));
     expect(onClick).toHaveBeenCalledOnce();
   });
 
   it("supports the native disabled attribute", () => {
-    render(<ItemButton label="Log out" disabled />);
+    render(<ItemButton disabled>Log out</ItemButton>);
     expect(screen.getByRole("button")).toBeDisabled();
   });
 
   it("renders the trailing slot", () => {
-    render(<ItemButton label="Notifications" slot={<span>3</span>} />);
+    render(<ItemButton slot={<span>3</span>}>Notifications</ItemButton>);
     expect(screen.getByText("3")).toBeInTheDocument();
   });
 
   it("always renders a button type, not submit", () => {
-    render(<ItemButton label="Log out" />);
+    render(<ItemButton>Log out</ItemButton>);
     expect(screen.getByRole("button")).toHaveAttribute("type", "button");
   });
 });

--- a/packages/react/ds-app/src/lib/SideNavigation/common/ItemButton/ItemButton.tsx
+++ b/packages/react/ds-app/src/lib/SideNavigation/common/ItemButton/ItemButton.tsx
@@ -9,12 +9,13 @@ const componentCssClassName = "ds side-navigation-item-button";
  * SideNavigation.ItemButton — a navigation row that performs an action
  * instead of navigating (e.g. "Log out", "Create context"). One of the
  * `control` variants selectable on a `LeafNavItem` (SPEC.md §4.4) — the
- * others are Item (link, the default) and ItemSwitch.
+ * others are Item (link, the default) and ItemSwitch. Content is composed
+ * via `children`, matching `Button`'s own convention.
  *
  * @implements ds:apps.subcomponent.side-navigation-item-button
  */
 const ItemButton = ({
-  label,
+  children,
   icon,
   slot,
   className,
@@ -24,11 +25,14 @@ const ItemButton = ({
   <li className={[componentCssClassName, className].filter(Boolean).join(" ")}>
     <button className="row" {...props} type="button">
       {/* Start cell is always rendered (empty when no icon), matching Item,
-          so labels align whether or not a row has an icon. */}
+          so content stays aligned whether or not a row has an icon. */}
       <span className="start p">{icon ? <Icon icon={icon} /> : null}</span>
-      {/* `title` — native tooltip fallback for a truncated label; SPEC.md §10.17. */}
-      <span className="label p" title={label}>
-        {label}
+      {/* `title` — native tooltip fallback for truncated text; SPEC.md §10.17. */}
+      <span
+        className="label p"
+        title={typeof children === "string" ? children : undefined}
+      >
+        {children}
       </span>
       {slot ? <span className="end slot">{slot}</span> : null}
     </button>

--- a/packages/react/ds-app/src/lib/SideNavigation/common/ItemButton/types.ts
+++ b/packages/react/ds-app/src/lib/SideNavigation/common/ItemButton/types.ts
@@ -4,8 +4,8 @@ import type { ComponentProps, ReactNode } from "react";
 type OwnProps = {
   /** Identity field, mirroring LeafNavItem.key — not spread to the DOM. */
   key?: string;
-  /** Display text. */
-  label?: string;
+  /** Content, composed via children (matches `Button`'s own convention). */
+  children?: ReactNode;
   /** Leading icon (start slot), by ds-assets icon name. */
   icon?: IconName;
   /** Trailing content (end slot): a badge, count, etc. */

--- a/packages/react/ds-app/src/lib/SideNavigation/common/ItemExpandable/ItemExpandable.ssr.tests.tsx
+++ b/packages/react/ds-app/src/lib/SideNavigation/common/ItemExpandable/ItemExpandable.ssr.tests.tsx
@@ -5,7 +5,7 @@ import ItemExpandable from "./ItemExpandable.js";
 describe("ItemExpandable SSR", () => {
   it("renders without hydration errors", () => {
     const html = renderToString(
-      <ItemExpandable label="Hardware" defaultExpanded>
+      <ItemExpandable heading="Hardware" defaultExpanded>
         <li>Machines</li>
       </ItemExpandable>,
     );

--- a/packages/react/ds-app/src/lib/SideNavigation/common/ItemExpandable/ItemExpandable.stories.tsx
+++ b/packages/react/ds-app/src/lib/SideNavigation/common/ItemExpandable/ItemExpandable.stories.tsx
@@ -26,12 +26,16 @@ type Story = StoryObj<typeof ItemExpandable>;
 /** Closed by default — activate the summary to reveal its children. */
 export const Closed: Story = {
   args: {
-    label: "Hardware",
+    heading: "Hardware",
     icon: "machines",
     children: (
       <>
-        <Item url="/machines" label="Machines" LinkComponent={HashLink} />
-        <Item url="/devices" label="Devices" LinkComponent={HashLink} />
+        <Item url="/machines" LinkComponent={HashLink}>
+          Machines
+        </Item>
+        <Item url="/devices" LinkComponent={HashLink}>
+          Devices
+        </Item>
       </>
     ),
   },

--- a/packages/react/ds-app/src/lib/SideNavigation/common/ItemExpandable/ItemExpandable.tests.tsx
+++ b/packages/react/ds-app/src/lib/SideNavigation/common/ItemExpandable/ItemExpandable.tests.tsx
@@ -5,9 +5,9 @@ import { describe, expect, it } from "vitest";
 import ItemExpandable from "./ItemExpandable.js";
 
 describe("ItemExpandable", () => {
-  it("renders the label and, when expanded, its children", () => {
+  it("renders the heading and, when expanded, its children", () => {
     render(
-      <ItemExpandable label="Hardware" defaultExpanded>
+      <ItemExpandable heading="Hardware" defaultExpanded>
         <li>Machines</li>
       </ItemExpandable>,
     );
@@ -17,7 +17,7 @@ describe("ItemExpandable", () => {
 
   it("starts closed by default", () => {
     const { container } = render(
-      <ItemExpandable label="Hardware">
+      <ItemExpandable heading="Hardware">
         <li>Machines</li>
       </ItemExpandable>,
     );
@@ -26,7 +26,7 @@ describe("ItemExpandable", () => {
 
   it("starts open when defaultExpanded is set", () => {
     const { container } = render(
-      <ItemExpandable label="Hardware" defaultExpanded>
+      <ItemExpandable heading="Hardware" defaultExpanded>
         <li>Machines</li>
       </ItemExpandable>,
     );
@@ -35,7 +35,7 @@ describe("ItemExpandable", () => {
 
   it("toggles open/closed when the summary is activated", () => {
     const { container } = render(
-      <ItemExpandable label="Hardware">
+      <ItemExpandable heading="Hardware">
         <li>Machines</li>
       </ItemExpandable>,
     );
@@ -51,7 +51,7 @@ describe("ItemExpandable", () => {
 
   it("ignores toggling when disabled", () => {
     const { container } = render(
-      <ItemExpandable label="Hardware" disabled>
+      <ItemExpandable heading="Hardware" disabled>
         <li>Machines</li>
       </ItemExpandable>,
     );
@@ -66,7 +66,7 @@ describe("ItemExpandable", () => {
 
   it("applies custom className", () => {
     const { container } = render(
-      <ItemExpandable label="Hardware" className="custom-class" />,
+      <ItemExpandable heading="Hardware" className="custom-class" />,
     );
     const el = container.firstElementChild;
     expect(el?.className).toContain("ds side-navigation-item-expandable");

--- a/packages/react/ds-app/src/lib/SideNavigation/common/ItemExpandable/ItemExpandable.tsx
+++ b/packages/react/ds-app/src/lib/SideNavigation/common/ItemExpandable/ItemExpandable.tsx
@@ -11,7 +11,9 @@ const componentCssClassName = "ds side-navigation-item-expandable";
  * (always-leaf) children instead of navigating (SPEC.md §4.3). Native
  * `<details>`/`<summary>` — no `role`/`aria-expanded` authored, per
  * `cs:ui_blocks.nojs.disclosure`; the element supplies the disclosure
- * semantics itself, correctly, without scripting.
+ * semantics itself, correctly, without scripting. `heading` (the summary's
+ * own label) and `children` (what disclosure reveals) are composed, not
+ * string props — matching `Accordion.Item`'s own `heading`/`children` split.
  *
  * Uncontrolled — seeded by `defaultExpanded`, mirroring SideNavigation's own
  * rail-collapse state, not Accordion.Item's externally-controlled circuit:
@@ -21,7 +23,7 @@ const componentCssClassName = "ds side-navigation-item-expandable";
  * @implements ds:apps.subcomponent.side-navigation-item-expandable
  */
 const ItemExpandable = ({
-  label,
+  heading,
   icon,
   disabled = false,
   defaultExpanded = false,
@@ -62,11 +64,14 @@ const ItemExpandable = ({
         {/* biome-ignore lint/a11y/noStaticElementInteractions: <summary> is the native disclosure trigger for its <details> (implicit button semantics per HTML-AAM); biome's static-element check doesn't recognise it. */}
         <summary className="row" onClick={handleSummaryClick}>
           {/* Start cell is always rendered (empty when no icon), matching
-              Item, so labels align whether or not a row has an icon. */}
+              Item, so content stays aligned whether or not a row has an icon. */}
           <span className="start p">{icon ? <Icon icon={icon} /> : null}</span>
-          {/* `title` — native tooltip fallback for a truncated label; SPEC.md §10.17. */}
-          <span className="label p" title={label}>
-            {label}
+          {/* `title` — native tooltip fallback for truncated text; SPEC.md §10.17. */}
+          <span
+            className="label p"
+            title={typeof heading === "string" ? heading : undefined}
+          >
+            {heading}
           </span>
           <Icon icon="chevron-down" className="end caret" />
         </summary>

--- a/packages/react/ds-app/src/lib/SideNavigation/common/ItemExpandable/types.ts
+++ b/packages/react/ds-app/src/lib/SideNavigation/common/ItemExpandable/types.ts
@@ -4,8 +4,12 @@ import type { ComponentProps, ReactNode } from "react";
 type OwnProps = {
   /** Identity field, mirroring LeafNavItem.key — not spread to the DOM. */
   key?: string;
-  /** Display text. Text only, matching LeafNavItem's `label` — not JSX. */
-  label?: string;
+  /**
+   * The row's own label, in the `<summary>` — composed, not a string prop
+   * (matches `Accordion.Item`'s own `heading`/`children` split: `heading` is
+   * the trigger's label, `children` is what disclosure reveals).
+   */
+  heading?: ReactNode;
   /** Leading icon (start slot), by ds-assets icon name. */
   icon?: IconName;
   /** Whether the item (and its disclosure) is interactive. */

--- a/packages/react/ds-app/src/lib/SideNavigation/common/ItemSwitch/ItemSwitch.ssr.tests.tsx
+++ b/packages/react/ds-app/src/lib/SideNavigation/common/ItemSwitch/ItemSwitch.ssr.tests.tsx
@@ -5,7 +5,7 @@ import ItemSwitch from "./ItemSwitch.js";
 describe("ItemSwitch SSR", () => {
   it("renders without hydration errors", () => {
     const html = renderToString(
-      <ItemSwitch label="Dark mode" defaultChecked />,
+      <ItemSwitch defaultChecked>Dark mode</ItemSwitch>,
     );
     expect(html).toContain("ds side-navigation-item-switch");
     expect(html).toContain("Dark mode");

--- a/packages/react/ds-app/src/lib/SideNavigation/common/ItemSwitch/ItemSwitch.stories.tsx
+++ b/packages/react/ds-app/src/lib/SideNavigation/common/ItemSwitch/ItemSwitch.stories.tsx
@@ -24,7 +24,7 @@ type Story = StoryObj<typeof ItemSwitch>;
 /** An unchecked toggle row, uncontrolled. */
 export const Off: Story = {
   args: {
-    label: "Dark mode",
+    children: "Dark mode",
     icon: "dark-theme",
   },
 };

--- a/packages/react/ds-app/src/lib/SideNavigation/common/ItemSwitch/ItemSwitch.tests.tsx
+++ b/packages/react/ds-app/src/lib/SideNavigation/common/ItemSwitch/ItemSwitch.tests.tsx
@@ -4,39 +4,41 @@ import ItemSwitch from "./ItemSwitch.js";
 
 describe("ItemSwitch", () => {
   it("renders a switch with the label as its accessible name", () => {
-    render(<ItemSwitch label="Dark mode" />);
+    render(<ItemSwitch>Dark mode</ItemSwitch>);
     expect(
       screen.getByRole("switch", { name: "Dark mode" }),
     ).toBeInTheDocument();
   });
 
   it("reflects the checked state", () => {
-    render(<ItemSwitch label="Dark mode" checked onCheckedChange={() => {}} />);
+    render(
+      <ItemSwitch checked onCheckedChange={() => {}}>
+        Dark mode
+      </ItemSwitch>,
+    );
     expect(screen.getByRole("switch")).toBeChecked();
   });
 
   it("calls onCheckedChange with the next value", () => {
     const onCheckedChange = vi.fn();
     render(
-      <ItemSwitch
-        label="Dark mode"
-        checked={false}
-        onCheckedChange={onCheckedChange}
-      />,
+      <ItemSwitch checked={false} onCheckedChange={onCheckedChange}>
+        Dark mode
+      </ItemSwitch>,
     );
     fireEvent.click(screen.getByRole("switch"));
     expect(onCheckedChange).toHaveBeenCalledWith(true);
   });
 
   it("supports the disabled state", () => {
-    render(<ItemSwitch label="Dark mode" disabled />);
+    render(<ItemSwitch disabled>Dark mode</ItemSwitch>);
     expect(screen.getByRole("switch")).toBeDisabled();
-    const { container } = render(<ItemSwitch label="Dark mode" disabled />);
+    const { container } = render(<ItemSwitch disabled>Dark mode</ItemSwitch>);
     expect(container.firstElementChild).toHaveAttribute("data-disabled");
   });
 
   it("supports being uncontrolled via defaultChecked", () => {
-    render(<ItemSwitch label="Dark mode" defaultChecked />);
+    render(<ItemSwitch defaultChecked>Dark mode</ItemSwitch>);
     expect(screen.getByRole("switch")).toBeChecked();
   });
 });

--- a/packages/react/ds-app/src/lib/SideNavigation/common/ItemSwitch/ItemSwitch.tsx
+++ b/packages/react/ds-app/src/lib/SideNavigation/common/ItemSwitch/ItemSwitch.tsx
@@ -13,12 +13,13 @@ const componentCssClassName = "ds side-navigation-item-switch";
  * `LeafNavItem` (SPEC.md §4.4) — the others are Item (link, the default)
  * and ItemButton. The row is a `<label>` wrapping the switch, so activating
  * anywhere on the row toggles it (native label-wraps-input association —
- * no `id`/`htmlFor` bookkeeping needed).
+ * no `id`/`htmlFor` bookkeeping needed). Content is composed via
+ * `children`, matching `Button`'s own convention.
  *
  * @implements ds:apps.subcomponent.side-navigation-item-switch
  */
 const ItemSwitch = ({
-  label,
+  children,
   icon,
   disabled = false,
   checked,
@@ -44,11 +45,14 @@ const ItemSwitch = ({
       {/* biome-ignore lint/a11y/noLabelWithoutControl: SwitchInput renders the actual <input> — biome's static check can't see through the component boundary to the control it wraps. */}
       <label className="row">
         {/* Start cell is always rendered (empty when no icon), matching
-            Item, so labels align whether or not a row has an icon. */}
+            Item, so content stays aligned whether or not a row has an icon. */}
         <span className="start p">{icon ? <Icon icon={icon} /> : null}</span>
-        {/* `title` — native tooltip fallback for a truncated label; SPEC.md §10.17. */}
-        <span className="label p" title={label}>
-          {label}
+        {/* `title` — native tooltip fallback for truncated text; SPEC.md §10.17. */}
+        <span
+          className="label p"
+          title={typeof children === "string" ? children : undefined}
+        >
+          {children}
         </span>
         <span className="end">
           <SwitchInput

--- a/packages/react/ds-app/src/lib/SideNavigation/common/ItemSwitch/types.ts
+++ b/packages/react/ds-app/src/lib/SideNavigation/common/ItemSwitch/types.ts
@@ -1,11 +1,16 @@
 import type { IconName } from "@canonical/ds-assets";
-import type { ComponentProps } from "react";
+import type { ComponentProps, ReactNode } from "react";
 
 type OwnProps = {
   /** Identity field, mirroring LeafNavItem.key — not spread to the DOM. */
   key?: string;
-  /** Display text — also the switch's accessible name (wrapping `<label>`). */
-  label?: string;
+  /**
+   * Content — also the switch's accessible name (wrapping `<label>`).
+   * Composed via children (matches `Button`'s own convention); only plain
+   * text contributes to the accessible name in the way a screen reader
+   * would expect, so keep it to text for the common case.
+   */
+  children?: ReactNode;
   /** Leading icon (start slot), by ds-assets icon name. */
   icon?: IconName;
   /** Whether the item (and its switch) is interactive. */

--- a/packages/react/ds-app/src/lib/SideNavigation/common/NavTree/NavTree.tsx
+++ b/packages/react/ds-app/src/lib/SideNavigation/common/NavTree/NavTree.tsx
@@ -27,7 +27,9 @@ const componentCssClassName = "ds nav-tree";
  * native HTML attribute of a different type (`slot` is a global attribute
  * on every element; a bare `onClick` expects a `MouseEvent` handler, not
  * this module's `() => void`), so leaving them in would either be a type
- * error or a silent DOM leak.
+ * error or a silent DOM leak. `label` (the authored data field, a plain
+ * string) is passed in as `children` — Item/ItemButton/ItemSwitch each
+ * compose their content via `children`, not a same-named `label` prop.
  */
 const renderEntry = (
   entry: _Item<_AnyNavNode>,
@@ -40,6 +42,7 @@ const renderEntry = (
     depth: _depth,
     items: _items,
     separator: _separator,
+    label,
     control,
     onClick,
     checked,
@@ -50,7 +53,11 @@ const renderEntry = (
 
   if (control === "button") {
     const { url: _url, ...buttonFields } = rest;
-    return <ItemButton key={entryId} {...buttonFields} onClick={onClick} />;
+    return (
+      <ItemButton key={entryId} {...buttonFields} onClick={onClick}>
+        {label}
+      </ItemButton>
+    );
   }
 
   if (control === "switch") {
@@ -62,17 +69,16 @@ const renderEntry = (
         checked={checked}
         defaultChecked={defaultChecked}
         onCheckedChange={onCheckedChange}
-      />
+      >
+        {label}
+      </ItemSwitch>
     );
   }
 
   return (
-    <Item
-      key={entryId}
-      {...rest}
-      active={active}
-      LinkComponent={LinkComponent}
-    />
+    <Item key={entryId} {...rest} active={active} LinkComponent={LinkComponent}>
+      {label}
+    </Item>
   );
 };
 
@@ -160,12 +166,14 @@ const NavTree = ({
                   onCheckedChange: _onCheckedChange,
                   slot: _slot,
                   url: _url,
+                  label,
                   ...expandableFields
                 } = entry;
                 return (
                   <ItemExpandable
                     key={entryId}
                     {...expandableFields}
+                    heading={label}
                     defaultExpanded={nav.getNodeStatus(entry).inSelectedBranch}
                   >
                     {children.map((child) =>

--- a/packages/react/ds-app/src/lib/SideNavigation/types.ts
+++ b/packages/react/ds-app/src/lib/SideNavigation/types.ts
@@ -269,6 +269,14 @@ type OwnProps = {
    * (SPEC.md §5, §10.1). No story enables it.
    */
   keyboardShortcut?: boolean;
+  /**
+   * Fallback content region, rendered by `Content` in place of a `root`-
+   * derived tree — lets a consumer compose the main navigation region
+   * directly (e.g. a `SideNavigation.ContextSwitcher` alongside hand-written
+   * items) instead of authoring the WD405 `root` data shape. Ignored when
+   * `root` is given.
+   */
+  children?: ReactNode;
 };
 
 /**


### PR DESCRIPTION
## Done

`Item`, `ItemButton`, and `ItemSwitch` each took a plain-string `label` prop for their row content, out of step with the rest of the design system (e.g. `Button`), where a component's own visible content is composed via `children`. `ItemExpandable`'s `label` conflated two different things — its own trigger text and the disclosed content — under `children` alone, with no way to pass both.

- `Item`, `ItemButton`, `ItemSwitch`: `label?: string` → `children?: ReactNode`.
- `ItemExpandable`: adds `heading?: ReactNode` for the summary's own label (matching `Accordion.Item`'s heading/children split); `children` is now exclusively the disclosed content.
- `NavTree` maps each data-driven entry's `label` field to `children` (or `heading`, for expandable entries) when rendering these subcomponents from the WD405 root/footerRoot data shape — the data vocabulary itself is unchanged, only how `NavTree` wires it up.
- `Footer`'s built-in footer-items renderer and `Group`'s stories/tests updated to compose the new children-based API.

Also, `SideNavigation.Content` already fell back to its own `children` when no `root` is given, but `SideNavigation` itself had no `children` prop and never forwarded one — a consumer wanting to compose the main navigation region directly out of JSX (e.g. to place a `ContextSwitcher` at its "content-defined position", `SPEC.md` §1.1/§4.5, without authoring the WD405 root data shape) had no way to reach that fallback short of using `SideNavigation.Content` directly and losing the Header/Footer/rail-state wiring `SideNavigation` itself owns. `SideNavigation` now accepts `children` and forwards it to `Content`, ignored when `root` is also given (`Content`'s existing precedence). Adds a `ComposedContent` story exercising `ContextSwitcher`, `Group`, `Item`, `ItemExpandable`, `ItemSwitch`, `ItemButton` and `Separator` together through this path, plus tests for the fallback and the root/children precedence.

**BREAKING CHANGE:** `SideNavigation.Item`, `SideNavigation.ItemButton`, and `SideNavigation.ItemSwitch` no longer accept a `label` prop — pass content as `children` instead. `SideNavigation.ItemExpandable` no longer accepts `label`; pass the trigger's own label as `heading` and the disclosed content as `children`. Consumers using `SideNavigation`'s own `root`/`footerRoot` data props (`LeafNavItem.label`, unchanged) are unaffected.

## QA

- `bun run test` and `bun run check` pass.
- New `ComposedContent` story — visually check `ContextSwitcher`/`Group`/rows composed directly as JSX children.

### PR readiness check

- [x] PR title follows Conventional Commits, marked `!` for the `label` → `children` breaking change.
- [x] The code follows the appropriate [code standards](https://github.com/canonical/web-code-standards)
- [x] All packages define the required scripts in `package.json`
- [ ] No new package introduced
- [ ] Chromatic: skip — no visual diff (prop rename plus a new fallback path).
