### PR TITLE
chore(monorepo): type-check test files in nine packages

### DIFF
--- a/docs/how-to-guides/ADDING_A_PACKAGE.md
+++ b/docs/how-to-guides/ADDING_A_PACKAGE.md
@@ -147,7 +147,7 @@ The package.json file defines the package identity, exports, scripts, and depend
   "scripts": {
     "build": "tsc -p tsconfig.build.json",
     "build:all": "tsc -p tsconfig.build.json",
-    "check": "bun run check:biome && bun run check:webarchitect",
+    "check": "bun run check:biome && bun run check:ts && bun run check:webarchitect",
     "check:webarchitect": "webarchitect library",
     "check:fix": "bun run check:biome:fix && bun run check:ts",
     "check:biome": "biome check",

--- a/docs/how-to-guides/ADDING_A_PACKAGE.md
+++ b/docs/how-to-guides/ADDING_A_PACKAGE.md
@@ -188,10 +188,14 @@ Create `tsconfig.json`:
     "baseUrl": "src",
     "types": ["node", "vitest/globals"]
   },
-  "include": ["src/**/*.ts", "vite.config.ts", "vitest.config.ts"],
-  "exclude": ["src/**/*.test.ts"]
+  "include": ["src/**/*.ts", "vite.config.ts", "vitest.config.ts"]
 }
 ```
+
+Note there is deliberately no `exclude` here. The base config is what `check:ts`
+(`tsc --noEmit`) reads, and test files must stay in its program — Vitest
+transpiles with esbuild, which strips types without checking them, so a test file
+excluded here is type-checked by nothing at all.
 
 Create `tsconfig.build.json`:
 
@@ -208,11 +212,16 @@ Create `tsconfig.build.json`:
     "types": ["node"]
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["src/**/*.tests.ts", "vite.config.ts", "vitest.config.ts"]
+  "exclude": [
+    "src/**/*.test.ts",
+    "src/**/*.tests.ts",
+    "vite.config.ts",
+    "vitest.config.ts"
+  ]
 }
 ```
 
-The base config extends the shared `@canonical/typescript-config` package, which defines strict type checking rules and module resolution settings. The build config adds output paths and excludes test files from compilation.
+The base config extends the shared `@canonical/typescript-config` package, which defines strict type checking rules and module resolution settings. The build config adds output paths and is the **only** place test files are excluded — they are excluded from *compilation*, so they never reach `dist/`, while remaining type-checked by `check:ts`. Keep both the singular and plural test patterns: the repo uses both namings.
 
 For React packages, extend `@canonical/typescript-config-react` instead of `@canonical/typescript-config`. The React config includes JSX settings and React-specific type definitions.
 

--- a/packages/cli/summon/src/components/undoPlan.test.ts
+++ b/packages/cli/summon/src/components/undoPlan.test.ts
@@ -79,7 +79,6 @@ describe("isUnreversibleExec", () => {
       _tag: "WriteFile",
       path: "a.ts",
       content: "",
-      overwrite: true,
     };
     expect(isUnreversibleExec(write)).toBe(false);
   });

--- a/packages/cli/summon/tsconfig.json
+++ b/packages/cli/summon/tsconfig.json
@@ -7,6 +7,5 @@
     "resolveJsonModule": true,
     "skipLibCheck": true
   },
-  "include": ["src/**/*.ts", "src/**/*.tsx"],
-  "exclude": ["src/**/*.test.ts", "src/**/*.test.tsx"]
+  "include": ["src/**/*.ts", "src/**/*.tsx"]
 }

--- a/packages/prism/contract/tsconfig.json
+++ b/packages/prism/contract/tsconfig.json
@@ -5,6 +5,5 @@
     "types": ["node"],
     "skipLibCheck": true
   },
-  "include": ["src/**/*.ts"],
-  "exclude": ["src/**/*.test.ts"]
+  "include": ["src/**/*.ts"]
 }

--- a/packages/prism/pragma-provider/tsconfig.json
+++ b/packages/prism/pragma-provider/tsconfig.json
@@ -5,6 +5,5 @@
     "types": ["node", "bun"],
     "skipLibCheck": true
   },
-  "include": ["src/**/*.ts", "demo/**/*.ts"],
-  "exclude": ["src/**/*.test.ts"]
+  "include": ["src/**/*.ts", "demo/**/*.ts"]
 }

--- a/packages/react/ssr-adapter-cloudflare/tsconfig.build.json
+++ b/packages/react/ssr-adapter-cloudflare/tsconfig.build.json
@@ -6,5 +6,10 @@
     "declaration": true,
     "declarationMap": true,
     "sourceMap": true
-  }
+  },
+  // Tests are excluded here and NOT in tsconfig.json: `check:ts` must keep them
+  // in its program (esbuild strips types without checking them, so an excluded
+  // test file is type-checked by nothing), while the emit must never carry them
+  // into dist/. Both spellings — this repo uses `*.test.ts` and `*.tests.ts`.
+  "exclude": ["src/**/*.test.ts", "src/**/*.tests.ts"]
 }

--- a/packages/react/ssr-adapter-cloudflare/tsconfig.json
+++ b/packages/react/ssr-adapter-cloudflare/tsconfig.json
@@ -5,6 +5,5 @@
     "types": ["@cloudflare/workers-types"],
     "skipLibCheck": true
   },
-  "include": ["src/**/*.ts"],
-  "exclude": ["src/**/*.tests.ts"]
+  "include": ["src/**/*.ts"]
 }

--- a/packages/react/ssr-adapter-deno/tsconfig.build.json
+++ b/packages/react/ssr-adapter-deno/tsconfig.build.json
@@ -6,5 +6,10 @@
     "declaration": true,
     "declarationMap": true,
     "sourceMap": true
-  }
+  },
+  // Tests are excluded here and NOT in tsconfig.json: `check:ts` must keep them
+  // in its program (esbuild strips types without checking them, so an excluded
+  // test file is type-checked by nothing), while the emit must never carry them
+  // into dist/. Both spellings — this repo uses `*.test.ts` and `*.tests.ts`.
+  "exclude": ["src/**/*.test.ts", "src/**/*.tests.ts"]
 }

--- a/packages/react/ssr-adapter-deno/tsconfig.json
+++ b/packages/react/ssr-adapter-deno/tsconfig.json
@@ -5,6 +5,5 @@
     "types": ["node"],
     "skipLibCheck": true
   },
-  "include": ["src/**/*.ts"],
-  "exclude": ["src/**/*.tests.ts"]
+  "include": ["src/**/*.ts"]
 }

--- a/packages/react/ssr-adapter-vercel/src/lib/handler/createNodeHandler.tests.ts
+++ b/packages/react/ssr-adapter-vercel/src/lib/handler/createNodeHandler.tests.ts
@@ -240,7 +240,11 @@ describe("createNodeHandler", () => {
 
   it("forwards an AbortSignal to the renderer and the Request (M3)", async () => {
     let renderSignal: AbortSignal | undefined;
-    let requestSignal: AbortSignal | null = null;
+    // Deliberately uninitialised. Both signals are assigned inside the factory
+    // callback below, so any initialiser (`= null`, `= undefined`) would leave
+    // control-flow analysis narrowed to the initialiser's type at the
+    // assertions, and `?.aborted` would then be an access on `never`.
+    let requestSignal: AbortSignal | undefined;
     const factory = (request: Request) => {
       requestSignal = request.signal;
       return {

--- a/packages/react/ssr-adapter-vercel/src/lib/handler/createNodeHandler.tests.ts
+++ b/packages/react/ssr-adapter-vercel/src/lib/handler/createNodeHandler.tests.ts
@@ -241,9 +241,10 @@ describe("createNodeHandler", () => {
   it("forwards an AbortSignal to the renderer and the Request (M3)", async () => {
     let renderSignal: AbortSignal | undefined;
     // Deliberately uninitialised. Both signals are assigned inside the factory
-    // callback below, so any initialiser (`= null`, `= undefined`) would leave
-    // control-flow analysis narrowed to the initialiser's type at the
-    // assertions, and `?.aborted` would then be an access on `never`.
+    // callback below, so an `= undefined` initialiser would leave control-flow
+    // analysis narrowed to `undefined` at the assertions, and `?.aborted` would
+    // then be an access on `never` — a silent trap, since the initialiser looks
+    // like harmless explicitness.
     let requestSignal: AbortSignal | undefined;
     const factory = (request: Request) => {
       requestSignal = request.signal;

--- a/packages/react/ssr-adapter-vercel/tsconfig.build.json
+++ b/packages/react/ssr-adapter-vercel/tsconfig.build.json
@@ -6,5 +6,10 @@
     "declaration": true,
     "declarationMap": true,
     "sourceMap": true
-  }
+  },
+  // Tests are excluded here and NOT in tsconfig.json: `check:ts` must keep them
+  // in its program (esbuild strips types without checking them, so an excluded
+  // test file is type-checked by nothing), while the emit must never carry them
+  // into dist/. Both spellings — this repo uses `*.test.ts` and `*.tests.ts`.
+  "exclude": ["src/**/*.test.ts", "src/**/*.tests.ts"]
 }

--- a/packages/react/ssr-adapter-vercel/tsconfig.json
+++ b/packages/react/ssr-adapter-vercel/tsconfig.json
@@ -5,6 +5,5 @@
     "types": ["node"],
     "skipLibCheck": true
   },
-  "include": ["src/**/*.ts"],
-  "exclude": ["src/**/*.tests.ts"]
+  "include": ["src/**/*.ts"]
 }

--- a/packages/runtime/harnesses/src/lib/config.test.ts
+++ b/packages/runtime/harnesses/src/lib/config.test.ts
@@ -609,8 +609,10 @@ describe("TOML config (Codex)", () => {
       }),
     );
 
-    expect(result.value.pragma).toBeDefined();
-    expect(result.value.pragma.command).toBe("pragma");
+    expect(result.value).toEqual({
+      figma: { url: "https://mcp.figma.com/mcp" },
+      pragma: { command: "pragma" },
+    });
   });
 
   it("writes mcp_servers entry as TOML table", () => {

--- a/packages/runtime/harnesses/tsconfig.json
+++ b/packages/runtime/harnesses/tsconfig.json
@@ -6,6 +6,5 @@
     "resolveJsonModule": true,
     "skipLibCheck": true
   },
-  "include": ["src/**/*.ts"],
-  "exclude": ["src/**/*.test.ts"]
+  "include": ["src/**/*.ts"]
 }

--- a/packages/runtime/i18n/tsconfig.json
+++ b/packages/runtime/i18n/tsconfig.json
@@ -6,6 +6,5 @@
     "resolveJsonModule": true,
     "skipLibCheck": true
   },
-  "include": ["src/**/*.ts"],
-  "exclude": ["src/**/*.test.ts"]
+  "include": ["src/**/*.ts"]
 }

--- a/packages/summon/package/CONVENTIONS.md
+++ b/packages/summon/package/CONVENTIONS.md
@@ -54,7 +54,7 @@
 |----|------|------|
 | P3.1 | `tsconfig.json` extends monorepo root or a shared config variant | `extends` field present |
 | P3.2 | `tsconfig.build.json` outputs to `dist/esm/` (JS) and `dist/types/` (declarations) | outDir = `dist/esm`, declarationDir = `dist/types` |
-| P3.3 | Test files (`*.test.ts`) are excluded from both tsconfigs | `exclude` includes test pattern |
+| P3.3 | Test files (`*.test.ts`) are excluded from `tsconfig.build.json` only, so `check:ts` still type-checks them | `tsconfig.build.json` `exclude` includes test pattern; `tsconfig.json` has none |
 | P3.4 | React packages have additional `tsconfig.json` with JSX support | jsx field set for React pkgs |
 | P3.5 | `biome.json` extends `@canonical/biome-config` (npm package, not relative path) | extends = `@canonical/biome-config` |
 | P3.6 | Biome scope includes `["src", "*.json"]` | scope covers src + json |

--- a/packages/summon/package/CONVENTIONS.md
+++ b/packages/summon/package/CONVENTIONS.md
@@ -54,7 +54,7 @@
 |----|------|------|
 | P3.1 | `tsconfig.json` extends monorepo root or a shared config variant | `extends` field present |
 | P3.2 | `tsconfig.build.json` outputs to `dist/esm/` (JS) and `dist/types/` (declarations) | outDir = `dist/esm`, declarationDir = `dist/types` |
-| P3.3 | Test files (`*.test.ts`) are excluded from `tsconfig.build.json` only, so `check:ts` still type-checks them | `tsconfig.build.json` `exclude` includes test pattern; `tsconfig.json` has none |
+| P3.3 | Test files (`*.test.ts`) are excluded from `tsconfig.build.json` only, so `check:ts` still type-checks them | `tsconfig.build.json` `exclude` includes test pattern; `tsconfig.json` excludes no test pattern |
 | P3.4 | React packages have additional `tsconfig.json` with JSX support | jsx field set for React pkgs |
 | P3.5 | `biome.json` extends `@canonical/biome-config` (npm package, not relative path) | extends = `@canonical/biome-config` |
 | P3.6 | Biome scope includes `["src", "*.json"]` | scope covers src + json |

--- a/packages/summon/package/src/templates/tsconfig.build.json.ejs
+++ b/packages/summon/package/src/templates/tsconfig.build.json.ejs
@@ -10,9 +10,14 @@
   },
 <% if (withReact) { -%>
   "include": ["src/**/*.ts", "src/**/*.tsx"],
-  "exclude": ["src/**/*.test.ts", "src/**/*.test.tsx"]
+  "exclude": [
+    "src/**/*.test.ts",
+    "src/**/*.test.tsx",
+    "src/**/*.tests.ts",
+    "src/**/*.tests.tsx"
+  ]
 <% } else { -%>
   "include": ["src/**/*.ts"],
-  "exclude": ["src/**/*.test.ts"]
+  "exclude": ["src/**/*.test.ts", "src/**/*.tests.ts"]
 <% } -%>
 }

--- a/packages/utils/tsconfig.json
+++ b/packages/utils/tsconfig.json
@@ -4,6 +4,5 @@
     "baseUrl": "src",
     "types": ["node", "vitest/globals"]
   },
-  "include": ["src/**/*.ts", "vite.config.ts", "vitest.config.ts"],
-  "exclude": ["src/**/*.test.ts"]
+  "include": ["src/**/*.ts", "vite.config.ts", "vitest.config.ts"]
 }


### PR DESCRIPTION
## Done

Closes #1152 — deliberately, even though it covers 9 of the 16 affected packages rather than all of them. The question that issue asked (are these exclusions deliberate or accumulated?) is answered here in full, and the remaining seven packages are not more of the same question but a different job: 263 pre-existing type errors to work through. **#1187** carries them, with per-package counts and the repo-wide guard that should eventually stop the exclusion coming back. If you would rather #1152 stayed open until every package is covered, say so and I will reopen it and drop the keyword.

Package `tsconfig.json` files carrying `"exclude": ["src/**/*.test.ts"]` (or `*.tests.ts`) kept their own test files out of `tsc --noEmit`. Vitest does not close that gap — esbuild strips types without checking them — so a type error in a fixture in those packages was reported by nothing at all.

### What the exclusions turned out to be

I checked all 51 package `tsconfig.json` files. 18 carry an `exclude`; 17 of those are test-related, not 14 as the issue estimated.

**They are a build concern that leaked into the check config.** In every affected package the build already excludes tests *independently*, via `tsconfig.build.json`. TypeScript **replaces** rather than merges `exclude` across `extends`, so where the build config declares its own `exclude`, the one in `tsconfig.json` does nothing for the build and only blinds the check. That is already the majority arrangement — 33 packages have no `exclude` in `tsconfig.json` at all and keep tests out of `dist` purely from `tsconfig.build.json` (e.g. `packages/react/hooks`), and the package generator's own templates (`packages/summon/package/src/templates/tsconfig*.json.ejs`) do the same.

Two exclusions are **not** accumulated and are left alone:

- `packages/react/router` excludes exactly one file, `src/lib/register.types.test.ts`. It is load-bearing and self-documenting: that file's `declare module` augmentation is program-global and would retype every sibling test, so it runs in its own program. It is already type-checked — the package's `check` runs `check:ts:registered` (`tsc --noEmit -p tsconfig.types.json`) alongside `check:ts`. Not a gap. The issue listed it as one.
- `packages/summon/application` excludes `src/application/react/templates/**` — scaffolding copied verbatim at build time, not tests. Its test files were already checked.

### What changed

For 6 packages the exclusion was deleted outright; their tests type-check clean with no other change:

`prism/contract`, `prism/pragma-provider`, `react/ssr-adapter-cloudflare`, `react/ssr-adapter-deno`, `runtime/i18n`, `utils`

For 3 more the exclusion was deleted and the single type error it surfaced was fixed:

- **`cli/summon`** — `undoPlan.test.ts` built a `WriteFile` effect with an `overwrite: true` property that has never existed on that variant (`packages/runtime/task/src/lib/types.ts`; `git log -S overwrite` on it is empty). Removed. `isUnreversibleExec` reads only `_tag` and `undo`, so the test still asserts exactly what its name says.
- **`react/ssr-adapter-vercel`** — `createNodeHandler.tests.ts` declared `let requestSignal: AbortSignal | null = null`. The variable is only ever assigned inside a callback, so control-flow analysis kept it narrowed to `null` and `requestSignal?.aborted` became an access on `never`. Now uninitialised and `AbortSignal | undefined`, matching `renderSignal` on the line above. The load-bearing part is dropping the *initialiser* — `= undefined` reproduces the same error — so there is a comment saying so.
- **`runtime/harnesses`** — `config.test.ts` read `result.value.pragma.command` off a `Record<string, unknown>`. Replaced with a whole-object `toEqual`, the idiom the other eight `result.value` assertions in that file already use. This **strengthens** the test: it now also pins the `figma` entry, which the fixture sets up but nothing asserted. Verified by mutation — making the TOML parser drop `url =` lines now fails this test, where before it passed.

For the three `ssr-adapter-*` packages the exclusion was **moved into `tsconfig.build.json`** rather than dropped. Unlike the others, those build configs declare no `exclude` of their own, so they inherited it; deleting it outright would have emitted test files into `dist` with `.d.ts` files beside them. This was confirmed by negative control — building with the old build config against the new base config does emit `createNodeHandler.tests.js` and friends. The moved patterns cover **both** `*.test.ts` and `*.tests.ts`, because the repo uses both namings and the adapters currently use only the plural one; a future singular test file would otherwise be shipped silently.

And four fixes to the guidance, because that is what regrows this bug. Every one of these is the same shape as the defect itself:

- `docs/how-to-guides/ADDING_A_PACKAGE.md` told authors to put `"exclude": ["src/**/*.test.ts"]` in `tsconfig.json` — byte-for-byte the shape this PR removes. Its build snippet also excluded only the plural spelling while its base snippet used the singular, so a package built from the guide would have emitted its tests.
- The same guide's `package.json` snippet defined `"check": "bun run check:biome && bun run check:webarchitect"`, wiring `check:ts` into `check:fix` only. CI runs `lerna run check`, so a package created from it type-checks **nothing** in CI — removing the exclusion from the guide would have achieved nothing while the check that reads it was not in the chain. 56 of the repo's 66 `check` scripts already include `check:ts`, and the guide's own ship-raw-TypeScript snippet further down already had it right. (The ten that do not are seven `configs/*`, two CSS packages, and one TTL package. The last commit's message says "53 of 63" and calls the ten "CSS and config packages" — the count is an undercount and the characterisation misses the TTL one. Correcting it here rather than rewriting a pushed commit.)
- The generator's `tsconfig.build.json` template (`packages/summon/package/src/templates/`) excluded only `*.test.ts`. That fails open in the mirror direction to the ssr-adapters: they excluded only the plural, this only the singular. The generator ships no vitest config, so nothing pins a generated package to either naming. Now both.
- `packages/summon/package/CONVENTIONS.md` rule P3.3 read "Test files are excluded from both tsconfigs" — already stale, since the generator's `tsconfig.json` template contradicts it.

### What is deferred, and why

Removing every exclusion surfaces **266 type errors across 10 packages**. That is not one PR, and none of them can be honestly silenced — so this PR takes the packages that come back clean or with a single mechanical error, and leaves the rest with their exclusion intact. **#1187** names them with counts:

| package | errors |
| --- | ---: |
| `runtime/ds-utils` | 89 |
| `cli/pragma` | 40 |
| `react/ssr` | 35 |
| `runtime/ke-graphql` | 34 |
| `runtime/ke` | 23 |
| `summon/core` | 22 |
| `runtime/task` | 20 |

These are real errors in real fixtures. `runtime/ds-utils` alone carries 76 `TS2345`s in `createNavigationReducer.test.ts` from the same `Item` union change that motivated the issue — and that package was not in the issue's list, even though the example it quoted lives there.

No `any`, `@ts-ignore`, `@ts-expect-error` or widened type is used anywhere in this PR to make a check pass.

### No new guard, deliberately

The repo has precedent for repo-wide invariant checks (`scripts/check-workspace-ranges.ts`, with its own test running first in CI). A guard forbidding a test `exclude` in `tsconfig.json` would lock this in, and it should eventually exist — nothing today stops someone re-adding the exclusion to quiet a failing test file, and CI would go green *because* of it.

It is not in this PR because with 7 packages still excluded it would need an allowlist nearly as large as the violation set, which teaches readers that the allowlist is a normal place to be. Note the allowlist will never be empty even then: `react/router` needs one permanent, justified entry. So the guard needs allowlist-with-reasons from day one, and it is better designed against a list of 1 than a list of 8. Recorded as the closing step of #1187.

### Noted, not done here

- `packages/utils` is the only one of these packages without `skipLibCheck`, costing ~7.8s of `check` time on its own. Measured and filed as #1188 — unrelated to this change.
- The three `ssr-adapter-*` packages now keep their test exclusion solely in `tsconfig.build.json`, which no `check` script reads. `cli/summon` has the precedent (`check:ts:build`). True of ~24 other build configs too, so it is a repo-wide question; noted in #1187.
- `vitest.config.ts` is outside the TypeScript program in 8 of these 9 packages — the same class of blind spot. Noted in #1187.
- `runtime/harnesses/src/lib/config.test.ts` routes ~25 assertions through `JSON.parse(...)`, which is `any`, so those chains stay unchecked even now. Noted in #1187.
- The three adapter `tsconfig.build.json` files lack `rootDir`/`include` and use a non-house `compilerOptions` key order. Pre-existing; not touched, to keep the diff to the exclusion.

## QA

- **CI `build-matrix` passed on both Node 22 and 24** — that is the authoritative gate and it covers the browser tests I cannot run locally.
- `bun run check` from the root: `Successfully ran target check for 66 projects and 41 tasks they depend on` (exit 0), re-confirmed after the last commit.
- `bun run test` from the root did not go fully green on my machine, for reasons unrelated to this diff — recorded here so the gap is visible rather than glossed. Run in parallel it returned exit 130 twice with a *different* untouched package failing each time (Nx labelled `@canonical/router-react:test` flaky; it passes in isolation, 15 files / 59 tests). Run serially the failure set is stable and confined to the Playwright browser-test packages: `@canonical/svelte-ds-global`, `@canonical/svelte-ds-app-wpe`, `@canonical/svelte-ds-app` and `@canonical/styles-vanilla-adapter`, all failing with `chrome-headless-shell: error while loading shared libraries: libglib-2.0.so.0`. Playwright's pinned Chromium cannot start on NixOS, which `packages/styles/vanilla-adapter/vite.config.ts` documents; setting the `PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH` escape hatch it provides makes `styles-vanilla-adapter` pass, and the three Svelte packages do not read it. None of the four is touched by this diff, and CI runs them green.
- `bun run test` in all 9 affected packages individually: pass (74, 21, 285, 11, 15, 49 and the rest, all green).
- `bun run build` in the three `ssr-adapter-*` packages: pass; 0 test artifacts across 52 `dist` files, and output byte-identical to `origin/main`.
- Every test file on disk is now in the TypeScript program in all 9 packages — an exact 1:1 match, 62 files total, no package silently a no-op.
- Negative control, both namings: appending `const __probe: number = "no";` to a test file now yields `error TS2322: Type 'string' is not assignable to type 'number'.` in `runtime/i18n` (`.test.ts`) and `react/ssr-adapter-cloudflare` (`.tests.ts`). On `origin/main` the same line produces no diagnostic at all.
- Type-check cost: about +0.25s per package, +2.3s summed across the nine.

Chromatic is skipped via the `Chromatic: skip` label — this change has no visual surface.
