### PR TITLE
feat(harnesses): register the pragma MCP server with Oh My Pi

### DIFF
--- a/packages/cli/pragma/src/capabilities/doctor/doctor.test.ts
+++ b/packages/cli/pragma/src/capabilities/doctor/doctor.test.ts
@@ -348,9 +348,9 @@ describe("doctor — the harness inventory", () => {
     const { global, project } = inventory(rows);
 
     // Every harness the registry knows, in both scopes.
-    expect(project?.items).toHaveLength(13);
-    expect(global?.items).toHaveLength(13);
-    expect(project?.detail).toBe("1 detected · 0 registered · 13 known");
+    expect(project?.items).toHaveLength(14);
+    expect(global?.items).toHaveLength(14);
+    expect(project?.detail).toBe("1 detected · 0 registered · 14 known");
 
     // `types.ts` forbids inflating the failure count: a machine that simply
     // does not have Cursor is not a broken machine.

--- a/packages/runtime/harnesses/src/lib/config.test.ts
+++ b/packages/runtime/harnesses/src/lib/config.test.ts
@@ -331,6 +331,118 @@ describe("Crush config (crush.json)", () => {
   });
 });
 
+describe("Oh My Pi config (.omp/mcp.json)", () => {
+  const omp = findHarnessById("oh-my-pi") as (typeof harnesses)[number];
+
+  it("writes the plain stdio shape under `mcpServers` in the project band", () => {
+    // Oh My Pi's stdio entry is the canonical `{command, args, cwd, env}` form
+    // with `type` optional (defaulting to "stdio"), so the row declares no
+    // `mcpEntry` and the DEFAULT serializer must be what reaches the file.
+    const result = dryRunWith(
+      writeMcpConfig(omp, "/project", "pragma", {
+        command: "pragma",
+        args: ["mcp"],
+        cwd: "/project",
+      }),
+      buildMocks({
+        Exists: existsMock(() => false),
+        MakeDir: mkdirMock,
+        WriteFile: writeMock,
+      }),
+    );
+
+    const writeEffects = filterEffects(result.effects, "WriteFile");
+    expect(writeEffects.length).toBe(1);
+    expect(writeEffects[0].path).toBe("/project/.omp/mcp.json");
+
+    const written = JSON.parse(writeEffects[0].content);
+    expect(written.mcpServers.pragma).toEqual({
+      command: "pragma",
+      args: ["mcp"],
+      cwd: "/project",
+    });
+  });
+
+  it("merges into an existing `mcpServers` block, preserving disabledServers", () => {
+    // `disabledServers`/`enabledServers` are Oh My Pi's own top-level keys —
+    // a write that dropped them would silently re-enable a server the user
+    // turned off.
+    const existingConfig = JSON.stringify({
+      $schema: "https://omp.sh/schemas/mcp.json",
+      mcpServers: {
+        context7: { command: "context7-mcp" },
+      },
+      disabledServers: ["context7"],
+    });
+
+    const result = dryRunWith(
+      writeMcpConfig(omp, "/project", "pragma", {
+        command: "pragma",
+        args: ["mcp"],
+      }),
+      buildMocks({
+        Exists: existsMock(() => true),
+        ReadFile: readFileMock(existingConfig),
+        WriteFile: writeMock,
+      }),
+    );
+
+    const written = JSON.parse(
+      filterEffects(result.effects, "WriteFile")[0].content,
+    );
+    expect(written.mcpServers.context7).toEqual({ command: "context7-mcp" });
+    expect(written.mcpServers.pragma).toEqual({
+      command: "pragma",
+      args: ["mcp"],
+    });
+    expect(written.disabledServers).toEqual(["context7"]);
+  });
+
+  it("writes the global band into the ACTIVE profile's agent dir", () => {
+    // The default profile and a named one are different files. Writing the
+    // default path for a user running under `OMP_PROFILE` would install into a
+    // file omp never reads — the same class of bug as an OpenCode entry in the
+    // wrong band.
+    const base = dryRunWith(
+      writeMcpConfig(
+        omp,
+        "/project",
+        "pragma",
+        { command: "pragma" },
+        "global",
+        PLATFORM,
+      ),
+      buildMocks({
+        Exists: existsMock(() => false),
+        MakeDir: mkdirMock,
+        WriteFile: writeMock,
+      }),
+    );
+    expect(filterEffects(base.effects, "WriteFile")[0].path).toBe(
+      "/home/tester/.omp/agent/mcp.json",
+    );
+
+    const profiled = dryRunWith(
+      writeMcpConfig(
+        omp,
+        "/project",
+        "pragma",
+        { command: "pragma" },
+        "global",
+        { ...PLATFORM, env: { OMP_PROFILE: "work" } },
+      ),
+      buildMocks({
+        Exists: existsMock(() => false),
+        MakeDir: mkdirMock,
+        WriteFile: writeMock,
+      }),
+    );
+    expect(filterEffects(profiled.effects, "WriteFile")[0].path).toBe(
+      "/home/tester/.omp/profiles/work/agent/mcp.json",
+    );
+  });
+});
+
 describe("removeMcpConfig", () => {
   it("is a no-op when config file does not exist", () => {
     const result = dryRunWith(

--- a/packages/runtime/harnesses/src/lib/detectHarnesses.test.ts
+++ b/packages/runtime/harnesses/src/lib/detectHarnesses.test.ts
@@ -437,3 +437,85 @@ describe("detectHarnesses — Crush signals", () => {
     expect(result.value).toEqual([]);
   });
 });
+
+/**
+ * Oh My Pi's signal set. The point of the block is the LAST case: `omp` is a
+ * name Oh My Posh also answers to, so the PATH probe must not detect a prompt
+ * theme engine as a coding agent.
+ */
+describe("detectHarnesses — Oh My Pi signals", () => {
+  const withPath = (path: string): PlatformEnv => ({
+    ...PLATFORM,
+    env: { ...PLATFORM.env, PATH: path },
+  });
+
+  /** Exists true for exactly one path; every other effect left unmocked. */
+  const only = (wanted: string): Map<string, (effect: Effect) => unknown> =>
+    new Map([
+      [
+        "Exists",
+        (effect: Effect): unknown =>
+          (effect as Effect & { _tag: "Exists"; path: string }).path === wanted,
+      ],
+    ]);
+
+  /** Exists true for one path, plus a stubbed `--version` stdout. */
+  const onlyWithVersion = (
+    wanted: string,
+    stdout: string,
+  ): Map<string, (effect: Effect) => unknown> =>
+    new Map<string, (effect: Effect) => unknown>([
+      [
+        "Exists",
+        (effect: Effect): unknown =>
+          (effect as Effect & { _tag: "Exists"; path: string }).path === wanted,
+      ],
+      ["Exec", () => ({ stdout, stderr: "", exitCode: 0 })],
+    ]);
+
+  it("detects Oh My Pi from the project .omp directory alone, at high confidence", () => {
+    const result = dryRunWith(
+      detectHarnesses("/project", PLATFORM),
+      only("/project/.omp"),
+    );
+
+    expect(result.value.map((d) => d.harness.id)).toEqual(["oh-my-pi"]);
+    expect(result.value[0]?.confidence).toBe("high");
+    expect(result.value[0]?.configPath).toBe("/project/.omp/mcp.json");
+  });
+
+  it("detects an installed Oh My Pi from ~/.omp before any project config exists", () => {
+    const result = dryRunWith(
+      detectHarnesses("/project", PLATFORM),
+      only("/home/tester/.omp"),
+    );
+
+    expect(result.value.map((d) => d.harness.id)).toEqual(["oh-my-pi"]);
+    expect(result.value[0]?.confidence).toBe("high");
+    expect(result.value[0]?.configExists).toBe(false);
+  });
+
+  it("detects `omp` on PATH when --version identifies Oh My Pi", () => {
+    const result = dryRunWith(
+      detectHarnesses("/project", withPath("/usr/bin:/bin:/usr/local/bin")),
+      onlyWithVersion("/usr/local/bin/omp", "omp/1.4.0\n"),
+    );
+
+    expect(result.value.map((d) => d.harness.id)).toEqual(["oh-my-pi"]);
+    // On PATH means "installed", not "this project uses it".
+    expect(result.value[0]?.confidence).toBe("medium");
+  });
+
+  it("does NOT detect Oh My Pi from an `omp` that is really Oh My Posh", () => {
+    // The false positive this guard exists for: Oh My Posh abbreviates itself
+    // "omp" and users alias the name, but its `--version` prints a bare
+    // version number. Without the `verify`, a prompt theme engine's account
+    // would be handed an MCP config file.
+    const result = dryRunWith(
+      detectHarnesses("/project", withPath("/usr/bin:/bin:/usr/local/bin")),
+      onlyWithVersion("/usr/local/bin/omp", "19.5.2\n"),
+    );
+
+    expect(result.value).toEqual([]);
+  });
+});

--- a/packages/runtime/harnesses/src/lib/harnesses.test.ts
+++ b/packages/runtime/harnesses/src/lib/harnesses.test.ts
@@ -4,7 +4,7 @@ import { crushMcpEntry, opendesignMcpEntry } from "./mcpEntries.js";
 
 describe("harnesses registry", () => {
   it("contains all known harnesses", () => {
-    expect(harnesses).toHaveLength(13);
+    expect(harnesses).toHaveLength(14);
     const ids = harnesses.map((h) => h.id);
     expect(ids).toEqual([
       "claude-code",
@@ -20,6 +20,7 @@ describe("harnesses registry", () => {
       "vscode",
       "opendesign",
       "crush",
+      "oh-my-pi",
     ]);
   });
 
@@ -336,6 +337,103 @@ describe("harnesses registry", () => {
     expect(paths).toContain(".crush");
     expect(paths).not.toContain(".crush/crush.json");
     expect(paths.some((p) => p.includes(".local/share"))).toBe(false);
+  });
+
+  it("oh-my-pi is dual-scope: project .omp/mcp.json, user ~/.omp/agent/mcp.json", () => {
+    // Oh My Pi reads both bands and the PROJECT file wins over the user one
+    // (docs/mcp-config.md), so a project-only row would be skipped by setup's
+    // default global band — the opencode/crush hole.
+    const omp = harnesses.find((h) => h.id === "oh-my-pi");
+    expect(omp?.scope).toBe("both");
+    expect(omp?.configPath("/project")).toBe("/project/.omp/mcp.json");
+    expect(omp?.homeConfigPath?.(PLATFORM)).toBe(
+      "/home/tester/.omp/agent/mcp.json",
+    );
+    expect(omp?.mcpKey).toBe("mcpServers");
+    expect(omp?.configFormat).toBe("json");
+  });
+
+  it("oh-my-pi takes the DEFAULT entry shape — no bespoke serializer", () => {
+    // Its stdio entry is the plain `{command, args?, cwd?, env?}` form under
+    // `mcpServers`, with `type` optional and defaulting to "stdio". Declaring
+    // an `mcpEntry` here would be a second serializer to keep in sync with
+    // nothing to gain.
+    const omp = harnesses.find((h) => h.id === "oh-my-pi");
+    expect(omp?.mcpEntry).toBeUndefined();
+  });
+
+  it("oh-my-pi's user config follows the active profile and $PI_CONFIG_DIR", () => {
+    // omp resolves the user band to the ACTIVE PROFILE's agent dir:
+    // `~/.omp/profiles/<name>/agent/mcp.json`. `OMP_PROFILE` is canonical and
+    // `PI_PROFILE` the legacy fallback, consulted only when `OMP_PROFILE` is
+    // undefined — an explicitly EMPTY `OMP_PROFILE` selects the default
+    // profile and must NOT fall through to `PI_PROFILE`. Writing the default
+    // path for a profile user would install into a file omp never reads.
+    const omp = harnesses.find((h) => h.id === "oh-my-pi");
+    expect(
+      omp?.homeConfigPath?.({ ...PLATFORM, env: { OMP_PROFILE: "work" } }),
+    ).toBe("/home/tester/.omp/profiles/work/agent/mcp.json");
+    expect(
+      omp?.homeConfigPath?.({ ...PLATFORM, env: { PI_PROFILE: "legacy" } }),
+    ).toBe("/home/tester/.omp/profiles/legacy/agent/mcp.json");
+    expect(
+      omp?.homeConfigPath?.({
+        ...PLATFORM,
+        env: { OMP_PROFILE: "work", PI_PROFILE: "legacy" },
+      }),
+    ).toBe("/home/tester/.omp/profiles/work/agent/mcp.json");
+    // Explicitly empty: default profile, NOT the legacy value.
+    expect(
+      omp?.homeConfigPath?.({
+        ...PLATFORM,
+        env: { OMP_PROFILE: "", PI_PROFILE: "legacy" },
+      }),
+    ).toBe("/home/tester/.omp/agent/mcp.json");
+    // The config dirname itself is relocatable under home.
+    expect(
+      omp?.homeConfigPath?.({
+        ...PLATFORM,
+        env: { PI_CONFIG_DIR: ".omp-alt" },
+      }),
+    ).toBe("/home/tester/.omp-alt/agent/mcp.json");
+  });
+
+  it("oh-my-pi guards its `omp` PATH probe against Oh My Posh", () => {
+    // `omp` is not an unambiguous binary name: Oh My Posh abbreviates itself
+    // "omp" throughout, so a bare process signal is a coin flip. The row
+    // carries the same `verify` guard the OpenDesign row uses for the Unix
+    // `od` — Oh My Pi's `--version` prints `omp/<version>`, Oh My Posh prints
+    // a bare version number.
+    const omp = harnesses.find((h) => h.id === "oh-my-pi");
+    const verifies = (omp?.detect ?? []).flatMap((s) =>
+      s.type === "process" && s.name === "omp" && s.verify ? [s.verify] : [],
+    );
+    expect(verifies).toHaveLength(1);
+    const verify = verifies[0];
+    expect(verify?.args).toEqual(["--version"]);
+    expect(verify?.match.test("omp/1.4.0\n")).toBe(true);
+    // Oh My Posh's own `--version` output, and its binary name.
+    expect(verify?.match.test("19.5.2\n")).toBe(false);
+    expect(verify?.match.test("oh-my-posh 19.5.2\n")).toBe(false);
+  });
+
+  it("oh-my-pi is detectable from its project AND user directories", () => {
+    // A project-only signal cannot see an installed omp whose `.omp/` is
+    // gitignored or not yet created; the user config root is the
+    // "omp is installed" signal that does not wait for a project config.
+    const omp = harnesses.find((h) => h.id === "oh-my-pi");
+    expect(omp?.detect).toContainEqual({ type: "directory", path: ".omp" });
+    expect(omp?.detect).toContainEqual({ type: "directory", path: "~/.omp" });
+  });
+
+  it("oh-my-pi links the cross-client skills dir, never omp's own managed one", () => {
+    // `.agent[s]/skills` is omp's canonical native skills location, read at
+    // both bands; `.agents/skills` is the cross-client directory
+    // `setup skills` already links. `~/.omp/agent/managed-skills` is omp's own
+    // auto-learn write target and is never pragma's to fill.
+    const omp = harnesses.find((h) => h.id === "oh-my-pi");
+    expect(omp?.skillsPath("/project")).toBe("/project/.agents/skills");
+    expect(omp?.skillsPath("/home/tester")).not.toContain("managed-skills");
   });
 
   it("roo-code skillsPath", () => {

--- a/packages/runtime/harnesses/src/lib/harnesses.ts
+++ b/packages/runtime/harnesses/src/lib/harnesses.ts
@@ -366,6 +366,103 @@ const harnesses: readonly HarnessDefinition[] = [
     // (`.crush/crush.json`, `$XDG_DATA_HOME/crush/crush.json`) merges above
     // everything. Both state files are Crush's write targets, never ours.
   },
+  {
+    id: "oh-my-pi",
+    name: "Oh My Pi",
+    version: "*",
+    // Oh My Pi (github.com/can1357/oh-my-pi, binary `omp`) reads BOTH bands and
+    // the project file wins: "Project `.omp/mcp.json` precedes … the active
+    // profile's user `mcp.json`" (docs/mcp-config.md). A project-only row would
+    // be skipped by setup's DEFAULT global band entirely — the opencode/crush
+    // lesson — so: both.
+    scope: "both",
+    detect: [
+      // Oh My Pi's PROJECT directory, which holds the `.omp/mcp.json` this row
+      // writes. Project-relative, so it answers "this repo uses omp".
+      { type: "directory", path: ".omp" },
+      // The user config root, created on first run — the "omp is installed"
+      // signal that does not wait for a project config to exist.
+      // `PI_CONFIG_DIR` relocates this dirname under home, but the signal
+      // grammar has no env-prefix form (see `resolveFsPath`); a user who sets
+      // it is still found by the PATH probe below.
+      { type: "directory", path: "~/.omp" },
+      {
+        type: "process",
+        name: "omp",
+        // `omp` is NOT an unambiguous binary name, so a bare PATH hit is not
+        // enough — the same problem the OpenDesign row has with the Unix `od`,
+        // solved the same way. Oh My Posh abbreviates itself "omp" everywhere
+        // (its `_omp_*` shell functions, its `*.omp.json` themes) and users
+        // alias the name, so a false positive would write an MCP config into a
+        // PROMPT THEME ENGINE's account. Oh My Pi's `--version` prints
+        // "<bin>/<version>" — i.e. `omp/1.2.3` (packages/utils/src/cli.ts,
+        // `run()`); Oh My Posh prints a bare version number and fails this
+        // match.
+        verify: { args: ["--version"], match: /^omp\/\d/m },
+      },
+    ],
+    configPath: (root) => `${root}/.omp/mcp.json`,
+    /**
+     * The user band is the ACTIVE PROFILE's agent directory, not one fixed
+     * path: `~/.omp/agent/mcp.json` by default,
+     * `~/.omp/profiles/<name>/agent/mcp.json` under a named profile, and the
+     * `.omp` dirname itself moves with `PI_CONFIG_DIR` (oh-my-pi
+     * `packages/utils/src/dirs.ts` — `getConfigDirName`,
+     * `getProfileConfigRoot`, `getConfigAgentDirName`; docs/mcp-config.md
+     * names both file paths).
+     *
+     * The profile is read the way omp reads it: `OMP_PROFILE` first — winning
+     * even when explicitly EMPTY, which selects the default profile, which is
+     * what `??` gives — then the legacy `PI_PROFILE`.
+     *
+     * TWO WAYS A USER CAN LAND ON A PROFILE THIS ROW DOES NOT REACH, written
+     * down rather than left to be discovered:
+     *
+     * - `omp --profile <name>` on omp's own command line. That is a fact of an
+     *   invocation that has not happened yet, not of this environment, and no
+     *   function of `PlatformEnv` can see it. A user who selects a profile ONLY
+     *   by flag gets no pragma entry in that profile, and must re-run
+     *   `pragma setup mcp` with `OMP_PROFILE` set to reach it. Modelling
+     *   profiles properly means a per-profile band in `HarnessDefinition` — a
+     *   type change every other row would pay for, to serve one harness's flag.
+     * - `PI_CODING_AGENT_DIR`, which relocates the default profile's agent
+     *   directory to an arbitrary path omp resolves against ITS OWN cwd.
+     *   `PlatformEnv` carries no cwd, so a relative value would resolve
+     *   somewhere else entirely; a documented gap beats a guessed path.
+     *
+     * The skills half is unaffected by either: it is a directory link, not a
+     * config write, and both `.agents/skills` bands load by default (see
+     * `skillsPath`).
+     */
+    homeConfigPath: (p) => {
+      const profile = (p.env.OMP_PROFILE ?? p.env.PI_PROFILE)?.trim();
+      const root = `${userHome(p)}/${p.env.PI_CONFIG_DIR ?? ".omp"}`;
+      return profile
+        ? `${root}/profiles/${profile}/agent/mcp.json`
+        : `${root}/agent/mcp.json`;
+    },
+    configFormat: "json",
+    mcpKey: "mcpServers",
+    // No `mcpEntry` column: Oh My Pi's stdio entry is the plain
+    // `{command, args?, cwd?, env?}` shape under `mcpServers`, with `type`
+    // optional and defaulting to "stdio" (docs/mcp-config.md) — exactly what
+    // `defaultMcpEntry` emits. A bespoke serializer here would only be another
+    // thing to keep in sync.
+    //
+    // Oh My Pi reads `.agent/skills` AND `.agents/skills` through its `agents`
+    // provider, "the canonical OMP-native location" (docs/skills.md), at BOTH
+    // the user and project level (`enableAgentsUser`/`enableAgentsProject`, on
+    // by default). `.agents/skills` is the cross-client directory
+    // `setup skills` already links unconditionally, so this row adds the MCP
+    // half to a skills half that was already working.
+    //
+    // Its user-level skills directory is deliberately NOT claimed as a verified
+    // global skills location: `~/.omp/agent/managed-skills` is where omp's own
+    // auto-learn writes, and pragma never links into a directory the tool owns
+    // (the rule the Crush row keeps for Crush's state files). The cross-client
+    // `~/.agents/skills` link covers the global band without touching it.
+    skillsPath: (root) => `${root}/.agents/skills`,
+  },
 ];
 
 // Deliberately ABSENT from the registry (product calls, not oversights):
@@ -376,6 +473,11 @@ const harnesses: readonly HarnessDefinition[] = [
 //   here would write config pi itself never reads. pi IS served on the skills
 //   side without a row: it reads `.agents/skills`, the cross-client directory
 //   `setup skills` always links into.
+//   NOT the same tool as `oh-my-pi` above, despite the name and the shared
+//   `.agents/skills` sentence: Oh My Pi (github.com/can1357/oh-my-pi, binary
+//   `omp`) is a separate project that DOES ship a first-party MCP client, which
+//   is why it has a row and this one does not. Neither entry was written in
+//   ignorance of the other.
 //
 // - `vscodium` as an MCP CLIENT: VSCodium has no first-party MCP surface (no
 //   Copilot agent mode), so there is nothing to configure. As an extension


### PR DESCRIPTION
## Done

Adds first-class support for **Oh My Pi** (binary `omp`,
[github.com/can1357/oh-my-pi](https://github.com/can1357/oh-my-pi)) to
`pragma setup mcp` and `pragma doctor`, as one row in the harness registry
(`packages/runtime/harnesses/src/lib/harnesses.ts`). The registry is pure data —
adding a harness is adding an entry, not writing code — so the row plus its test
coverage is the whole change. No production code outside the registry moved.

**Half of this already worked.** `setup skills` links the cross-client
`.agents/skills` directory unconditionally, and Oh My Pi reads `.agent[s]/skills`
through its `agents` provider — "the canonical OMP-native location" — at both the
project and the user level, on by default. So omp users already got pragma's
skills. What they did not get was the MCP server registered, or any mention of
omp in `doctor`'s harness inventory. This PR adds that half.

What the row declares:

- **Scope `both`.** Project config is `.omp/mcp.json`; the user config is the
  active profile's `mcp.json` (`~/.omp/agent/mcp.json` by default). The project
  file takes precedence over the user one. A project-only row would have been
  skipped by `setup`'s default *global* band entirely — the same hole the
  OpenCode and Crush rows were fixed for.
- **`mcpServers`, plain stdio shape, no custom serializer.** Oh My Pi's stdio
  entry is the canonical `{command, args?, cwd?, env?}` form with `type` optional
  and defaulting to `"stdio"` — exactly what pragma's shared `defaultMcpEntry`
  emits. Declaring a bespoke `mcpEntry` here (as OpenCode, Cursor, Copilot and
  Crush need) would only be another serializer to keep in sync.
- **`.agents/skills`** as the skills path, matching what `setup skills` already
  links.

### The `omp` detection guard

`omp` is not an unambiguous binary name. **Oh My Posh** — a prompt theme engine,
an entirely unrelated tool — abbreviates itself `omp` throughout: its shell
functions are `_omp_*`, its themes are `*.omp.json`, and users commonly alias the
name. A bare `{type: "process", name: "omp"}` probe would therefore be a coin
flip, and a false positive means pragma writing an MCP config file into a prompt
theme engine's account.

So the process signal carries a `verify` guard, exactly as the OpenDesign row
guards `od` against the Unix octal-dump utility: the binary is only accepted when
`omp --version` prints `omp/<version>`, the form Oh My Pi's own CLI emits. Oh My
Posh prints a bare version number and fails the match. Directory signals are the
primary route regardless — the project `.omp/` directory and the user `~/.omp`
config root — with the PATH probe covering an install that has no project config
yet.

### Per-profile config: what this reaches, and what it does not

Oh My Pi supports named profiles, and each one has its *own* user MCP config at
`~/.omp/profiles/<name>/agent/mcp.json`. Writing the default-profile path for a
user who is on a named profile would install into a file omp never reads — a
silent, invisible failure.

The row therefore resolves the user band the way omp itself does: profile from
`OMP_PROFILE`, falling back to the legacy `PI_PROFILE` only when `OMP_PROFILE` is
undefined (an explicitly *empty* `OMP_PROFILE` selects the default profile and
must not fall through), and the `.omp` dirname relocatable via `PI_CONFIG_DIR`.

Two cases remain out of reach, and are written down on the row rather than left
to be discovered:

- **`omp --profile <name>` on omp's own command line.** That is a fact of an
  invocation that has not happened yet, not of the environment `pragma` runs in,
  so no function of the platform environment can see it. A user who selects a
  profile *only* by flag gets no entry in that profile, and must re-run
  `pragma setup mcp` with `OMP_PROFILE` set. Modelling this properly means adding
  a per-profile band to `HarnessDefinition` — a type change every other row would
  pay for, to serve one harness's flag. That is a bigger design change than
  registering a harness, and is deliberately not in this PR.
- **`PI_CODING_AGENT_DIR`**, which relocates the default profile's agent
  directory to an arbitrary path that omp resolves against *its own* working
  directory. The registry's platform-environment value carries no working
  directory, so a relative value would resolve somewhere else entirely. A
  documented gap beats a guessed path.

Neither affects the skills half, which is a directory link rather than a config
write.

### Not added: a user-level skills link

`oh-my-pi` is deliberately **not** added to `setup skills`'
`VERIFIED_GLOBAL_SKILL_HARNESSES`. Oh My Pi's user-level skills directory,
`~/.omp/agent/managed-skills`, is where omp's own auto-learn feature *writes*,
and pragma does not link into a directory the tool owns — the same rule that
keeps the Crush row off Crush's state files. The cross-client `~/.agents/skills`
link already covers the global band without touching it.

### Clarifying the neighbouring `pi` note

The registry's "Deliberately ABSENT" block declines `pi`
(github.com/earendil-works/pi) because it has no first-party MCP client. Oh My Pi
is a *different* project that does ship one, which is why it gets a row. A
sentence saying so now sits on the `pi` note, so a future reader does not read
the pair as a mix-up.

All paths and shapes verified against Oh My Pi's own `docs/mcp-config.md`,
`docs/skills.md`, and `packages/utils/src/cli.ts` / `packages/utils/src/dirs.ts`.

## QA

1. `cd packages/runtime/harnesses && bun run test` — 285 tests pass, 100%
   coverage held. New coverage: the row's paths and profile/`PI_CONFIG_DIR`
   resolution, the `verify` guard asserted against both Oh My Pi's and Oh My
   Posh's `--version` output, project/global write targets, and a merge that
   preserves omp's own `disabledServers` key.
2. `cd packages/cli/pragma && bunx vitest run src/capabilities/doctor` — 82 tests
   pass; the harness inventory now reports 14 known harnesses in both scopes.
3. With `omp` installed, `pragma setup mcp --local` writes `.omp/mcp.json` and
   `pragma doctor --verbose` lists **Oh My Pi** as detected. With Oh My Posh
   installed and Oh My Pi absent, `pragma doctor --verbose` must list Oh My Pi as
   *not detected* — that is the false positive the guard exists for.

### PR readiness check

- [x] PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format, using one of the allowed types: `feat`, `fix`, `docs`, `refactor`, `chore`, `test`, `ci`, `revert`.
  - The matching type label is applied automatically from the title — there is no type label to add by hand.
  - Breaking changes are marked with `!` in the title (e.g. `feat(router)!: …`), which adds the `breaking` label.
- [x] The code follows the appropriate [code standards](https://github.com/canonical/web-code-standards)
- [x] All packages define the required scripts in `package.json`:
  - [x] All packages: `check`, `check:fix`, and `test`.
  - [x] Packages with build steps: `build` to build the package for development or distribution, `build:all` to build **all** artifacts.
- [x] No new package is introduced, so no first-time publish or trusted-publisher setup is needed.
- [x] This PR does not require visual testing — the `Chromatic: skip` label is applied.

## Screenshots

Not applicable: no rendered UI surface changes.
