### PR TITLE
ci(pr-lint): move the label reconciliation into a composite action

### DIFF
--- a/.github/actions/apply-type-label/action.yml
+++ b/.github/actions/apply-type-label/action.yml
@@ -1,0 +1,29 @@
+name: Apply type label
+description: Reconciles a pull request's managed type labels against its title.
+inputs:
+  github-token:
+    description: >-
+      Token used to read the pull request and write its labels. Defaults to the
+      job's own token, which is all the labelling needs. Note that supplying a
+      wider one does not extend the action to pull requests from forks: those
+      are skipped on principle, not for want of permission.
+    required: false
+    default: ${{ github.token }}
+runs:
+  using: composite
+  steps:
+    # The logic sits in a sibling `.cjs` file rather than inline in this YAML,
+    # where it would have no syntax checking, no editor support and nothing
+    # able to load it. `github-script` injects `github`, `context` and `core`,
+    # and builds `context` from the runner environment rather than from the
+    # calling workflow — so the module needs nothing passed down but the token
+    # above. The path comes from the environment rather than from a `${{ }}`
+    # expression: interpolating one into a JavaScript string literal would put
+    # a Windows runner's backslashes inside quotes, where they are escapes.
+    - name: Reconcile the managed labels against the title
+      uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+      with:
+        github-token: ${{ inputs.github-token }}
+        script: |
+          const applyTypeLabel = require(`${process.env.GITHUB_ACTION_PATH}/apply-type-label.cjs`);
+          await applyTypeLabel({ github, context, core });

--- a/.github/actions/apply-type-label/apply-type-label.cjs
+++ b/.github/actions/apply-type-label/apply-type-label.cjs
@@ -1,0 +1,96 @@
+/**
+ * Reconciles a pull request's managed type labels against its title.
+ *
+ * Loaded by the sibling `action.yml` through `actions/github-script`, which
+ * is why this file is CommonJS and exports the github-script contract: a
+ * single async function taking the `{ github, context, core }` toolkit that
+ * action injects. Nothing imports it and it belongs to no workspace — it runs
+ * only on the runner, so it stays dependency-free and plain ES2022.
+ *
+ * The labels it manages are the conventional-commit types plus `breaking`;
+ * it adds the ones the title implies, removes the ones it no longer does, and
+ * leaves every other label alone.
+ *
+ * @note Impure — reads a pull request and writes its labels through the
+ * GitHub API.
+ */
+
+// The closed type vocabulary, which must stay in step with the `types:` input
+// given to `amannn/action-semantic-pull-request` in `pr-lint.yml`: that job
+// decides which titles are legal, this one labels them.
+const TYPES = ["feat", "fix", "docs", "refactor", "chore", "test", "ci", "revert"];
+const BREAKING = "breaking";
+// Only consulted when a label is missing from the repository, so a
+// freshly generated repo labels its first PR correctly.
+const COLORS = Object.fromEntries(TYPES.map((type) => [type, "b3c5d7"]));
+COLORS[BREAKING] = "b60205";
+
+async function applyTypeLabel({ github, context, core }) {
+  const { owner, repo } = context.repo;
+  // Read the pull request as it stands NOW, not as the event payload
+  // snapshotted it when the edit was queued. A run that starts after
+  // a later edit would otherwise reconcile a title and a label set
+  // that are already history, and converge on the wrong answer while
+  // reporting success.
+  const { data: pr } = await github.rest.pulls.get({
+    owner,
+    repo,
+    pull_number: context.payload.pull_request.number,
+  });
+
+  // A fork PR gets a read-only token, so labelling would fail the run.
+  if (pr.head.repo.full_name !== `${owner}/${repo}`) {
+    core.warning("PR is from a fork; skipping labelling (the token is read-only).");
+    return;
+  }
+
+  const match = /^([a-z]+)(\([^)]*\))?(!)?:\s/.exec(pr.title);
+  if (!match) {
+    core.setFailed(`PR title is not a conventional commit: ${pr.title}`);
+    return;
+  }
+  const [, type, , breaking] = match;
+  if (!TYPES.includes(type)) {
+    core.setFailed(`"${type}" is not one of the allowed types: ${TYPES.join(", ")}`);
+    return;
+  }
+
+  const managed = new Set([...TYPES, BREAKING]);
+  const desired = new Set([type, ...(breaking ? [BREAKING] : [])]);
+  const current = new Set(pr.labels.map((label) => label.name).filter((name) => managed.has(name)));
+
+  const add = [...desired].filter((name) => !current.has(name));
+  const remove = [...current].filter((name) => !desired.has(name));
+
+  for (const name of add) {
+    try {
+      await github.rest.issues.getLabel({ owner, repo, name });
+    } catch (error) {
+      if (error.status !== 404) throw error;
+      await github.rest.issues.createLabel({ owner, repo, name, color: COLORS[name] });
+      core.info(`Created missing label "${name}"`);
+    }
+  }
+  if (add.length > 0) {
+    await github.rest.issues.addLabels({ owner, repo, issue_number: pr.number, labels: add });
+  }
+  for (const name of remove) {
+    // A label that is already gone is the outcome this loop wants,
+    // not an error. Anyone may remove one between the read above and
+    // the write here — a maintainer clicking it off, another
+    // automation — and GitHub answers a removal of an absent label
+    // with a 404, which would fail the whole job over a state that
+    // is already correct. The add loop above also catches a 404,
+    // but for a different condition: there it means the repository
+    // has no such label defined yet, and the answer is to create it.
+    try {
+      await github.rest.issues.removeLabel({ owner, repo, issue_number: pr.number, name });
+    } catch (error) {
+      if (error.status !== 404) throw error;
+      core.info(`Label "${name}" was already absent`);
+    }
+  }
+  core.info(`${pr.title}\n  added:   ${add.join(", ") || "—"}\n  removed: ${remove.join(", ") || "—"}`);
+}
+
+module.exports = applyTypeLabel;

--- a/.github/workflows/pr-lint.yml
+++ b/.github/workflows/pr-lint.yml
@@ -23,7 +23,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           # The closed type vocabulary. Every entry has a label of the same name,
-          # applied by `apply-type-label` below — keep the two lists in step.
+          # applied by `apply-type-label` below — keep this list in step with
+          # `TYPES` in `.github/actions/apply-type-label/apply-type-label.cjs`.
           types: |
             feat
             fix
@@ -54,88 +55,31 @@ jobs:
       group: apply-type-label-${{ github.event.pull_request.number }}
       cancel-in-progress: true
     permissions:
+      # A job that declares any permission gets none of the others, so the read
+      # the checkout step needs has to be named here explicitly.
+      contents: read
       pull-requests: write
       # Creating a managed label that does not exist yet goes through the issues API.
       issues: write
     steps:
+      # A local `uses: ./…` action has to be on disk before it can run, and the
+      # workspace starts empty. Only the actions tree is needed, so the checkout
+      # is shallow and sparse. It lands on the PR's merge commit — the same ref
+      # this workflow file itself is read from on a `pull_request` event, so
+      # the action is no more trusted than the workflow already was. That
+      # equivalence is what `pull_request` buys, and only it: do not move
+      # this job to `pull_request_target`, where the same two steps would
+      # run a pull request's own code against a writable token.
+      - name: Check out the label action
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          fetch-depth: 1
+          sparse-checkout: .github/actions
+
       # The title is the source of truth. It has just been validated, so the type
       # label is derived from it rather than applied by hand: `feat(x): …` gets
       # `feat`, and a `!` marker gets `breaking` alongside it. Labels this job
       # manages are also removed when the title stops implying them, so an edited
       # title never leaves a stale type behind.
       - name: Derive the type label from the PR title
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const TYPES = ["feat", "fix", "docs", "refactor", "chore", "test", "ci", "revert"];
-            const BREAKING = "breaking";
-            // Only consulted when a label is missing from the repository, so a
-            // freshly generated repo labels its first PR correctly.
-            const COLORS = Object.fromEntries(TYPES.map((type) => [type, "b3c5d7"]));
-            COLORS[BREAKING] = "b60205";
-
-            const { owner, repo } = context.repo;
-            // Read the pull request as it stands NOW, not as the event payload
-            // snapshotted it when the edit was queued. A run that starts after
-            // a later edit would otherwise reconcile a title and a label set
-            // that are already history, and converge on the wrong answer while
-            // reporting success.
-            const { data: pr } = await github.rest.pulls.get({
-              owner,
-              repo,
-              pull_number: context.payload.pull_request.number,
-            });
-
-            // A fork PR gets a read-only token, so labelling would fail the run.
-            if (pr.head.repo.full_name !== `${owner}/${repo}`) {
-              core.warning("PR is from a fork; skipping labelling (the token is read-only).");
-              return;
-            }
-
-            const match = /^([a-z]+)(\([^)]*\))?(!)?:\s/.exec(pr.title);
-            if (!match) {
-              core.setFailed(`PR title is not a conventional commit: ${pr.title}`);
-              return;
-            }
-            const [, type, , breaking] = match;
-            if (!TYPES.includes(type)) {
-              core.setFailed(`"${type}" is not one of the allowed types: ${TYPES.join(", ")}`);
-              return;
-            }
-
-            const managed = new Set([...TYPES, BREAKING]);
-            const desired = new Set([type, ...(breaking ? [BREAKING] : [])]);
-            const current = new Set(pr.labels.map((label) => label.name).filter((name) => managed.has(name)));
-
-            const add = [...desired].filter((name) => !current.has(name));
-            const remove = [...current].filter((name) => !desired.has(name));
-
-            for (const name of add) {
-              try {
-                await github.rest.issues.getLabel({ owner, repo, name });
-              } catch (error) {
-                if (error.status !== 404) throw error;
-                await github.rest.issues.createLabel({ owner, repo, name, color: COLORS[name] });
-                core.info(`Created missing label "${name}"`);
-              }
-            }
-            if (add.length > 0) {
-              await github.rest.issues.addLabels({ owner, repo, issue_number: pr.number, labels: add });
-            }
-            for (const name of remove) {
-              // A label that is already gone is the outcome this loop wants,
-              // not an error. Anyone may remove one between the read above and
-              // the write here — a maintainer clicking it off, another
-              // automation — and GitHub answers a removal of an absent label
-              // with a 404, which would fail the whole job over a state that
-              // is already correct. The add loop above also catches a 404,
-              // but for a different condition: there it means the repository
-              // has no such label defined yet, and the answer is to create it.
-              try {
-                await github.rest.issues.removeLabel({ owner, repo, issue_number: pr.number, name });
-              } catch (error) {
-                if (error.status !== 404) throw error;
-                core.info(`Label "${name}" was already absent`);
-              }
-            }
-            core.info(`${pr.title}\n  added:   ${add.join(", ") || "—"}\n  removed: ${remove.join(", ") || "—"}`);
+        uses: ./.github/actions/apply-type-label

--- a/packages/summon/monorepo/README.md
+++ b/packages/summon/monorepo/README.md
@@ -22,6 +22,9 @@ summon monorepo --name=my-project --description="My awesome project"
 <repo>/
 ├── .github/
 │   ├── actions/
+│   │   ├── apply-type-label/ # Type label reconciliation, used by pr-lint.yml
+│   │   │   ├── action.yml
+│   │   │   └── apply-type-label.cjs
 │   │   ├── lerna-version/    # Version bump + changelog action
 │   │   │   ├── action.yml
 │   │   │   ├── version.sh

--- a/packages/summon/monorepo/src/generators.test.ts
+++ b/packages/summon/monorepo/src/generators.test.ts
@@ -81,6 +81,12 @@ describe("monorepo generator", () => {
       expect(filePaths).toContain(
         "test-monorepo/.github/actions/lerna-version/git-commit.sh",
       );
+      expect(filePaths).toContain(
+        "test-monorepo/.github/actions/apply-type-label/action.yml",
+      );
+      expect(filePaths).toContain(
+        "test-monorepo/.github/actions/apply-type-label/apply-type-label.cjs",
+      );
 
       // PR template
       expect(filePaths).toContain(
@@ -189,6 +195,60 @@ describe("monorepo generator", () => {
       // a step the publish never runs in. OIDC needs neither secret.
       expect(tagFile?.content).toContain("id-token: write");
       expect(tagFile?.content).not.toContain("NPM_AUTH_TOKEN");
+    });
+
+    it("keeps the type vocabulary in step across the two files it spans", () => {
+      // `pr-lint.yml` decides which titles are legal; the label action's
+      // `TYPES` decides which labels are managed. They were one list inside a
+      // single `script:` block and are now two lists in two files, so nothing
+      // but this assertion stops them drifting apart. Order is compared too:
+      // it means nothing to either consumer, but two lists that must mirror
+      // each other are only readable side by side while they do.
+      const files = getFiles(dryRun(generator.generate(defaultAnswers)));
+      const workflow = files.find(
+        (f) => f.path === "test-monorepo/.github/workflows/pr-lint.yml",
+      );
+      const action = files.find(
+        (f) =>
+          f.path ===
+          "test-monorepo/.github/actions/apply-type-label/apply-type-label.cjs",
+      );
+      expect(workflow).toBeDefined();
+      expect(action).toBeDefined();
+
+      const declared =
+        /types: \|\n((?:\s+\w+\n)+)/
+          .exec(workflow?.content ?? "")?.[1]
+          ?.split("\n")
+          .map((line) => line.trim())
+          .filter(Boolean) ?? [];
+      const managed = JSON.parse(
+        /const TYPES = (\[[^\]]*\]);/.exec(action?.content ?? "")?.[1] ?? "[]",
+      );
+
+      expect(declared).toEqual(managed);
+      expect(declared.length).toBeGreaterThan(0);
+    });
+
+    it("emits the file the label action requires at runtime", () => {
+      // The action names its script by path in a string the generator never
+      // reads, so a renamed template would fail only on a runner, in a repo
+      // nobody has generated yet.
+      const files = getFiles(dryRun(generator.generate(defaultAnswers)));
+      const action = files.find(
+        (f) =>
+          f.path ===
+          "test-monorepo/.github/actions/apply-type-label/action.yml",
+      );
+      expect(action).toBeDefined();
+
+      const required = /GITHUB_ACTION_PATH\}\/([\w.-]+)`\)/.exec(
+        action?.content ?? "",
+      )?.[1];
+      expect(required).toBeDefined();
+      expect(files.map((f) => f.path)).toContain(
+        `test-monorepo/.github/actions/apply-type-label/${required}`,
+      );
     });
 
     it("canonicalizes a noncanonical repository URL in the metadata", () => {

--- a/packages/summon/monorepo/src/monorepo/index.ts
+++ b/packages/summon/monorepo/src/monorepo/index.ts
@@ -50,6 +50,11 @@ const templates = {
   lernaVersionAction: path.join(templatesDir, "lerna-version-action.yml.ejs"),
   versionSh: path.join(templatesDir, "version.sh.ejs"),
   gitCommitSh: path.join(templatesDir, "git-commit.sh.ejs"),
+  applyTypeLabelAction: path.join(
+    templatesDir,
+    "apply-type-label-action.yml.ejs",
+  ),
+  applyTypeLabelCjs: path.join(templatesDir, "apply-type-label.cjs.ejs"),
   renovateJson: path.join(templatesDir, "renovate.json.ejs"),
 };
 
@@ -194,6 +199,7 @@ POST-SETUP:
       mkdir(path.join(repoDir, ".github", "actions", "setup-env")),
       mkdir(path.join(repoDir, ".github", "actions", "setup-git")),
       mkdir(path.join(repoDir, ".github", "actions", "lerna-version")),
+      mkdir(path.join(repoDir, ".github", "actions", "apply-type-label")),
 
       // Root config files
       template({
@@ -326,6 +332,28 @@ POST-SETUP:
           "actions",
           "lerna-version",
           "git-commit.sh",
+        ),
+        vars: ctx,
+      }),
+      template({
+        source: templates.applyTypeLabelAction,
+        dest: path.join(
+          repoDir,
+          ".github",
+          "actions",
+          "apply-type-label",
+          "action.yml",
+        ),
+        vars: ctx,
+      }),
+      template({
+        source: templates.applyTypeLabelCjs,
+        dest: path.join(
+          repoDir,
+          ".github",
+          "actions",
+          "apply-type-label",
+          "apply-type-label.cjs",
         ),
         vars: ctx,
       }),

--- a/packages/summon/monorepo/src/templates/apply-type-label-action.yml.ejs
+++ b/packages/summon/monorepo/src/templates/apply-type-label-action.yml.ejs
@@ -1,0 +1,29 @@
+name: Apply type label
+description: Reconciles a pull request's managed type labels against its title.
+inputs:
+  github-token:
+    description: >-
+      Token used to read the pull request and write its labels. Defaults to the
+      job's own token, which is all the labelling needs. Note that supplying a
+      wider one does not extend the action to pull requests from forks: those
+      are skipped on principle, not for want of permission.
+    required: false
+    default: ${{ github.token }}
+runs:
+  using: composite
+  steps:
+    # The logic sits in a sibling `.cjs` file rather than inline in this YAML,
+    # where it would have no syntax checking, no editor support and nothing
+    # able to load it. `github-script` injects `github`, `context` and `core`,
+    # and builds `context` from the runner environment rather than from the
+    # calling workflow — so the module needs nothing passed down but the token
+    # above. The path comes from the environment rather than from a `${{ }}`
+    # expression: interpolating one into a JavaScript string literal would put
+    # a Windows runner's backslashes inside quotes, where they are escapes.
+    - name: Reconcile the managed labels against the title
+      uses: actions/github-script@v7
+      with:
+        github-token: ${{ inputs.github-token }}
+        script: |
+          const applyTypeLabel = require(`${process.env.GITHUB_ACTION_PATH}/apply-type-label.cjs`);
+          await applyTypeLabel({ github, context, core });

--- a/packages/summon/monorepo/src/templates/apply-type-label.cjs.ejs
+++ b/packages/summon/monorepo/src/templates/apply-type-label.cjs.ejs
@@ -1,0 +1,96 @@
+/**
+ * Reconciles a pull request's managed type labels against its title.
+ *
+ * Loaded by the sibling `action.yml` through `actions/github-script`, which
+ * is why this file is CommonJS and exports the github-script contract: a
+ * single async function taking the `{ github, context, core }` toolkit that
+ * action injects. Nothing imports it and it belongs to no workspace — it runs
+ * only on the runner, so it stays dependency-free and plain ES2022.
+ *
+ * The labels it manages are the conventional-commit types plus `breaking`;
+ * it adds the ones the title implies, removes the ones it no longer does, and
+ * leaves every other label alone.
+ *
+ * @note Impure — reads a pull request and writes its labels through the
+ * GitHub API.
+ */
+
+// The closed type vocabulary, which must stay in step with the `types:` input
+// given to `amannn/action-semantic-pull-request` in `pr-lint.yml`: that job
+// decides which titles are legal, this one labels them.
+const TYPES = ["feat", "fix", "docs", "refactor", "chore", "test", "ci", "revert"];
+const BREAKING = "breaking";
+// Only consulted when a label is missing from the repository, so a
+// freshly generated repo labels its first PR correctly.
+const COLORS = Object.fromEntries(TYPES.map((type) => [type, "b3c5d7"]));
+COLORS[BREAKING] = "b60205";
+
+async function applyTypeLabel({ github, context, core }) {
+  const { owner, repo } = context.repo;
+  // Read the pull request as it stands NOW, not as the event payload
+  // snapshotted it when the edit was queued. A run that starts after
+  // a later edit would otherwise reconcile a title and a label set
+  // that are already history, and converge on the wrong answer while
+  // reporting success.
+  const { data: pr } = await github.rest.pulls.get({
+    owner,
+    repo,
+    pull_number: context.payload.pull_request.number,
+  });
+
+  // A fork PR gets a read-only token, so labelling would fail the run.
+  if (pr.head.repo.full_name !== `${owner}/${repo}`) {
+    core.warning("PR is from a fork; skipping labelling (the token is read-only).");
+    return;
+  }
+
+  const match = /^([a-z]+)(\([^)]*\))?(!)?:\s/.exec(pr.title);
+  if (!match) {
+    core.setFailed(`PR title is not a conventional commit: ${pr.title}`);
+    return;
+  }
+  const [, type, , breaking] = match;
+  if (!TYPES.includes(type)) {
+    core.setFailed(`"${type}" is not one of the allowed types: ${TYPES.join(", ")}`);
+    return;
+  }
+
+  const managed = new Set([...TYPES, BREAKING]);
+  const desired = new Set([type, ...(breaking ? [BREAKING] : [])]);
+  const current = new Set(pr.labels.map((label) => label.name).filter((name) => managed.has(name)));
+
+  const add = [...desired].filter((name) => !current.has(name));
+  const remove = [...current].filter((name) => !desired.has(name));
+
+  for (const name of add) {
+    try {
+      await github.rest.issues.getLabel({ owner, repo, name });
+    } catch (error) {
+      if (error.status !== 404) throw error;
+      await github.rest.issues.createLabel({ owner, repo, name, color: COLORS[name] });
+      core.info(`Created missing label "${name}"`);
+    }
+  }
+  if (add.length > 0) {
+    await github.rest.issues.addLabels({ owner, repo, issue_number: pr.number, labels: add });
+  }
+  for (const name of remove) {
+    // A label that is already gone is the outcome this loop wants,
+    // not an error. Anyone may remove one between the read above and
+    // the write here — a maintainer clicking it off, another
+    // automation — and GitHub answers a removal of an absent label
+    // with a 404, which would fail the whole job over a state that
+    // is already correct. The add loop above also catches a 404,
+    // but for a different condition: there it means the repository
+    // has no such label defined yet, and the answer is to create it.
+    try {
+      await github.rest.issues.removeLabel({ owner, repo, issue_number: pr.number, name });
+    } catch (error) {
+      if (error.status !== 404) throw error;
+      core.info(`Label "${name}" was already absent`);
+    }
+  }
+  core.info(`${pr.title}\n  added:   ${add.join(", ") || "—"}\n  removed: ${remove.join(", ") || "—"}`);
+}
+
+module.exports = applyTypeLabel;

--- a/packages/summon/monorepo/src/templates/pr-lint.yml.ejs
+++ b/packages/summon/monorepo/src/templates/pr-lint.yml.ejs
@@ -23,7 +23,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           # The closed type vocabulary. Every entry has a label of the same name,
-          # applied by `apply-type-label` below — keep the two lists in step.
+          # applied by `apply-type-label` below — keep this list in step with
+          # `TYPES` in `.github/actions/apply-type-label/apply-type-label.cjs`.
           types: |
             feat
             fix
@@ -54,88 +55,31 @@ jobs:
       group: apply-type-label-${{ github.event.pull_request.number }}
       cancel-in-progress: true
     permissions:
+      # A job that declares any permission gets none of the others, so the read
+      # the checkout step needs has to be named here explicitly.
+      contents: read
       pull-requests: write
       # Creating a managed label that does not exist yet goes through the issues API.
       issues: write
     steps:
+      # A local `uses: ./…` action has to be on disk before it can run, and the
+      # workspace starts empty. Only the actions tree is needed, so the checkout
+      # is shallow and sparse. It lands on the PR's merge commit — the same ref
+      # this workflow file itself is read from on a `pull_request` event, so
+      # the action is no more trusted than the workflow already was. That
+      # equivalence is what `pull_request` buys, and only it: do not move
+      # this job to `pull_request_target`, where the same two steps would
+      # run a pull request's own code against a writable token.
+      - name: Check out the label action
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+          sparse-checkout: .github/actions
+
       # The title is the source of truth. It has just been validated, so the type
       # label is derived from it rather than applied by hand: `feat(x): …` gets
       # `feat`, and a `!` marker gets `breaking` alongside it. Labels this job
       # manages are also removed when the title stops implying them, so an edited
       # title never leaves a stale type behind.
       - name: Derive the type label from the PR title
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const TYPES = ["feat", "fix", "docs", "refactor", "chore", "test", "ci", "revert"];
-            const BREAKING = "breaking";
-            // Only consulted when a label is missing from the repository, so a
-            // freshly generated repo labels its first PR correctly.
-            const COLORS = Object.fromEntries(TYPES.map((type) => [type, "b3c5d7"]));
-            COLORS[BREAKING] = "b60205";
-
-            const { owner, repo } = context.repo;
-            // Read the pull request as it stands NOW, not as the event payload
-            // snapshotted it when the edit was queued. A run that starts after
-            // a later edit would otherwise reconcile a title and a label set
-            // that are already history, and converge on the wrong answer while
-            // reporting success.
-            const { data: pr } = await github.rest.pulls.get({
-              owner,
-              repo,
-              pull_number: context.payload.pull_request.number,
-            });
-
-            // A fork PR gets a read-only token, so labelling would fail the run.
-            if (pr.head.repo.full_name !== `${owner}/${repo}`) {
-              core.warning("PR is from a fork; skipping labelling (the token is read-only).");
-              return;
-            }
-
-            const match = /^([a-z]+)(\([^)]*\))?(!)?:\s/.exec(pr.title);
-            if (!match) {
-              core.setFailed(`PR title is not a conventional commit: ${pr.title}`);
-              return;
-            }
-            const [, type, , breaking] = match;
-            if (!TYPES.includes(type)) {
-              core.setFailed(`"${type}" is not one of the allowed types: ${TYPES.join(", ")}`);
-              return;
-            }
-
-            const managed = new Set([...TYPES, BREAKING]);
-            const desired = new Set([type, ...(breaking ? [BREAKING] : [])]);
-            const current = new Set(pr.labels.map((label) => label.name).filter((name) => managed.has(name)));
-
-            const add = [...desired].filter((name) => !current.has(name));
-            const remove = [...current].filter((name) => !desired.has(name));
-
-            for (const name of add) {
-              try {
-                await github.rest.issues.getLabel({ owner, repo, name });
-              } catch (error) {
-                if (error.status !== 404) throw error;
-                await github.rest.issues.createLabel({ owner, repo, name, color: COLORS[name] });
-                core.info(`Created missing label "${name}"`);
-              }
-            }
-            if (add.length > 0) {
-              await github.rest.issues.addLabels({ owner, repo, issue_number: pr.number, labels: add });
-            }
-            for (const name of remove) {
-              // A label that is already gone is the outcome this loop wants,
-              // not an error. Anyone may remove one between the read above and
-              // the write here — a maintainer clicking it off, another
-              // automation — and GitHub answers a removal of an absent label
-              // with a 404, which would fail the whole job over a state that
-              // is already correct. The add loop above also catches a 404,
-              // but for a different condition: there it means the repository
-              // has no such label defined yet, and the answer is to create it.
-              try {
-                await github.rest.issues.removeLabel({ owner, repo, issue_number: pr.number, name });
-              } catch (error) {
-                if (error.status !== 404) throw error;
-                core.info(`Label "${name}" was already absent`);
-              }
-            }
-            core.info(`${pr.title}\n  added:   ${add.join(", ") || "—"}\n  removed: ${remove.join(", ") || "—"}`);
+        uses: ./.github/actions/apply-type-label

--- a/packages/summon/monorepo/src/testing/integration/generator-undo.test.ts
+++ b/packages/summon/monorepo/src/testing/integration/generator-undo.test.ts
@@ -22,8 +22,8 @@ describe("monorepo generator undo plan", () => {
     const task = generator.generate(defaultAnswers);
     const undos = collectUndos(task);
 
-    // 9 mkdirs + 19 templates × 2 = 47
-    expect(undos.length).toBe(47);
+    // 10 mkdirs + 21 templates × 2 = 52
+    expect(undos.length).toBe(52);
   });
 
   it("exec effects (initGit, runInstall, chmod) produce no undos", () => {


### PR DESCRIPTION
## Done

`.github/workflows/pr-lint.yml`'s `apply-type-label` job carried ninety lines of
JavaScript inline in a `script:` block. Inside a YAML string that program had no
syntax checking, no editor support and nothing able to load it — the only way to
learn whether an edit was even parseable was to open a pull request and retitle
it.

It now lives in a local composite action, `.github/actions/apply-type-label`:

- **`action.yml`** — `runs: using: composite`, wrapping `actions/github-script`.
  One input, `github-token`, defaulting to `${{ github.token }}`; its
  description says that supplying a wider token does *not* extend the action to
  fork pull requests, because those are skipped on principle rather than for
  want of permission.
- **`apply-type-label.cjs`** — the module, exporting the contract github-script
  calls it with, `async ({ github, context, core })`. Unchanged line for line
  from the block it replaces, comments included. `.cjs` rather than `.js`
  because it must stay CommonJS whatever the root manifest later says about
  `"type"` — and `.github/actions/lerna-version/semver.cjs` is the precedent.

The action loads its module by `process.env.GITHUB_ACTION_PATH` rather than by
interpolating `${{ github.action_path }}` into the JavaScript, so a Windows
runner's backslashes never land inside a string literal as escape sequences.

### Three consequences worth reviewing

- **The job now checks the repository out.** A local `uses: ./…` action has to
  be on disk before the runner can resolve it, and the workspace starts empty.
  The checkout is shallow (`fetch-depth: 1`) and sparse (`.github/actions`), and
  lands on the merge commit — the same ref this workflow file itself is read
  from on a `pull_request` event, so the action is no more trusted than the
  workflow already was. A comment in the file says not to move the job to
  `pull_request_target`, where that equivalence stops holding and checkout +
  local action + a writable token would become something much worse.
- **`contents: read` joins the job's permissions.** A job that declares any
  permission gets none of the scopes it does not name, so the checkout would
  have failed with a 403 without it. This is the one line most likely to be
  missed by anyone reproducing the change.
- **Both actions the job uses are pinned by SHA** with a `# v7` comment,
  matching `pr.yml` and `push.yml`.

### The generator gets the same split

`packages/summon/monorepo` emits this workflow into every new monorepo, so it
gains a matching template pair (`apply-type-label-action.yml.ejs` and
`apply-type-label.cjs.ejs`) registered beside the other local-action templates,
plus the directory it needs. Two new tests guard exactly what the split newly
makes possible:

- the `types:` vocabulary in the workflow and the module's `TYPES` cannot drift
  apart — mutation-checked by deleting `revert` from one side and confirming the
  test goes red;
- the file the rendered `action.yml` requires at runtime is one the generator
  actually writes, so renaming one without the other cannot ship a generated
  repo whose first pull request fails at the labelling step.

## QA

**Behaviour is checked, not asserted.** The extracted module and the inline
block currently on `main` were both loaded and run against the same stubbed
GitHub API across ten titles — every allowed type, a `!` breaking marker, a fork
pull request, a non-conventional title, a disallowed type, and a label already
absent so the removal 404s. They produced identical API calls and identical log
output in **10/10** scenarios. The same harness confirms the repo copy and the
generator-rendered copy behave identically to each other.

Root gate, from the repository root:

- `bun run check` — 63 projects, green
- `bunx lerna run test --concurrency 1 --no-bail` — 52 projects, green but for
  the three environment failures noted below
- `@canonical/summon-monorepo` alone — 6 files / 31 tests, 100% coverage
- `bun run build` — green; the generator now ships 21 template files
- `bun run check:ranges` — 63 workspace packages, every sibling range satisfied
- `bun run collect:check` — clean, `data/` unchanged

One environment note, reproducible on an unmodified `main` and untouched by this
diff: the three Playwright-tagged svelte projects cannot start a browser in this
sandbox (`libglib-2.0.so.0` absent). Lerna's default parallelism also exhausts
the machine, so the run above used `--concurrency 1`.

Reviewing the workflow itself is best done by reading the diff of
`.github/workflows/pr-lint.yml` beside `.github/actions/apply-type-label/` — the
comments were split deliberately, with the concurrency and permissions rationale
staying in the YAML and the live-read, fork and two-distinct-404 rationales
moving with the code.

## Carried

- **The generator's templates stay on floating `@vN` action refs** while this
  repo pins by SHA. The pinning here comes from Renovate's
  `helpers:pinGitHubActionDigests`, which the generated `renovate.json` does not
  extend — a SHA in a template would go stale with nothing to bump it. Pinning
  generated repos means adding that helper to the template first, which is a
  separate change. The new template lines use `actions/checkout@v6` to match
  `ci.yml.ejs` and `tag.yml.ejs` rather than this repo's v7.
- **Nothing tests the copy of the module under `.github/actions`.** Its twin in
  the generator is tested because that rides the package's own `test` target; a
  root-level equivalent would need a new shared CI job, which AGENTS.md reserves
  for repo-wide invariants. The equivalence harness above was run by hand.

### PR readiness check

- [x] PR title follows the Conventional Commits format (`ci`)
- [x] The code follows the appropriate code standards
- [x] All packages define the required scripts in `package.json` — no package
      manifests change
- [x] No new package
- [x] No visual change

Chromatic: skip
