### PR TITLE
feat(dataviews): core package scaffold with identity tokens

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1009,6 +1009,19 @@
         "vitest": "^4.0.18",
       },
     },
+    "packages/runtime/dataviews": {
+      "name": "@canonical/dataviews-core",
+      "version": "0.37.0",
+      "devDependencies": {
+        "@biomejs/biome": "2.5.12",
+        "@canonical/biome-config": "^0.37.0",
+        "@canonical/webarchitect": "^0.37.0",
+        "@types/node": "^26.0.0",
+        "@vitest/coverage-v8": "^4.0.18",
+        "typescript": "^5.9.3",
+        "vitest": "^4.0.18",
+      },
+    },
     "packages/runtime/ds-utils": {
       "name": "@canonical/ds-utils",
       "version": "0.37.0",
@@ -1856,6 +1869,8 @@
     "@canonical/anatomy-dsl": ["@canonical/anatomy-dsl@0.3.0", "", {}, "sha512-9jPkepRinrJ1X/fpNIgseuBcVy0lk06g4RySjgv3sXrhmr1iqSavlGTw68oKZddIMBG0Axg/RVyQZ8LyCEO+Tg=="],
 
     "@canonical/biome-config": ["@canonical/biome-config@workspace:configs/biome"],
+
+    "@canonical/dataviews-core": ["@canonical/dataviews-core@workspace:packages/runtime/dataviews"],
 
     "@canonical/design-system": ["@canonical/design-system@0.2.5", "", { "dependencies": { "ajv": "^8.17.1", "jsonld": "^9.0.0", "n3": "^2.0.1", "tinyglobby": "^0.2.14" }, "bin": { "collect-implementations": "src/collect-implementations.ts" } }, "sha512-+J/GQ64Z+RHEC4fLYCcSV9CIVrIlYZQ2tpzG1mcpSWjs9foFZmvbCKfhxyMzPxx9RZNeNX2PfnBixWpdyBgPoQ=="],
 
@@ -4475,7 +4490,7 @@
 
     "undici": ["undici@7.24.4", "", {}, "sha512-BM/JzwwaRXxrLdElV2Uo6cTLEjhSb3WXboncJamZ15NgUURmvlXvxa6xkwIOILIjPNo9i8ku136ZvWV0Uly8+w=="],
 
-    "undici-types": ["undici-types@7.24.4", "", {}, "sha512-cRaY9PagdEZoRmcwzk3tUV3SVGrVQkR6bcSilav/A0vXsfpW4Lvd0BvgRMwTEDTLLGN+QdyBTG+nnvTgJhdt6w=="],
+    "undici-types": ["undici-types@8.3.0", "", {}, "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ=="],
 
     "unicorn-magic": ["unicorn-magic@0.3.0", "", {}, "sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA=="],
 
@@ -4805,9 +4820,9 @@
 
     "@types/jsdom/@types/node": ["@types/node@24.12.0", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-GYDxsZi3ChgmckRT9HPU0WEhKLP08ev/Yfcq2AstjrDASOYCSXeyjDsHg4v5t4jOj7cyDX3vmprafKlWIG9MXQ=="],
 
-    "@types/keyv/@types/node": ["@types/node@24.12.0", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-GYDxsZi3ChgmckRT9HPU0WEhKLP08ev/Yfcq2AstjrDASOYCSXeyjDsHg4v5t4jOj7cyDX3vmprafKlWIG9MXQ=="],
+    "@types/jsdom/undici-types": ["undici-types@7.24.4", "", {}, "sha512-cRaY9PagdEZoRmcwzk3tUV3SVGrVQkR6bcSilav/A0vXsfpW4Lvd0BvgRMwTEDTLLGN+QdyBTG+nnvTgJhdt6w=="],
 
-    "@types/node/undici-types": ["undici-types@8.3.0", "", {}, "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ=="],
+    "@types/keyv/@types/node": ["@types/node@24.12.0", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-GYDxsZi3ChgmckRT9HPU0WEhKLP08ev/Yfcq2AstjrDASOYCSXeyjDsHg4v5t4jOj7cyDX3vmprafKlWIG9MXQ=="],
 
     "@types/react-relay/@types/relay-runtime": ["@types/relay-runtime@19.0.3", "", {}, "sha512-pvpWWQq5e9KeESF8klQaP2igLLhr2bRd3XxVCxNpGElsPQiP6Mejr59RT9/OGY3O3i8jAGGQsshVe0QCQDbxNg=="],
 

--- a/packages/runtime/dataviews/README.md
+++ b/packages/runtime/dataviews/README.md
@@ -1,0 +1,31 @@
+# @canonical/dataviews-core
+
+Framework-agnostic core for Canonical collection views. It will hold the query grammar, lifecycle transition contracts, row and cell projections, and shared table geometry that framework bindings build on — logic, never markup. The current surface is the runtime identity-token foundation described under Status.
+
+> **Stability: pre-1.0 / experimental.** The API is still consolidating and breaking changes may land between minor versions. Every breaking change ships with a conventional-commit subject and a CHANGELOG entry — those are the migration record. Pin a minor version if you need stability today.
+
+## Installation
+
+```bash
+bun add @canonical/dataviews-core
+```
+
+## Status
+
+This package is under active development and its public surface grows change by change. The current exports mint and check runtime identity tokens — the referential markers that later contracts use to keep a value created against one DataViews scope (a provider, a column set) from being silently consumed by another:
+
+```ts
+import { createIdentity, isIdentity } from "@canonical/dataviews-core";
+
+const providerScope = createIdentity();
+
+// At a scope boundary, values arrive untyped; the guard narrows them.
+function adoptScopeToken(value: unknown) {
+  if (!isIdentity(value)) {
+    throw new Error("Expected a DataViews scope token");
+  }
+  return value; // value: Identity
+}
+```
+
+Comparing identities is referential (`tokenA === tokenB`); tokens carry no key, label, or serialized data, and structural copies of a token are not tokens. Query grammar, lifecycle transitions, projections, and geometry contracts land in subsequent changes.

--- a/packages/runtime/dataviews/biome.json
+++ b/packages/runtime/dataviews/biome.json
@@ -1,0 +1,6 @@
+{
+  "extends": ["@canonical/biome-config"],
+  "files": {
+    "includes": ["**/src/**", "**/*.json"]
+  }
+}

--- a/packages/runtime/dataviews/package.json
+++ b/packages/runtime/dataviews/package.json
@@ -1,0 +1,56 @@
+{
+  "name": "@canonical/dataviews-core",
+  "description": "Framework-agnostic collection-views core for Canonical apps; currently ships runtime identity tokens for scope boundaries",
+  "version": "0.37.0",
+  "type": "module",
+  "module": "dist/esm/index.js",
+  "types": "dist/types/index.d.ts",
+  "sideEffects": false,
+  "exports": {
+    ".": {
+      "types": "./dist/types/index.d.ts",
+      "import": "./dist/esm/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "author": {
+    "email": "webteam@canonical.com",
+    "name": "Canonical Webteam"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/canonical/pragma"
+  },
+  "license": "LGPL-3.0",
+  "bugs": {
+    "url": "https://github.com/canonical/pragma/issues"
+  },
+  "homepage": "https://github.com/canonical/pragma#readme",
+  "publishConfig": {
+    "access": "public"
+  },
+  "scripts": {
+    "build": "tsc -p tsconfig.build.json",
+    "build:all": "bun run build",
+    "check": "bun run check:biome && bun run check:ts && bun run check:webarchitect",
+    "check:webarchitect": "webarchitect library",
+    "check:fix": "bun run check:biome:fix && bun run check:ts",
+    "check:biome": "biome check",
+    "check:biome:fix": "biome check --write",
+    "check:ts": "tsc --noEmit",
+    "test": "bun run test:vitest",
+    "test:vitest": "vitest run --coverage",
+    "test:vitest:watch": "vitest"
+  },
+  "devDependencies": {
+    "@biomejs/biome": "2.5.12",
+    "@canonical/biome-config": "^0.37.0",
+    "@canonical/webarchitect": "^0.37.0",
+    "@types/node": "^26.0.0",
+    "@vitest/coverage-v8": "^4.0.18",
+    "typescript": "^5.9.3",
+    "vitest": "^4.0.18"
+  }
+}

--- a/packages/runtime/dataviews/src/index.test.ts
+++ b/packages/runtime/dataviews/src/index.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "vitest";
+import * as dataviews from "./index.js";
+
+describe("public surface", () => {
+  it("exports exactly the identity API", () => {
+    expect(Object.keys(dataviews).sort()).toEqual([
+      "createIdentity",
+      "isIdentity",
+    ]);
+  });
+
+  it("wires the barrel to working functions", () => {
+    expect(dataviews.isIdentity(dataviews.createIdentity())).toBe(true);
+  });
+});

--- a/packages/runtime/dataviews/src/index.ts
+++ b/packages/runtime/dataviews/src/index.ts
@@ -1,0 +1,10 @@
+/**
+ * @canonical/dataviews-core — collection-views core for Canonical apps.
+ * Current surface: runtime identity tokens for scope boundaries; query
+ * grammar, lifecycle transitions, projections, and shared geometry land
+ * as they are implemented.
+ *
+ * @packageDocumentation
+ */
+
+export * from "./lib/index.js";

--- a/packages/runtime/dataviews/src/index.types.test.ts
+++ b/packages/runtime/dataviews/src/index.types.test.ts
@@ -1,0 +1,30 @@
+/**
+ * Compile-time contract tests for the package's public type surface.
+ *
+ * Runtime behavior lives in the sibling test files; this file pins the type
+ * exports, including the barrel re-export. Every assertion here has been
+ * mutation-tested: change the source type and the assertion fails.
+ */
+
+import { describe, expectTypeOf, it } from "vitest";
+import type { Identity } from "./index.js";
+import * as dataviews from "./index.js";
+
+describe("public surface types", () => {
+  it("exports the identity functions with the declared shapes", () => {
+    expectTypeOf(dataviews.createIdentity).returns.toEqualTypeOf<Identity>();
+    expectTypeOf(dataviews.isIdentity).parameter(0).toEqualTypeOf<unknown>();
+  });
+
+  it("narrows unknown values to Identity", () => {
+    const value: unknown = undefined;
+    if (dataviews.isIdentity(value)) {
+      expectTypeOf(value).toEqualTypeOf<Identity>();
+    }
+  });
+
+  it("keeps Identity opaque to structural construction", () => {
+    expectTypeOf<Record<string, never>>().not.toMatchTypeOf<Identity>();
+    expectTypeOf<object>().not.toMatchTypeOf<Identity>();
+  });
+});

--- a/packages/runtime/dataviews/src/lib/createIdentity.test.ts
+++ b/packages/runtime/dataviews/src/lib/createIdentity.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+import createIdentity from "./createIdentity.js";
+
+describe("createIdentity", () => {
+  it("returns a fresh token per call", () => {
+    expect(createIdentity()).not.toBe(createIdentity());
+  });
+
+  it("freezes the token against mutation", () => {
+    expect(Object.isFrozen(createIdentity())).toBe(true);
+  });
+
+  it("keeps the brand out of structural copies", () => {
+    const token = createIdentity() as object;
+    expect({ ...token }).toEqual({});
+  });
+});

--- a/packages/runtime/dataviews/src/lib/createIdentity.ts
+++ b/packages/runtime/dataviews/src/lib/createIdentity.ts
@@ -1,0 +1,32 @@
+import { identityBrand } from "./identityBrand.js";
+
+/**
+ * An opaque identity token for a DataViews runtime scope.
+ *
+ * Identities are referential: two tokens are the same identity only when they
+ * are the same object. They carry no key, label, or serializable data.
+ */
+export type Identity = {
+  readonly [identityBrand]: true;
+};
+
+/**
+ * Create a fresh identity token, distinct from every other identity.
+ *
+ * Identity tokens mark runtime scopes (a provider, a column set, a cell
+ * handle) so consumers can enforce, at runtime, that a value created against
+ * one scope is not silently consumed by another. Structural copies of a
+ * token and forged-key look-alikes are rejected by `isIdentity`.
+ */
+export default function createIdentity(): Identity {
+  // The brand is a non-enumerable own property: spread and Object.assign
+  // skip it, and the guard's own-property check rejects Object.create copies.
+  const token = {} as Identity;
+  Object.defineProperty(token, identityBrand, {
+    value: true,
+    enumerable: false,
+    writable: false,
+    configurable: false,
+  });
+  return Object.freeze(token);
+}

--- a/packages/runtime/dataviews/src/lib/identityBrand.ts
+++ b/packages/runtime/dataviews/src/lib/identityBrand.ts
@@ -1,0 +1,2 @@
+/** Internal brand marking DataViews identity tokens. Not part of the public API. */
+export const identityBrand = Symbol("DataViewsIdentity");

--- a/packages/runtime/dataviews/src/lib/index.ts
+++ b/packages/runtime/dataviews/src/lib/index.ts
@@ -1,0 +1,3 @@
+export type { Identity } from "./createIdentity.js";
+export { default as createIdentity } from "./createIdentity.js";
+export { default as isIdentity } from "./isIdentity.js";

--- a/packages/runtime/dataviews/src/lib/isIdentity.test.ts
+++ b/packages/runtime/dataviews/src/lib/isIdentity.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import createIdentity from "./createIdentity.js";
+import isIdentity from "./isIdentity.js";
+
+describe("isIdentity", () => {
+  it("accepts identity tokens", () => {
+    expect(isIdentity(createIdentity())).toBe(true);
+  });
+
+  it("rejects null and undefined", () => {
+    expect(isIdentity(null)).toBe(false);
+    expect(isIdentity(undefined)).toBe(false);
+  });
+
+  it("rejects primitives", () => {
+    expect(isIdentity(42)).toBe(false);
+    expect(isIdentity("DataViewsIdentity")).toBe(false);
+  });
+
+  it("rejects plain objects", () => {
+    expect(isIdentity({})).toBe(false);
+    expect(isIdentity({ key: "provider" })).toBe(false);
+  });
+
+  it("rejects forged symbol keys with the same description", () => {
+    const forged = { [Symbol("DataViewsIdentity")]: true };
+    expect(isIdentity(forged)).toBe(false);
+  });
+
+  it("rejects string-keyed look-alikes", () => {
+    expect(isIdentity({ DataViewsIdentity: true })).toBe(false);
+  });
+
+  it("rejects structural copies of a real token", () => {
+    const token = createIdentity();
+    expect(isIdentity({ ...token })).toBe(false);
+    expect(isIdentity(Object.assign({}, token))).toBe(false);
+    expect(isIdentity(Object.create(token))).toBe(false);
+  });
+});

--- a/packages/runtime/dataviews/src/lib/isIdentity.ts
+++ b/packages/runtime/dataviews/src/lib/isIdentity.ts
@@ -1,0 +1,18 @@
+import type { Identity } from "./createIdentity.js";
+import { identityBrand } from "./identityBrand.js";
+
+/**
+ * Check whether an unknown value is a DataViews identity token.
+ *
+ * Accepts tokens created by `createIdentity` and rejects structural copies
+ * and forged-key look-alikes: spread and Object.assign drop the
+ * non-enumerable brand, the own-property check rejects prototype copies,
+ * and forged symbols fail on symbol identity.
+ */
+export default function isIdentity(value: unknown): value is Identity {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    Object.hasOwn(value, identityBrand)
+  );
+}

--- a/packages/runtime/dataviews/tsconfig.build.json
+++ b/packages/runtime/dataviews/tsconfig.build.json
@@ -1,0 +1,13 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist/esm",
+    "declaration": true,
+    "declarationDir": "dist/types",
+    "declarationMap": true,
+    "sourceMap": true
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["src/**/*.test.ts"]
+}

--- a/packages/runtime/dataviews/tsconfig.json
+++ b/packages/runtime/dataviews/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../../configs/typescript/tsconfig.json",
+  "compilerOptions": {
+    "baseUrl": "src",
+    "types": ["node"],
+    "resolveJsonModule": true,
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/packages/runtime/dataviews/vitest.config.ts
+++ b/packages/runtime/dataviews/vitest.config.ts
@@ -1,0 +1,20 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    globals: true,
+    include: ["src/**/*.test.ts"],
+    environment: "node",
+    coverage: {
+      provider: "v8",
+      include: ["src/**/*.ts"],
+      exclude: ["**/index.ts", "**/*.test.ts", "**/*.d.ts", "**/types.ts"],
+      thresholds: {
+        branches: 100,
+        functions: 100,
+        lines: 100,
+        statements: 100,
+      },
+    },
+  },
+});


### PR DESCRIPTION
## Done

- Adds `@canonical/dataviews-core` under `packages/runtime/`, the framework-agnostic foundation package for Canonical collection views (query grammar, lifecycle transitions, projections, and shared table geometry will land as implemented changes).
- First runtime surface: a branded identity-token utility — `createIdentity`, `isIdentity`, and the opaque `Identity` type — the referential markers later provider/column-set/cell-handle contracts use to keep a value created against one scope from being silently consumed by another.
- Identity semantics are pinned by tests: tokens are referentially distinct and frozen; structural copies (spread, `Object.assign`, `Object.create`) and forged-key look-alikes (same-description symbols, string keys) are rejected; the guard narrows `unknown` to `Identity`.
- The public surface is machine-enforced from day one: a runtime export pin, compile-time type pins (barrel re-export, function shapes, narrowing, opacity — mutation-verified), and a behavioral barrel test.

Three deliberate deviations from sibling shape, all called out here:

1. `"sideEffects": false` in the manifest — no runtime sibling declares it, but the module graph is verifiably side-effect-free (one module-scope `Symbol()`), and the flag sets the tree-shaking posture for a barrel that will grow substantially.
2. Coverage rides the standard gate using the established `test` → `test:vitest` (`vitest run --coverage`) vocabulary (as in `task`/`harnesses`), with `@vitest/coverage-v8` declared; thresholds are 100% branch/function/line/statement.
3. The package description names only the current surface (identity tokens) so npm metadata does not overclaim; the README frames the full charter in future tense.

Also: `bun.lock` regenerated per repo convention — besides the new workspace entry, bun refreshed `undici-types` placement (7.24.4 → 8.3.0 top-level, one nested `@types/jsdom` entry); the resolved version set is otherwise unchanged and the regeneration is deterministic from the committed lock.

## QA

- `bun run check` green at the root (biome + tsc + webarchitect for the new package).
- `bunx nx affected -t test --base=origin/main --head=HEAD` green — the CI gate (15/15 tests, 100% coverage).
- A full-universe local `bun run test` surfaced three failures in `webarchitect` (`discoverAllRulesets`) and `react-ssr` (`viteFetchMiddleware`, `serveString`) — all three pass unloaded on both a clean `origin/main` worktree and this branch, and their 8–11s durations under the parallel run indicate timeout-under-load flakes in packages this change does not touch.
- `tsc -p tsconfig.build.json` emits cleanly (declaration maps verified).

### PR readiness check

- [x] PR title follows the Conventional Commits format.
- [x] The code follows the appropriate code standards.
- [x] All packages define the required scripts (`check`, `check:fix`, `test`; `build`/`build:all` for this buildable package).
- [x] New package: first-time publish is a manual follow-up for a human (npm 2FA) once this lands; OIDC trusted-publisher setup after that. Not blocking this PR.
- [x] No visual surface — Chromatic: skip label applied.

Chromatic: skip