### PR TITLE
chore(react-ssr): drop the JSON comments from the adapter build configs

### DIFF
--- a/packages/react/ssr-adapter-cloudflare/tsconfig.build.json
+++ b/packages/react/ssr-adapter-cloudflare/tsconfig.build.json
@@ -7,9 +7,5 @@
     "declarationMap": true,
     "sourceMap": true
   },
-  // Tests are excluded here and NOT in tsconfig.json: `check:ts` must keep them
-  // in its program (esbuild strips types without checking them, so an excluded
-  // test file is type-checked by nothing), while the emit must never carry them
-  // into dist/. Both spellings — this repo uses `*.test.ts` and `*.tests.ts`.
   "exclude": ["src/**/*.test.ts", "src/**/*.tests.ts"]
 }

--- a/packages/react/ssr-adapter-deno/tsconfig.build.json
+++ b/packages/react/ssr-adapter-deno/tsconfig.build.json
@@ -7,9 +7,5 @@
     "declarationMap": true,
     "sourceMap": true
   },
-  // Tests are excluded here and NOT in tsconfig.json: `check:ts` must keep them
-  // in its program (esbuild strips types without checking them, so an excluded
-  // test file is type-checked by nothing), while the emit must never carry them
-  // into dist/. Both spellings — this repo uses `*.test.ts` and `*.tests.ts`.
   "exclude": ["src/**/*.test.ts", "src/**/*.tests.ts"]
 }

--- a/packages/react/ssr-adapter-vercel/tsconfig.build.json
+++ b/packages/react/ssr-adapter-vercel/tsconfig.build.json
@@ -7,9 +7,5 @@
     "declarationMap": true,
     "sourceMap": true
   },
-  // Tests are excluded here and NOT in tsconfig.json: `check:ts` must keep them
-  // in its program (esbuild strips types without checking them, so an excluded
-  // test file is type-checked by nothing), while the emit must never carry them
-  // into dist/. Both spellings — this repo uses `*.test.ts` and `*.tests.ts`.
   "exclude": ["src/**/*.test.ts", "src/**/*.tests.ts"]
 }


### PR DESCRIPTION
## Done

#1189 added a four-line comment to three `tsconfig.build.json` files. This removes them.

The three files now parse as strict JSON. The explanation is not lost — it already exists in prose in `docs/how-to-guides/ADDING_A_PACKAGE.md`, which states both halves: that the base config deliberately carries no `exclude`, because `check:ts` must keep test files in its program (esbuild strips types without checking them, so an excluded test file is type-checked by nothing), and that the build config excludes them so the emit never carries them into `dist/`. That guide is what a new package is written from, so it is the right home for the rule.

## What the removal does not change

The exclusion itself stays exactly where #1189 put it, which was the correct call — the four `react/ssr*` packages inherit their base config's `exclude` rather than declaring their own, so deleting it outright would have shipped test files into `dist/`.

Verified rather than assumed: all three packages build clean, and `dist/esm/` contains no test output.

## Three files not touched, and the decision they need

Comments in a `tsconfig` are legal — TypeScript reads these as JSONC — and nothing in this repo parses them with a strict JSON parser. The reason they show as errors in an editor is narrower: `tsconfig.json` is mapped to the JSONC schema by name, and `tsconfig.build.json` is not, so the same comment is fine in one filename and flagged in the other.

Three files on `main` still carry comments, 33 lines in total:

| File | Lines |
|---|---|
| `packages/cli/pragma/tsconfig.build.json` | 22 |
| `packages/cli/summon/tsconfig.build.json` | 9 |
| `packages/lit/ds-prototype/tsconfig.json` | 2 |

They predate #1189 and are almost certainly where the pattern was copied from. They are **deliberately left alone here**, because unlike the four lines this PR removes, their content is not documented anywhere else: the `cli/pragma` block explains that `rootDir: "."` is load-bearing (`src/kernel/render/prefixes.ts` imports `../../../pragma.conf.js`, which resolves only if the conf keeps its position above `src/`) and why `declaration` is deliberately absent. Deleting that would lose the knowledge rather than relocate it.

So there is a call to make, and it is not this PR's to make silently:

1. **Leave them.** Comments in tsconfig are legal and idiomatic; accept the editor noise on the `.build.json` filenames.
2. **Relocate and strip.** Move each block into prose beside its package, then remove — the same treatment this PR gives the four lines, applied to the remaining 33.
3. **Strip everywhere** and accept the content loss.

Until one is chosen the repo is inconsistent, and the next person to copy an existing build config will reintroduce exactly what this PR removes.

## QA

```bash
bun run check   # Successfully ran target check for 66 projects — exit 0

# each adapter builds, and emits no tests:
cd packages/react/ssr-adapter-cloudflare && bun run build && ls dist/esm | grep -i test
# (no output — the exclusion still holds)
```

### PR readiness check

- [x] PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format — `chore(react-ssr)`.
- [x] The code follows the appropriate [code standards](https://github.com/canonical/web-code-standards)
- [x] All packages define the required scripts in `package.json` — unchanged.
- [x] If this PR introduces a **new package** — n/a.
- [x] If this PR does not require visual testing, add the `Chromatic: skip` label — applied. Three build-config files; no runtime, no rendered output.

## Screenshots

n/a — no visual surface.
