### PR TITLE
chore(styles): the stylesheet packages check their own architecture

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1280,6 +1280,7 @@
       "devDependencies": {
         "@biomejs/biome": "2.5.11",
         "@canonical/biome-config": "^0.37.0",
+        "@canonical/webarchitect": "^0.37.0",
       },
       "peerDependencies": {
         "@canonical/design-tokens": "0.8.1",
@@ -1298,6 +1299,7 @@
       "devDependencies": {
         "@biomejs/biome": "2.5.11",
         "@canonical/biome-config": "^0.37.0",
+        "@canonical/webarchitect": "^0.37.0",
       },
       "peerDependencies": {
         "@canonical/ds-assets": ">=0.18.0",
@@ -1320,6 +1322,7 @@
         "@biomejs/biome": "2.5.11",
         "@canonical/biome-config": "^0.37.0",
         "@canonical/typescript-config": "^0.37.0",
+        "@canonical/webarchitect": "^0.37.0",
         "@types/bun": "^1.3.10",
         "@types/node": "^26.0.0",
         "typescript": "^5.9.3",

--- a/packages/styles/debug/package.json
+++ b/packages/styles/debug/package.json
@@ -34,10 +34,11 @@
     "access": "public"
   },
   "scripts": {
-    "check": "bun run check:biome",
+    "check": "bun run check:biome && bun run check:webarchitect",
     "check:fix": "bun run check:biome:fix",
     "check:biome": "biome check",
-    "check:biome:fix": "biome check --write"
+    "check:biome:fix": "biome check --write",
+    "check:webarchitect": "webarchitect assets"
   },
   "peerDependencies": {
     "@canonical/design-tokens": "0.8.1"
@@ -49,6 +50,7 @@
   },
   "devDependencies": {
     "@biomejs/biome": "2.5.11",
-    "@canonical/biome-config": "^0.37.0"
+    "@canonical/biome-config": "^0.37.0",
+    "@canonical/webarchitect": "^0.37.0"
   }
 }

--- a/packages/styles/main/package.json
+++ b/packages/styles/main/package.json
@@ -33,14 +33,16 @@
     "access": "public"
   },
   "scripts": {
-    "check": "bun run check:biome",
+    "check": "bun run check:biome && bun run check:webarchitect",
     "check:fix": "bun run check:biome:fix",
     "check:biome": "biome check",
-    "check:biome:fix": "biome check --write"
+    "check:biome:fix": "biome check --write",
+    "check:webarchitect": "webarchitect assets"
   },
   "devDependencies": {
     "@biomejs/biome": "2.5.11",
-    "@canonical/biome-config": "^0.37.0"
+    "@canonical/biome-config": "^0.37.0",
+    "@canonical/webarchitect": "^0.37.0"
   },
   "dependencies": {
     "@canonical/design-tokens": "0.8.1",

--- a/packages/styles/typography/package.json
+++ b/packages/styles/typography/package.json
@@ -25,11 +25,12 @@
   "scripts": {
     "dev": "bun --watch run ./example/serve.ts",
     "extract-font-data": "bun run ./src/scripts/extractFontData.ts",
-    "check": "bun run check:biome && bun run check:ts",
+    "check": "bun run check:biome && bun run check:ts && bun run check:webarchitect",
     "check:fix": "bun run check:biome:fix && bun run check:ts",
     "check:biome": "biome check",
     "check:biome:fix": "biome check --write",
     "check:ts": "tsc --noEmit",
+    "check:webarchitect": "webarchitect assets",
     "test": "vitest run --passWithNoTests",
     "test:watch": "vitest"
   },
@@ -50,6 +51,7 @@
     "@biomejs/biome": "2.5.11",
     "@canonical/biome-config": "^0.37.0",
     "@canonical/typescript-config": "^0.37.0",
+    "@canonical/webarchitect": "^0.37.0",
     "@types/bun": "^1.3.10",
     "@types/node": "^26.0.0",
     "typescript": "^5.9.3",


### PR DESCRIPTION
`@canonical/styles`, `@canonical/styles-typography` and `@canonical/styles-debug` did not run webarchitect. The Vanilla adapter does, and these three are the same shape of package, so they now run the same ruleset.

`assets` is the right one: it is for a package that ships files and builds nothing. The `library` ruleset a code package uses asks for a module entry, type declarations and a build script, and fails a stylesheet package on all three.

## What this checks, and what it does not

The assets ruleset checks the licence. It does not check the biome configuration, because that rule lives in the `package` ruleset a stylesheet package cannot satisfy — a gap worth closing in webarchitect itself by moving that rule down into `base`, which is a change to that package rather than to these.

## Gates

`check` passes in all three, webarchitect included.