### PR TITLE
feat(dataviews): transition contracts with stage-one counterexamples

### DIFF
--- a/packages/runtime/dataviews/README.md
+++ b/packages/runtime/dataviews/README.md
@@ -1,6 +1,6 @@
 # @canonical/dataviews-core
 
-Framework-agnostic core for Canonical collection views. It will hold the query grammar, lifecycle transition contracts, row and cell projections, and shared table geometry that framework bindings build on — logic, never markup. The current surface is the runtime identity-token foundation described under Status.
+Framework-agnostic core for Canonical collection views. It holds the bounded query grammar and addressed commands, the field/operation/save-race interaction records, and the collection coordinator that owns query/window coherence and the request lifecycle — logic, never markup. Framework bindings, URL transport and data-source adapters are wired above this layer.
 
 > **Stability: pre-1.0 / experimental.** The API is still consolidating and breaking changes may land between minor versions. Every breaking change ships with a conventional-commit subject and a CHANGELOG entry — those are the migration record. Pin a minor version if you need stability today.
 
@@ -12,20 +12,13 @@ bun add @canonical/dataviews-core
 
 ## Status
 
-This package is under active development and its public surface grows change by change. The current exports mint and check runtime identity tokens — the referential markers that later contracts use to keep a value created against one DataViews scope (a provider, a column set) from being silently consumed by another:
+Under active development; the public surface grows change by change. The current runtime exports are `createIdentity`, `isIdentity`, `canonicalSlice`, `sliceEquals`, `createFieldInteraction`, `createOperation`, `createCollectionCoordinator` and `createSaveSession`, together with their config, state, result and grammar types (`Slice`, `ResultWindow`, `QueryCommand`, `CompletionResult` and friends re-exported from the package root):
 
-```ts
-import { createIdentity, isIdentity } from "@canonical/dataviews-core";
+- **Identity tokens** — `createIdentity`, `isIdentity`: referential scope markers; structural copies and forged-key look-alikes are rejected.
+- **Query grammar** — `Slice`/`ResultWindow` types, `canonicalSlice` (equality operands are sets, sort order is never reordered, empty search is no search), `sliceEquals` for semantic equality.
+- **Field interaction** — `createFieldInteraction`: input buffer and feedback for one filter field; invalid or incomplete edits retain the applied predicate; explicit `clear` is distinct from invalid input.
+- **Operation record** — `createOperation`: captures targets and selection revision immutably at construction so later selection changes never retarget execution; partial outcomes settle each target once; retry re-runs only failed targets.
+- **Collection coordinator** — `createCollectionCoordinator`: addressed commands as coherent query+window transitions (a query change resets the page), request identities whose stale completions are ignored, atomic publication of rows/provenance/count, scope rotation, and `adopt` for externally authoritative state such as back/forward navigation.
+- **Save race** — `createSaveSession`: a save completion updates only the submitted baseline, so edits made while saving remain dirty; delayed external reads never overwrite newer local state.
 
-const providerScope = createIdentity();
-
-// At a scope boundary, values arrive untyped; the guard narrows them.
-function adoptScopeToken(value: unknown) {
-  if (!isIdentity(value)) {
-    throw new Error("Expected a DataViews scope token");
-  }
-  return value; // value: Identity
-}
-```
-
-Comparing identities is referential (`tokenA === tokenB`); tokens carry no key, label, or serialized data, and structural copies of a token are not tokens. Query grammar, lifecycle transitions, projections, and geometry contracts land in subsequent changes.
+Rows are opaque to the core: adapters execute request identities and publish completions; nothing here knows a data source, a router or the DOM.

--- a/packages/runtime/dataviews/package.json
+++ b/packages/runtime/dataviews/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@canonical/dataviews-core",
-  "description": "Framework-agnostic collection-views core for Canonical apps; currently ships runtime identity tokens for scope boundaries",
+  "description": "Framework-agnostic collection-views core for Canonical apps: query grammar, lifecycle transition records, and the request-lifecycle coordinator",
   "version": "0.37.0",
   "type": "module",
   "module": "dist/esm/index.js",

--- a/packages/runtime/dataviews/src/index.test.ts
+++ b/packages/runtime/dataviews/src/index.test.ts
@@ -2,14 +2,44 @@ import { describe, expect, it } from "vitest";
 import * as dataviews from "./index.js";
 
 describe("public surface", () => {
-  it("exports exactly the identity API", () => {
+  it("exports exactly the public API", () => {
     expect(Object.keys(dataviews).sort()).toEqual([
+      "canonicalSlice",
+      "createCollectionCoordinator",
+      "createFieldInteraction",
       "createIdentity",
+      "createOperation",
+      "createSaveSession",
       "isIdentity",
+      "sliceEquals",
     ]);
   });
 
   it("wires the barrel to working functions", () => {
     expect(dataviews.isIdentity(dataviews.createIdentity())).toBe(true);
+    expect(dataviews.createCollectionCoordinator().state.result.status).toBe(
+      "idle",
+    );
+    expect(
+      dataviews.createSaveSession({
+        initial: 0,
+        equals: (a: number, b: number) => a === b,
+      }).state.dirty,
+    ).toBe(false);
+  });
+
+  it("keeps save attempts one-shot", () => {
+    const save = dataviews.createSaveSession({
+      initial: 0,
+      equals: (a: number, b: number) => a === b,
+    });
+    save.edit(1);
+    const attempt = save.beginSave();
+    if (attempt === null) {
+      throw new Error("expected a save attempt");
+    }
+    save.saveCompleted(attempt);
+    save.saveCompleted(attempt);
+    expect(save.state.baseline).toBe(1);
   });
 });

--- a/packages/runtime/dataviews/src/index.ts
+++ b/packages/runtime/dataviews/src/index.ts
@@ -1,8 +1,10 @@
 /**
- * @canonical/dataviews-core — collection-views core for Canonical apps.
- * Current surface: runtime identity tokens for scope boundaries; query
- * grammar, lifecycle transitions, projections, and shared geometry land
- * as they are implemented.
+ * @canonical/dataviews-core — collection-views core for Canonical apps:
+ * runtime identity tokens, the bounded query grammar with addressed
+ * commands, field interaction, operation and save-race records, and the
+ * collection coordinator owning query/window coherence and the request
+ * lifecycle. React/Svelte bindings, URL transport and adapters are wired
+ * above this layer.
  *
  * @packageDocumentation
  */

--- a/packages/runtime/dataviews/src/index.types.test.ts
+++ b/packages/runtime/dataviews/src/index.types.test.ts
@@ -2,15 +2,87 @@
  * Compile-time contract tests for the package's public type surface.
  *
  * Runtime behavior lives in the sibling test files; this file pins the type
- * exports, including the barrel re-export. Every assertion here has been
- * mutation-tested: change the source type and the assertion fails.
+ * exports through the barrel: removing any name from a folder barrel, or
+ * changing one of the pinned shapes, fails compilation here.
  */
 
 import { describe, expectTypeOf, it } from "vitest";
-import type { Identity } from "./index.js";
+import type {
+  CollectionCoordinator,
+  CollectionCoordinatorConfig,
+  CollectionCoordinatorState,
+  CompletionResult,
+  DispatchResult,
+  FieldFeedback,
+  FieldInteraction,
+  FieldInteractionConfig,
+  FieldInteractionState,
+  FieldValidation,
+  Identity,
+  Operation,
+  OperationConfig,
+  OperationFailure,
+  OperationOutcome,
+  OperationState,
+  Predicate,
+  PredicateOperand,
+  PredicateOperator,
+  QueryCommand,
+  QueryCommandResult,
+  ResultProvenance,
+  ResultState,
+  ResultStatus,
+  ResultWindow,
+  SaveSession,
+  SaveSessionConfig,
+  SaveSessionState,
+  Slice,
+  SortDirection,
+  SortTerm,
+} from "./index.js";
 import * as dataviews from "./index.js";
 
+/** Every type the package root re-exports, as one enumerable tuple. */
+type EveryPublicType = [
+  CollectionCoordinator,
+  CollectionCoordinatorConfig,
+  CollectionCoordinatorState,
+  CompletionResult,
+  DispatchResult,
+  FieldFeedback,
+  FieldInteraction,
+  FieldInteractionConfig,
+  FieldInteractionState,
+  FieldValidation,
+  Identity,
+  Operation,
+  OperationConfig,
+  OperationFailure,
+  OperationOutcome,
+  OperationState,
+  Predicate,
+  PredicateOperand,
+  PredicateOperator,
+  QueryCommand,
+  QueryCommandResult,
+  ResultProvenance,
+  ResultState,
+  ResultStatus,
+  ResultWindow,
+  SaveSession<unknown>,
+  SaveSessionConfig<unknown>,
+  SaveSessionState<unknown>,
+  Slice,
+  SortDirection,
+  SortTerm,
+];
+
 describe("public surface types", () => {
+  it("re-exports the full type surface from the barrel", () => {
+    expectTypeOf<EveryPublicType>().not.toBeAny();
+    expectTypeOf<EveryPublicType["length"]>().toEqualTypeOf<31>();
+  });
+
   it("exports the identity functions with the declared shapes", () => {
     expectTypeOf(dataviews.createIdentity).returns.toEqualTypeOf<Identity>();
     expectTypeOf(dataviews.isIdentity).parameter(0).toEqualTypeOf<unknown>();
@@ -26,5 +98,40 @@ describe("public surface types", () => {
   it("keeps Identity opaque to structural construction", () => {
     expectTypeOf<Record<string, never>>().not.toMatchTypeOf<Identity>();
     expectTypeOf<object>().not.toMatchTypeOf<Identity>();
+  });
+
+  it("re-exports the query grammar types from the barrel", () => {
+    expectTypeOf(dataviews.canonicalSlice).parameter(0).toEqualTypeOf<Slice>();
+    expectTypeOf(dataviews.sliceEquals).parameters.toEqualTypeOf<
+      [Slice, Slice]
+    >();
+  });
+
+  it("re-exports the machine handle types from the barrel", () => {
+    expectTypeOf(
+      dataviews.createFieldInteraction,
+    ).returns.toEqualTypeOf<FieldInteraction>();
+    expectTypeOf(dataviews.createOperation).returns.toEqualTypeOf<Operation>();
+    expectTypeOf(
+      dataviews.createCollectionCoordinator,
+    ).returns.toEqualTypeOf<CollectionCoordinator>();
+    expectTypeOf(
+      dataviews.createSaveSession<{ density: string }>,
+    ).returns.toEqualTypeOf<SaveSession<{ density: string }>>();
+  });
+
+  it("discriminates command and completion unions by status or kind", () => {
+    expectTypeOf<QueryCommand["kind"]>().toEqualTypeOf<
+      | "replacePredicate"
+      | "removePredicate"
+      | "replaceSearch"
+      | "replaceSort"
+      | "setGroup"
+      | "navigateWindow"
+    >();
+    expectTypeOf<CompletionResult["status"]>().toEqualTypeOf<
+      "success" | "failure"
+    >();
+    expectTypeOf<ResultWindow["page"]>().toEqualTypeOf<number>();
   });
 });

--- a/packages/runtime/dataviews/src/lib/collection/createCollectionCoordinator.test.ts
+++ b/packages/runtime/dataviews/src/lib/collection/createCollectionCoordinator.test.ts
@@ -1,0 +1,688 @@
+import { describe, expect, it } from "vitest";
+import type {
+  Predicate,
+  ResultWindow,
+  Slice,
+  SortTerm,
+} from "../query/types.js";
+import createCollectionCoordinator from "./createCollectionCoordinator.js";
+
+const slice = (overrides: Partial<Slice> = {}): Slice => ({
+  filter: [],
+  search: null,
+  sort: [],
+  group: null,
+  ...overrides,
+});
+
+const window = (page = 1, size = 50): ResultWindow => ({ page, size });
+
+const statusPredicate = (...operands: string[]): Slice["filter"][number] => ({
+  field: "status",
+  operator: "eq",
+  operands,
+});
+
+/** Dispatch a query change and return its request id, failing loudly. */
+const dispatchRequest = (
+  coordinator: ReturnType<typeof createCollectionCoordinator>,
+  command: Parameters<
+    ReturnType<typeof createCollectionCoordinator>["dispatch"]
+  >[0],
+): string => {
+  const result = coordinator.dispatch(command);
+  if (result.status !== "accepted" || result.requestId === null) {
+    throw new Error("expected an accepted command with a request id");
+  }
+  return result.requestId;
+};
+
+describe("createCollectionCoordinator", () => {
+  it("seeds idle with the configured slice and window", () => {
+    const coordinator = createCollectionCoordinator({
+      slice: slice({
+        filter: [statusPredicate("failed")],
+      }),
+      window: window(2, 25),
+    });
+    const state = coordinator.state;
+    expect(state.result.status).toBe("idle");
+    expect(state.window).toEqual({ page: 2, size: 25 });
+    expect(state.slice.filter).toHaveLength(1);
+    expect(state.resultsMatchCurrentQuery).toBe(false);
+  });
+
+  it("issues a request on a query change, resets the window and retains rows", () => {
+    const coordinator = createCollectionCoordinator({
+      window: window(4),
+    });
+    const first = dispatchRequest(coordinator, {
+      kind: "replacePredicate",
+      predicate: statusPredicate("failed"),
+    });
+    expect(coordinator.state.window).toEqual({ page: 1, size: 50 });
+    coordinator.complete(first, {
+      status: "success",
+      rows: [{ id: "machine-1" }],
+      count: 1,
+    });
+    expect(coordinator.state.result.status).toBe("ready");
+    expect(coordinator.state.resultsMatchCurrentQuery).toBe(true);
+
+    const second = dispatchRequest(coordinator, {
+      kind: "replacePredicate",
+      predicate: statusPredicate("cancelled"),
+    });
+    expect(second).not.toBe(first);
+    // Different query pending: retained rows and count keep their old
+    // provenance.
+    expect(coordinator.state.result.status).toBe("pending");
+    expect(coordinator.state.result.rows).toEqual([{ id: "machine-1" }]);
+    expect(coordinator.state.result.count).toBe(1);
+    expect(coordinator.state.result.provenance?.requestId).toBe(first);
+    expect(coordinator.state.resultsMatchCurrentQuery).toBe(false);
+  });
+
+  it("marks retained rows stale after a window-only change", () => {
+    const coordinator = createCollectionCoordinator();
+    const request = dispatchRequest(coordinator, {
+      kind: "replacePredicate",
+      predicate: statusPredicate("failed"),
+    });
+    coordinator.complete(request, {
+      status: "success",
+      rows: [{ id: "machine-1" }],
+      count: 200,
+    });
+    expect(coordinator.state.resultsMatchCurrentQuery).toBe(true);
+
+    dispatchRequest(coordinator, { kind: "navigateWindow", page: 2 });
+    const result = coordinator.state.result;
+    expect(result.status).toBe("pending");
+    expect(result.rows).toEqual([{ id: "machine-1" }]);
+    expect(coordinator.state.resultsMatchCurrentQuery).toBe(false);
+    expect(coordinator.state.window).toEqual({ page: 2, size: 50 });
+  });
+
+  it("ignores completions for superseded requests", () => {
+    const coordinator = createCollectionCoordinator();
+    const first = dispatchRequest(coordinator, {
+      kind: "replaceSearch",
+      search: "yak",
+    });
+    const second = dispatchRequest(coordinator, {
+      kind: "replaceSearch",
+      search: "zebu",
+    });
+    // The slower first response arrives after the second request replaced it.
+    expect(
+      coordinator.complete(first, {
+        status: "success",
+        rows: [{ id: "stale" }],
+        count: 99,
+      }),
+    ).toBe(false);
+    expect(coordinator.state.result.rows).toBeNull();
+    expect(coordinator.state.result.lastError).toBeNull();
+
+    expect(
+      coordinator.complete(second, {
+        status: "success",
+        rows: [{ id: "fresh" }],
+        count: 1,
+      }),
+    ).toBe(true);
+    expect(coordinator.state.result.rows).toEqual([{ id: "fresh" }]);
+  });
+
+  it("ignores stale failure completions", () => {
+    const coordinator = createCollectionCoordinator();
+    const first = dispatchRequest(coordinator, {
+      kind: "replaceSearch",
+      search: "yak",
+    });
+    const second = dispatchRequest(coordinator, {
+      kind: "replaceSearch",
+      search: "zebu",
+    });
+    expect(
+      coordinator.complete(first, { status: "failure", reason: "gateway" }),
+    ).toBe(false);
+    expect(coordinator.state.result.lastError).toBeNull();
+    expect(
+      coordinator.complete(second, {
+        status: "success",
+        rows: [{ id: "fresh" }],
+        count: 1,
+      }),
+    ).toBe(true);
+  });
+
+  it("publishes rows, provenance and count together", () => {
+    const coordinator = createCollectionCoordinator();
+    const request = dispatchRequest(coordinator, {
+      kind: "replaceSearch",
+      search: "yak",
+    });
+    const rows = [{ id: "machine-1" }, { id: "machine-2" }];
+    coordinator.complete(request, {
+      status: "success",
+      rows,
+      count: 2,
+    });
+    const result = coordinator.state.result;
+    expect(result.status).toBe("ready");
+    expect(result.rows).toHaveLength(2);
+    expect(result.count).toBe(2);
+    expect(result.provenance?.requestId).toBe(request);
+    expect(coordinator.state.resultsMatchCurrentQuery).toBe(true);
+    // The published rows are a defensive copy of the caller's array.
+    rows.push({ id: "machine-3" });
+    expect(coordinator.state.result.rows).toHaveLength(2);
+  });
+
+  it("publishes a request completion at most once", () => {
+    const coordinator = createCollectionCoordinator();
+    const request = dispatchRequest(coordinator, {
+      kind: "replaceSearch",
+      search: "yak",
+    });
+    expect(
+      coordinator.complete(request, {
+        status: "success",
+        rows: [{ id: "machine-1" }],
+        count: 1,
+      }),
+    ).toBe(true);
+    // A duplicated delivery of the same completion must not overwrite.
+    expect(
+      coordinator.complete(request, {
+        status: "failure",
+        reason: "duplicate delivery",
+      }),
+    ).toBe(false);
+    expect(coordinator.state.result.rows).toEqual([{ id: "machine-1" }]);
+    expect(coordinator.state.result.lastError).toBeNull();
+  });
+
+  it("retains rows with the error recorded when a refresh fails", () => {
+    const coordinator = createCollectionCoordinator();
+    const request = dispatchRequest(coordinator, {
+      kind: "replaceSearch",
+      search: "yak",
+    });
+    coordinator.complete(request, {
+      status: "success",
+      rows: [{ id: "machine-1" }],
+      count: 1,
+    });
+
+    const refreshId = coordinator.refresh();
+    if (refreshId === null) {
+      throw new Error("expected a refresh request");
+    }
+    expect(coordinator.state.result.status).toBe("refreshing");
+    expect(coordinator.state.result.rows).toEqual([{ id: "machine-1" }]);
+    expect(coordinator.state.resultsMatchCurrentQuery).toBe(true);
+
+    coordinator.complete(refreshId, {
+      status: "failure",
+      reason: "gateway down",
+    });
+    const result = coordinator.state.result;
+    expect(result.status).toBe("ready");
+    expect(result.rows).toEqual([{ id: "machine-1" }]);
+    expect(result.lastError).toBe("gateway down");
+    expect(result.provenance?.requestId).toBe(request);
+    // The retained rows still match the unchanged query.
+    expect(coordinator.state.resultsMatchCurrentQuery).toBe(true);
+  });
+
+  it("publishes refreshed rows on a successful refresh", () => {
+    const coordinator = createCollectionCoordinator();
+    const request = dispatchRequest(coordinator, {
+      kind: "replaceSearch",
+      search: "yak",
+    });
+    coordinator.complete(request, {
+      status: "success",
+      rows: [{ id: "machine-1" }],
+      count: 1,
+    });
+    const refreshId = coordinator.refresh();
+    if (refreshId === null) {
+      throw new Error("expected a refresh request");
+    }
+    coordinator.complete(refreshId, {
+      status: "success",
+      rows: [{ id: "machine-1" }, { id: "machine-2" }],
+      count: 2,
+    });
+    const result = coordinator.state.result;
+    expect(result.status).toBe("ready");
+    expect(result.rows).toHaveLength(2);
+    expect(result.provenance?.requestId).toBe(refreshId);
+    expect(coordinator.state.resultsMatchCurrentQuery).toBe(true);
+  });
+
+  it("records error without rows when an initial request fails", () => {
+    const coordinator = createCollectionCoordinator();
+    const request = dispatchRequest(coordinator, {
+      kind: "replaceSearch",
+      search: "yak",
+    });
+    coordinator.complete(request, { status: "failure", reason: "offline" });
+    expect(coordinator.state.result.status).toBe("error");
+    expect(coordinator.state.result.rows).toBeNull();
+    expect(coordinator.state.result.lastError).toBe("offline");
+  });
+
+  it("keeps retained rows unmatched when a different query fails", () => {
+    const coordinator = createCollectionCoordinator();
+    const request = dispatchRequest(coordinator, {
+      kind: "replaceSearch",
+      search: "yak",
+    });
+    coordinator.complete(request, {
+      status: "success",
+      rows: [{ id: "machine-1" }],
+      count: 1,
+    });
+    const failedRequest = dispatchRequest(coordinator, {
+      kind: "replaceSearch",
+      search: "zebu",
+    });
+    coordinator.complete(failedRequest, {
+      status: "failure",
+      reason: "offline",
+    });
+    const result = coordinator.state.result;
+    // The retained rows belong to the old query; the failure is recorded and
+    // the rows are never described as results of the current query.
+    expect(result.status).toBe("ready");
+    expect(result.rows).toEqual([{ id: "machine-1" }]);
+    expect(result.lastError).toBe("offline");
+    expect(coordinator.state.resultsMatchCurrentQuery).toBe(false);
+  });
+
+  it("issues no request for a semantically unchanged edit", () => {
+    const coordinator = createCollectionCoordinator({
+      slice: slice({ search: "yak" }),
+      window: window(3, 25),
+    });
+    const result = coordinator.dispatch({
+      kind: "replaceSearch",
+      search: "yak",
+    });
+    if (result.status !== "accepted") {
+      throw new Error("expected acceptance");
+    }
+    expect(result.requestId).toBeNull();
+    expect(coordinator.state.result.status).toBe("idle");
+    expect(coordinator.state.window).toEqual({ page: 3, size: 25 });
+  });
+
+  it("issues no request when navigating to the current window", () => {
+    const coordinator = createCollectionCoordinator({
+      window: window(2, 25),
+    });
+    const result = coordinator.dispatch({
+      kind: "navigateWindow",
+      page: 2,
+      size: 25,
+    });
+    if (result.status !== "accepted") {
+      throw new Error("expected acceptance");
+    }
+    expect(result.requestId).toBeNull();
+  });
+
+  it("adopts external query and window together, superseding pending requests", () => {
+    const coordinator = createCollectionCoordinator();
+    const stale = dispatchRequest(coordinator, {
+      kind: "replaceSearch",
+      search: "yak",
+    });
+    const adopted = coordinator.adopt(
+      slice({ search: "zebu", sort: [{ field: "name", direction: "asc" }] }),
+      window(2, 25),
+    );
+    if (adopted === null) {
+      throw new Error("expected an adopted request");
+    }
+    expect(coordinator.state.slice.search).toBe("zebu");
+    expect(coordinator.state.window).toEqual({ page: 2, size: 25 });
+    expect(coordinator.state.result.status).toBe("pending");
+    // The superseded request's completion never publishes.
+    expect(
+      coordinator.complete(stale, {
+        status: "success",
+        rows: [{ id: "stale" }],
+        count: 1,
+      }),
+    ).toBe(false);
+    expect(
+      coordinator.complete(adopted, {
+        status: "success",
+        rows: [{ id: "adopted" }],
+        count: 1,
+      }),
+    ).toBe(true);
+  });
+
+  it("adopts an identical state without issuing a request", () => {
+    const seed = slice({ search: "yak" });
+    const coordinator = createCollectionCoordinator({
+      slice: seed,
+      window: window(2, 25),
+    });
+    expect(coordinator.adopt(seed, window(2, 25))).toBeNull();
+    expect(coordinator.state.result.status).toBe("idle");
+  });
+
+  it("adopts a canonically equal spelling without issuing a request", () => {
+    const coordinator = createCollectionCoordinator({
+      slice: slice({ filter: [statusPredicate("failed", "cancelled")] }),
+    });
+    const respeled = slice({
+      filter: [statusPredicate("cancelled", "failed")],
+    });
+    expect(coordinator.adopt(respeled, window())).toBeNull();
+    expect(coordinator.state.result.status).toBe("idle");
+  });
+
+  it("distinguishes non-finite from null operands in request identity", () => {
+    const coordinator = createCollectionCoordinator();
+    const withNaN = slice({
+      filter: [{ field: "cpu", operator: "gte", operands: [Number.NaN] }],
+    });
+    const withNull = slice({
+      filter: [{ field: "cpu", operator: "gte", operands: [null] }],
+    });
+    const nanRequest = coordinator.adopt(withNaN, window());
+    expect(nanRequest).not.toBeNull();
+    expect(coordinator.adopt(withNull, window())).not.toBeNull();
+  });
+
+  it("distinguishes NaN from Infinity and from look-alike strings", () => {
+    const withNaN = slice({
+      filter: [{ field: "cpu", operator: "gte", operands: [Number.NaN] }],
+    });
+    const withInfinity = slice({
+      filter: [
+        { field: "cpu", operator: "gte", operands: [Number.POSITIVE_INFINITY] },
+      ],
+    });
+    const withString = slice({
+      filter: [{ field: "cpu", operator: "gte", operands: ["NaN"] }],
+    });
+    const first = createCollectionCoordinator();
+    expect(first.adopt(withNaN, window())).not.toBeNull();
+    expect(first.adopt(withInfinity, window())).not.toBeNull();
+
+    const second = createCollectionCoordinator();
+    expect(second.adopt(withNaN, window())).not.toBeNull();
+    expect(second.adopt(withString, window())).not.toBeNull();
+  });
+
+  it("treats a key-order respelling as a canonical no-op", () => {
+    const coordinator = createCollectionCoordinator({
+      slice: slice({
+        filter: [
+          {
+            field: "status",
+            operator: "eq",
+            operands: ["failed", "cancelled"],
+          },
+        ],
+        sort: [{ field: "name", direction: "asc" }],
+      }),
+    });
+    const respeled = slice({
+      filter: [
+        {
+          operands: ["cancelled", "failed"],
+          operator: "eq",
+          field: "status",
+        },
+      ],
+      sort: [{ direction: "asc", field: "name" }],
+    });
+    expect(coordinator.adopt(respeled, window())).toBeNull();
+    expect(coordinator.state.result.status).toBe("idle");
+  });
+
+  it("keeps adopted state immune to nested caller mutations", () => {
+    const coordinator = createCollectionCoordinator();
+    const predicate = {
+      field: "status",
+      operator: "eq" as const,
+      operands: ["failed" as const],
+    };
+    const adopted = slice({ filter: [predicate] });
+    const callerWindow = window(2, 25);
+    const request = coordinator.adopt(adopted, callerWindow);
+    if (request === null) {
+      throw new Error("expected an adopted request");
+    }
+    coordinator.complete(request, {
+      status: "success",
+      rows: [{ id: "machine-1" }],
+      count: 1,
+    });
+    (predicate.operands as string[]).push("cancelled");
+    (callerWindow as { page: number }).page = 9;
+    expect(coordinator.state.slice.filter[0]?.operands).toEqual(["failed"]);
+    expect(coordinator.state.window).toEqual({ page: 2, size: 25 });
+  });
+
+  it("keeps the configured window immune to caller mutations", () => {
+    const callerWindow = window(3, 25);
+    const coordinator = createCollectionCoordinator({
+      window: callerWindow,
+    });
+    (callerWindow as { page: number }).page = 7;
+    expect(coordinator.state.window).toEqual({ page: 3, size: 25 });
+  });
+
+  it("freezes adopted nested state against mutation", () => {
+    const coordinator = createCollectionCoordinator();
+    const request = coordinator.adopt(
+      slice({ filter: [statusPredicate("failed")] }),
+      window(),
+    );
+    if (request === null) {
+      throw new Error("expected an adopted request");
+    }
+    const filter = coordinator.state.slice.filter as Predicate[];
+    expect(() => filter.push(statusPredicate("cancelled"))).toThrow();
+  });
+
+  it("clears the last error when a new request begins", () => {
+    const coordinator = createCollectionCoordinator();
+    const first = dispatchRequest(coordinator, {
+      kind: "replaceSearch",
+      search: "yak",
+    });
+    coordinator.complete(first, { status: "failure", reason: "offline" });
+    expect(coordinator.state.result.lastError).toBe("offline");
+    dispatchRequest(coordinator, { kind: "replaceSearch", search: "zebu" });
+    expect(coordinator.state.result.lastError).toBeNull();
+    expect(coordinator.state.result.status).toBe("pending");
+  });
+
+  it("issues distinct request ids across coordinator instances", () => {
+    const a = createCollectionCoordinator();
+    const b = createCollectionCoordinator();
+    const requestA = dispatchRequest(a, { kind: "navigateWindow", page: 2 });
+    const requestB = dispatchRequest(b, { kind: "navigateWindow", page: 2 });
+    expect(requestA).not.toBe(requestB);
+  });
+
+  it("ignores completions when idle without a request", () => {
+    const coordinator = createCollectionCoordinator();
+    expect(
+      coordinator.complete("does-not-exist", {
+        status: "success",
+        rows: [{ id: "bogus" }],
+        count: 1,
+      }),
+    ).toBe(false);
+    expect(
+      coordinator.complete(null as unknown as string, {
+        status: "success",
+        rows: [{ id: "bogus" }],
+        count: 1,
+      }),
+    ).toBe(false);
+    expect(coordinator.state.result.rows).toBeNull();
+  });
+
+  it("keeps the configured seed immune to caller mutations", () => {
+    const seed = slice({
+      filter: [statusPredicate("failed")],
+      sort: [{ field: "name", direction: "asc" }],
+    });
+    const coordinator = createCollectionCoordinator({ slice: seed });
+    const mutableFilter = seed.filter as Predicate[];
+    const mutableSort = seed.sort as SortTerm[];
+    mutableFilter.push(statusPredicate("cancelled"));
+    mutableSort.push({ field: "zone", direction: "desc" });
+    coordinator.dispatch({ kind: "navigateWindow", page: 3 });
+    coordinator.rotateScope();
+    expect(coordinator.state.slice.filter).toEqual([statusPredicate("failed")]);
+    expect(coordinator.state.slice.sort).toEqual([
+      { field: "name", direction: "asc" },
+    ]);
+  });
+
+  it("rejects commands after dispose and ignores completions", () => {
+    const coordinator = createCollectionCoordinator();
+    const request = dispatchRequest(coordinator, {
+      kind: "navigateWindow",
+      page: 2,
+    });
+    coordinator.dispose();
+    expect(
+      coordinator.complete(request, {
+        status: "success",
+        rows: [],
+        count: 0,
+      }),
+    ).toBe(false);
+    const after = coordinator.dispatch({ kind: "navigateWindow", page: 3 });
+    expect(after.status).toBe("rejected");
+    expect(coordinator.state.disposed).toBe(true);
+  });
+
+  it("returns no refresh or adopt after dispose", () => {
+    const coordinator = createCollectionCoordinator();
+    coordinator.dispose();
+    expect(coordinator.refresh()).toBeNull();
+    expect(coordinator.adopt(slice(), window())).toBeNull();
+    expect(coordinator.state.result.status).toBe("idle");
+  });
+
+  it("leaves a disposed coordinator's snapshot untouched on rotateScope", () => {
+    const coordinator = createCollectionCoordinator();
+    coordinator.dispose();
+    const before = coordinator.state;
+    coordinator.rotateScope();
+    expect(coordinator.state).toBe(before);
+    expect(coordinator.state.disposed).toBe(true);
+  });
+
+  it("passes command rejections through without a request", () => {
+    const coordinator = createCollectionCoordinator();
+    const result = coordinator.dispatch({
+      kind: "navigateWindow",
+      page: 0,
+    });
+    if (result.status !== "rejected") {
+      throw new Error("expected rejection");
+    }
+    expect(result.requestId).toBeNull();
+    expect(result.reason).toBe("page must be a positive integer");
+    expect(coordinator.state.result.status).toBe("idle");
+  });
+
+  it("never publishes old-scope completions into a rotated scope", () => {
+    const seed = slice({ search: "yak" });
+    const coordinator = createCollectionCoordinator({ slice: seed });
+    const scopeBefore = coordinator.state.scope;
+    const staleRequest = dispatchRequest(coordinator, {
+      kind: "replaceSearch",
+      search: "zebu",
+    });
+    coordinator.rotateScope();
+    expect(coordinator.state.scope).not.toBe(scopeBefore);
+    // A slow response from the previous scope arrives after rotation.
+    expect(
+      coordinator.complete(staleRequest, {
+        status: "success",
+        rows: [{ id: "old-scope" }],
+        count: 1,
+      }),
+    ).toBe(false);
+    expect(coordinator.state.result.rows).toBeNull();
+    expect(coordinator.state.slice.search).toBe("yak");
+
+    const fresh = dispatchRequest(coordinator, {
+      kind: "navigateWindow",
+      page: 2,
+    });
+    expect(
+      coordinator.complete(fresh, {
+        status: "success",
+        rows: [{ id: "new-scope" }],
+        count: 1,
+      }),
+    ).toBe(true);
+    expect(coordinator.state.result.rows).toEqual([{ id: "new-scope" }]);
+  });
+
+  it("resets to the configured seed on scope rotation", () => {
+    const seed = slice({ search: "yak" });
+    const coordinator = createCollectionCoordinator({
+      slice: seed,
+      window: window(1, 25),
+    });
+    coordinator.dispatch({ kind: "replaceSearch", search: "zebu" });
+    coordinator.dispatch({ kind: "navigateWindow", page: 4 });
+    coordinator.rotateScope();
+    const state = coordinator.state;
+    expect(state.slice.search).toBe("yak");
+    expect(state.window).toEqual({ page: 1, size: 25 });
+    expect(state.result.status).toBe("idle");
+    expect(state.resultsMatchCurrentQuery).toBe(false);
+  });
+
+  it("serves a referentially stable snapshot between mutations", () => {
+    const coordinator = createCollectionCoordinator();
+    const first = coordinator.state;
+    expect(coordinator.state).toBe(first);
+    // No-change and rejected dispatches must not churn the snapshot either.
+    coordinator.dispatch({ kind: "navigateWindow", page: 1 });
+    expect(coordinator.state).toBe(first);
+    coordinator.dispatch({ kind: "navigateWindow", page: 0 });
+    expect(coordinator.state).toBe(first);
+    coordinator.dispatch({ kind: "navigateWindow", page: 2 });
+    expect(coordinator.state).not.toBe(first);
+  });
+
+  it("refreshes from an idle state without prior rows", () => {
+    const coordinator = createCollectionCoordinator();
+    const refreshId = coordinator.refresh();
+    if (refreshId === null) {
+      throw new Error("expected a refresh request");
+    }
+    expect(coordinator.state.result.status).toBe("refreshing");
+    expect(coordinator.state.result.rows).toBeNull();
+    coordinator.complete(refreshId, {
+      status: "success",
+      rows: [{ id: "machine-1" }],
+      count: 1,
+    });
+    expect(coordinator.state.result.status).toBe("ready");
+  });
+});

--- a/packages/runtime/dataviews/src/lib/collection/createCollectionCoordinator.ts
+++ b/packages/runtime/dataviews/src/lib/collection/createCollectionCoordinator.ts
@@ -1,0 +1,324 @@
+import createIdentity, { type Identity } from "../createIdentity.js";
+import applyQueryCommand from "../query/applyQueryCommand.js";
+import canonicalSlice from "../query/canonicalSlice.js";
+import type {
+  QueryCommand,
+  QueryCommandResult,
+  ResultWindow,
+  Slice,
+} from "../query/types.js";
+
+/** Display status of the result projection. */
+export type ResultStatus =
+  | "idle"
+  | "pending"
+  | "refreshing"
+  | "ready"
+  | "error";
+
+/**
+ * Which request produced the currently displayed rows. A pending or failed
+ * request keeps the previous provenance: retained rows are never described
+ * as results of the current query.
+ */
+export type ResultProvenance = {
+  readonly requestId: string;
+};
+
+/**
+ * Immutable result state. `lastError` records a failed request truthfully;
+ * retained rows stay displayed when one exists.
+ */
+export type ResultState = {
+  readonly status: ResultStatus;
+  readonly rows: readonly unknown[] | null;
+  readonly count: number | null;
+  readonly provenance: ResultProvenance | null;
+  readonly lastError: string | null;
+};
+
+/** Completion payload of one request. */
+export type CompletionResult =
+  | {
+      readonly status: "success";
+      readonly rows: readonly unknown[];
+      readonly count: number | null;
+    }
+  | { readonly status: "failure"; readonly reason: string };
+
+/** Coordinator configuration; `slice` and `window` seed every fresh scope. */
+export type CollectionCoordinatorConfig = {
+  readonly slice?: Slice;
+  readonly window?: ResultWindow;
+};
+
+/** Result of dispatching one command through the coordinator. */
+export type DispatchResult = QueryCommandResult & {
+  /** Request identity to execute, or null when no new request is needed. */
+  readonly requestId: string | null;
+};
+
+/** Immutable coordinator snapshot; referentially stable between mutations. */
+export type CollectionCoordinatorState = {
+  readonly scope: Identity;
+  readonly slice: Slice;
+  readonly window: ResultWindow;
+  readonly result: ResultState;
+  /** True when displayed rows were produced by the current query and window. */
+  readonly resultsMatchCurrentQuery: boolean;
+  readonly disposed: boolean;
+};
+
+/** Handle owning query/window coherence and the request lifecycle. */
+export type CollectionCoordinator = {
+  readonly state: CollectionCoordinatorState;
+  /**
+   * Apply one addressed command coherently. An accepted change that moves
+   * the query or window issues a new request identity and retains previous
+   * rows with their old provenance until a matching completion arrives.
+   */
+  readonly dispatch: (command: QueryCommand) => DispatchResult;
+  /**
+   * Refresh the current query: retained rows stay displayed with a
+   * refreshing status until a matching completion arrives.
+   */
+  readonly refresh: () => string | null;
+  /**
+   * Adopt an externally authoritative slice and window together, as on
+   * back/forward navigation or a restored view. Supersedes any pending
+   * request, discards stale input sessions above this layer, and returns a
+   * request identity when the adopted state differs from the current one.
+   */
+  readonly adopt: (slice: Slice, window: ResultWindow) => string | null;
+  /**
+   * Publish a completion for the most recently issued request, at most once.
+   * Completions for superseded requests, rotated scopes or a disposed
+   * coordinator are ignored; a success publishes rows, provenance and count
+   * together; a failure retains rows with the error recorded.
+   */
+  readonly complete: (requestId: string, result: CompletionResult) => boolean;
+  /**
+   * Rotate to a fresh scope: query, window and result reset to the
+   * configured seed and pending requests die. Completions from the old
+   * scope never publish into the new one.
+   */
+  readonly rotateScope: () => void;
+  /** Detach permanently; every later completion is ignored. */
+  readonly dispose: () => void;
+};
+
+const emptySlice: Slice = Object.freeze({
+  filter: [],
+  search: null,
+  sort: [],
+  group: null,
+});
+
+const defaultWindow: ResultWindow = { page: 1, size: 50 };
+
+/** Monotonic instance key: exact cross-instance distinctness, no
+ * environment requirements. */
+let coordinatorInstances = 0;
+
+const idleResult: ResultState = Object.freeze({
+  status: "idle",
+  rows: null,
+  count: null,
+  provenance: null,
+  lastError: null,
+});
+
+const fingerprintOf = (slice: Slice, window: ResultWindow): string =>
+  JSON.stringify([canonicalSlice(slice), window], (_key, value) =>
+    typeof value === "number" && !Number.isFinite(value)
+      ? // An object marker cannot collide with any genuine operand: the
+        // operand domain has no objects.
+        { nonfinite: String(value) }
+      : value,
+  );
+
+/**
+ * Copy a caller-supplied slice so later mutations of the original cannot
+ * corrupt adopted or seeded state, including nested predicate and
+ * sort-term objects.
+ */
+const copySlice = (slice: Slice): Slice =>
+  Object.freeze({
+    filter: Object.freeze(
+      slice.filter.map((predicate) =>
+        Object.freeze({
+          field: predicate.field,
+          operator: predicate.operator,
+          operands: Object.freeze([...predicate.operands]),
+        }),
+      ),
+    ),
+    search: slice.search,
+    sort: Object.freeze(
+      slice.sort.map((term) =>
+        Object.freeze({ field: term.field, direction: term.direction }),
+      ),
+    ),
+    group: slice.group,
+  });
+
+const copyWindow = (window: ResultWindow): ResultWindow =>
+  Object.freeze({ page: window.page, size: window.size });
+
+/**
+ * Create the collection coordinator: one owner of query/window coherence
+ * and the request lifecycle. Requests carry scope-bound identities; only
+ * the completion of the most recently issued request publishes, once. The
+ * authority for the applied query (for example the browser URL) and the
+ * execution of requests are wired above this layer.
+ */
+export default function createCollectionCoordinator(
+  config: CollectionCoordinatorConfig = {},
+): CollectionCoordinator {
+  const seedSlice =
+    config.slice === undefined ? emptySlice : copySlice(config.slice);
+  const seedWindow = Object.freeze({
+    page: config.window?.page ?? defaultWindow.page,
+    size: config.window?.size ?? defaultWindow.size,
+  });
+
+  let scope = createIdentity();
+  // Instance-unique request ids: a completion routed to the wrong
+  // coordinator must mismatch loudly, never publish silently.
+  const instanceKey = `i${++coordinatorInstances}`;
+  let counter = 0;
+  let lastRequestId: string | null = null;
+  /** Fingerprint of the query and window that produced the displayed rows. */
+  let publishedFingerprint: string | null = null;
+  let slice: Slice = seedSlice;
+  let window: ResultWindow = seedWindow;
+  let currentFingerprint = fingerprintOf(slice, window);
+  let result: ResultState = idleResult;
+  let disposed = false;
+
+  function buildSnapshot(): CollectionCoordinatorState {
+    return Object.freeze({
+      scope,
+      slice,
+      window,
+      result,
+      resultsMatchCurrentQuery:
+        result.provenance !== null &&
+        publishedFingerprint === currentFingerprint,
+      disposed,
+    });
+  }
+
+  let snapshot = buildSnapshot();
+
+  const publish = (next: ResultState): void => {
+    result = next;
+    snapshot = buildSnapshot();
+  };
+
+  const beginRequest = (refreshing: boolean): string => {
+    counter += 1;
+    lastRequestId = `${instanceKey}:r${counter}`;
+    publish({
+      status: refreshing ? "refreshing" : "pending",
+      rows: result.rows,
+      count: result.count,
+      provenance: result.provenance,
+      lastError: null,
+    });
+    return lastRequestId;
+  };
+
+  return {
+    get state(): CollectionCoordinatorState {
+      return snapshot;
+    },
+    dispatch(command: QueryCommand): DispatchResult {
+      if (disposed) {
+        return {
+          status: "rejected",
+          reason: "coordinator is disposed",
+          slice,
+          window,
+          requestId: null,
+        };
+      }
+      const applied = applyQueryCommand(slice, window, command);
+      if (applied.status === "rejected") {
+        return { ...applied, requestId: null };
+      }
+      if (!applied.queryChanged && !applied.windowChanged) {
+        return { ...applied, requestId: null };
+      }
+      slice = applied.slice;
+      window = applied.window;
+      currentFingerprint = fingerprintOf(slice, window);
+      const requestId = beginRequest(false);
+      return { ...applied, requestId };
+    },
+    refresh(): string | null {
+      if (disposed) {
+        return null;
+      }
+      return beginRequest(true);
+    },
+    adopt(nextSlice: Slice, nextWindow: ResultWindow): string | null {
+      if (disposed) {
+        return null;
+      }
+      const copiedSlice = copySlice(nextSlice);
+      const copiedWindow = copyWindow(nextWindow);
+      const nextFingerprint = fingerprintOf(copiedSlice, copiedWindow);
+      if (nextFingerprint === currentFingerprint) {
+        return null;
+      }
+      slice = copiedSlice;
+      window = copiedWindow;
+      currentFingerprint = nextFingerprint;
+      return beginRequest(false);
+    },
+    complete(requestId: string, completion: CompletionResult): boolean {
+      if (disposed || lastRequestId === null || requestId !== lastRequestId) {
+        // Obsolete request, rotated scope, repeated delivery, idle
+        // coordinator, or no request at all: never publish stale results.
+        return false;
+      }
+      lastRequestId = null;
+      if (completion.status === "success") {
+        publishedFingerprint = currentFingerprint;
+        publish({
+          status: "ready",
+          rows: [...completion.rows],
+          count: completion.count,
+          provenance: { requestId },
+          lastError: null,
+        });
+        return true;
+      }
+      publish({
+        status: result.rows === null ? "error" : "ready",
+        rows: result.rows,
+        count: result.count,
+        provenance: result.provenance,
+        lastError: completion.reason,
+      });
+      return true;
+    },
+    rotateScope(): void {
+      if (disposed) {
+        return;
+      }
+      scope = createIdentity();
+      lastRequestId = null;
+      slice = seedSlice;
+      window = seedWindow;
+      currentFingerprint = fingerprintOf(slice, window);
+      publishedFingerprint = null;
+      publish(idleResult);
+    },
+    dispose(): void {
+      disposed = true;
+      snapshot = buildSnapshot();
+    },
+  };
+}

--- a/packages/runtime/dataviews/src/lib/collection/createSaveSession.test.ts
+++ b/packages/runtime/dataviews/src/lib/collection/createSaveSession.test.ts
@@ -1,0 +1,222 @@
+import { describe, expect, it } from "vitest";
+import createSaveSession from "./createSaveSession.js";
+
+interface Preferences {
+  readonly density: "comfortable" | "compact";
+}
+
+const equals = (a: Preferences, b: Preferences): boolean =>
+  a.density === b.density;
+
+const session = (initial: Preferences = { density: "comfortable" }) =>
+  createSaveSession<Preferences>({ initial, equals });
+
+const beginSave = (save: ReturnType<typeof session>): string => {
+  const attempt = save.beginSave();
+  if (attempt === null) {
+    throw new Error("expected a save attempt");
+  }
+  return attempt;
+};
+
+describe("createSaveSession", () => {
+  it("starts clean at the initial baseline", () => {
+    expect(session().state).toMatchObject({
+      status: "idle",
+      dirty: false,
+      revision: 0,
+      failureReason: null,
+      submitted: null,
+    });
+  });
+
+  it("marks edits dirty and bumps the revision", () => {
+    const save = session();
+    save.edit({ density: "compact" });
+    expect(save.state.dirty).toBe(true);
+    expect(save.state.revision).toBe(1);
+  });
+
+  it("updates only the submitted baseline on completion", () => {
+    const save = session();
+    save.edit({ density: "compact" });
+    const attempt = beginSave(save);
+    // The user keeps editing while the save is in flight.
+    save.edit({ density: "comfortable" });
+    save.saveCompleted(attempt);
+    const state = save.state;
+    expect(state.baseline).toEqual({ density: "compact" });
+    expect(state.current).toEqual({ density: "comfortable" });
+    // Edits made while saving remain dirty.
+    expect(state.dirty).toBe(true);
+    expect(state.status).toBe("idle");
+  });
+
+  it("reports clean when the saved snapshot is still current", () => {
+    const save = session();
+    save.edit({ density: "compact" });
+    const attempt = beginSave(save);
+    save.saveCompleted(attempt);
+    expect(save.state.dirty).toBe(false);
+    expect(save.state.baseline).toEqual({ density: "compact" });
+  });
+
+  it("retains the baseline and records the reason on failure", () => {
+    const save = session();
+    save.edit({ density: "compact" });
+    const attempt = beginSave(save);
+    save.saveFailed(attempt, "quota exceeded");
+    const state = save.state;
+    expect(state.baseline).toEqual({ density: "comfortable" });
+    expect(state.current).toEqual({ density: "compact" });
+    expect(state.dirty).toBe(true);
+    expect(state.status).toBe("failed");
+    expect(state.failureReason).toBe("quota exceeded");
+  });
+
+  it("allows a retry after failure", () => {
+    const save = session();
+    save.edit({ density: "compact" });
+    const first = beginSave(save);
+    save.saveFailed(first, "offline");
+    const second = beginSave(save);
+    save.saveCompleted(second);
+    expect(save.state.status).toBe("idle");
+    expect(save.state.dirty).toBe(false);
+  });
+
+  it("ignores a late completion of a superseded attempt", () => {
+    const save = session();
+    save.edit({ density: "compact" });
+    const first = beginSave(save);
+    save.saveFailed(first, "offline");
+    save.edit({ density: "compact" });
+    const second = beginSave(save);
+    // The first attempt's durable success resolves after the retry started.
+    save.saveCompleted(first);
+    const state = save.state;
+    expect(state.status).toBe("saving");
+    expect(state.submitted).toEqual({ density: "compact" });
+    save.saveCompleted(second);
+    expect(save.state.status).toBe("idle");
+    expect(save.state.dirty).toBe(false);
+  });
+
+  it("ignores a late failure of a superseded attempt", () => {
+    const save = session();
+    save.edit({ density: "compact" });
+    const first = beginSave(save);
+    save.saveFailed(first, "offline");
+    save.edit({ density: "compact" });
+    const second = beginSave(save);
+    // The first attempt's failure resolves after the retry started.
+    save.saveFailed(first, "stale failure");
+    const state = save.state;
+    expect(state.status).toBe("saving");
+    expect(state.submitted).toEqual({ density: "compact" });
+    expect(state.failureReason).toBeNull();
+    save.saveCompleted(second);
+    expect(save.state.status).toBe("idle");
+  });
+
+  it("refuses a second save while one is in flight", () => {
+    const save = session();
+    save.edit({ density: "compact" });
+    expect(save.beginSave()).not.toBeNull();
+    expect(save.beginSave()).toBeNull();
+    expect(save.state.submitted).toEqual({ density: "compact" });
+  });
+
+  it("ignores completions and failures without a current attempt", () => {
+    const save = session();
+    save.saveCompleted("s9");
+    save.saveFailed("s9", "unexpected");
+    expect(save.state.status).toBe("idle");
+    expect(save.state.failureReason).toBeNull();
+  });
+
+  it("applies a delayed external read to the still-current target", () => {
+    const save = session();
+    const seenRevision = save.state.revision;
+    save.edit({ density: "compact" });
+    // The read resolves after it was issued but the value moved on.
+    expect(save.applyExternalRead({ density: "compact" }, seenRevision)).toBe(
+      false,
+    );
+    expect(save.state.current).toEqual({ density: "compact" });
+    expect(save.state.baseline).toEqual({ density: "comfortable" });
+  });
+
+  it("adopts an external read that is still current", () => {
+    const save = session();
+    const seenRevision = save.state.revision;
+    expect(save.applyExternalRead({ density: "compact" }, seenRevision)).toBe(
+      true,
+    );
+    expect(save.state.baseline).toEqual({ density: "compact" });
+    expect(save.state.current).toEqual({ density: "compact" });
+    expect(save.state.dirty).toBe(false);
+  });
+
+  it("clears the failed status when an external read applies", () => {
+    const save = session();
+    save.edit({ density: "compact" });
+    const attempt = beginSave(save);
+    save.saveFailed(attempt, "offline");
+    expect(save.state.status).toBe("failed");
+    const seenRevision = save.state.revision;
+    expect(save.applyExternalRead({ density: "compact" }, seenRevision)).toBe(
+      true,
+    );
+    const state = save.state;
+    expect(state.status).toBe("idle");
+    expect(state.failureReason).toBeNull();
+    expect(state.dirty).toBe(false);
+  });
+
+  it("discards an external read while a save is in flight", () => {
+    const save = session();
+    save.edit({ density: "compact" });
+    const seenRevision = save.state.revision;
+    beginSave(save);
+    expect(
+      save.applyExternalRead({ density: "comfortable" }, seenRevision),
+    ).toBe(false);
+    expect(save.state.current).toEqual({ density: "compact" });
+  });
+
+  it("discards a read that raced a save submission", () => {
+    const save = session();
+    const seenRevision = save.state.revision;
+    save.edit({ density: "compact" });
+    const attempt = beginSave(save);
+    save.saveCompleted(attempt);
+    // The read was issued against the pre-save store value; the submission
+    // moved the revision, so it must not revert the saved value locally.
+    expect(
+      save.applyExternalRead({ density: "comfortable" }, seenRevision),
+    ).toBe(false);
+    expect(save.state.current).toEqual({ density: "compact" });
+    expect(save.state.dirty).toBe(false);
+  });
+
+  it("resets the failed status on the next edit", () => {
+    const save = session();
+    save.edit({ density: "compact" });
+    const attempt = beginSave(save);
+    save.saveFailed(attempt, "offline");
+    expect(save.state.status).toBe("failed");
+    save.edit({ density: "compact" });
+    expect(save.state.status).toBe("idle");
+    expect(save.state.failureReason).toBeNull();
+    expect(save.state.dirty).toBe(true);
+  });
+
+  it("serves a referentially stable snapshot between mutations", () => {
+    const save = session();
+    const first = save.state;
+    expect(save.state).toBe(first);
+    save.edit({ density: "compact" });
+    expect(save.state).not.toBe(first);
+  });
+});

--- a/packages/runtime/dataviews/src/lib/collection/createSaveSession.ts
+++ b/packages/runtime/dataviews/src/lib/collection/createSaveSession.ts
@@ -1,0 +1,162 @@
+/**
+ * Save-race semantics for durable preferences and views: a completion
+ * updates the submitted baseline only, so edits made while saving remain
+ * dirty, and a delayed external read never overwrites newer local state.
+ */
+
+/** Immutable state of one save session. */
+export type SaveSessionState<T> = {
+  /** Baseline of the last durable success. */
+  readonly baseline: T;
+  /** Current local value; may be edited while a save is in flight. */
+  readonly current: T;
+  /** Snapshot submitted to the store, or null when idle. */
+  readonly submitted: T | null;
+  readonly status: "idle" | "saving" | "failed";
+  readonly dirty: boolean;
+  /**
+   * Version of the local value: bumped on every edit and on every save
+   * submission. External reads carry the revision they were issued under.
+   */
+  readonly revision: number;
+  /** Failure note of the last save attempt; null means no failure on record. */
+  readonly failureReason: string | null;
+};
+
+/** Configuration of one save session. */
+export type SaveSessionConfig<T> = {
+  readonly initial: T;
+  readonly equals: (a: T, b: T) => boolean;
+};
+
+/** Handle of one save session. */
+export type SaveSession<T> = {
+  readonly state: SaveSessionState<T>;
+  /** Edit the local value. Allowed while saving; bumps the revision. */
+  readonly edit: (next: T) => void;
+  /**
+   * Submit the current value and return the attempt identity, or null when
+   * a save is already in flight.
+   */
+  readonly beginSave: () => string | null;
+  /**
+   * Record a durable success for the given attempt: only the submitted
+   * snapshot becomes the baseline. Edits made while saving remain dirty.
+   */
+  readonly saveCompleted: (attempt: string) => void;
+  /**
+   * Record a failure for the given attempt: the baseline is retained and
+   * the failure is recorded.
+   */
+  readonly saveFailed: (attempt: string, reason: string) => void;
+  /**
+   * Apply a delayed external read (for example a preference that resolved
+   * late). It applies only to the still-current target: when local edits or
+   * a save submission moved the revision since the read was issued, the
+   * read is discarded.
+   */
+  readonly applyExternalRead: (value: T, seenRevision: number) => boolean;
+};
+
+/** Monotonic instance key: exact cross-session distinctness. */
+let saveSessionInstances = 0;
+
+/**
+ * Create a save session over one durable value. Persistence execution stays
+ * with the caller; this record owns only the baseline/dirty race. Attempt
+ * identities make completions one-shot: a late completion of a superseded
+ * attempt is ignored, exactly like stale request completions.
+ */
+export default function createSaveSession<T>(
+  config: SaveSessionConfig<T>,
+): SaveSession<T> {
+  let baseline = config.initial;
+  let current = config.initial;
+  let submitted: T | null = null;
+  let currentAttempt: string | null = null;
+  // Instance-unique attempt ids: a completion routed to the wrong session
+  // must mismatch loudly, never advance a baseline silently.
+  const instanceKey = `i${++saveSessionInstances}`;
+  let attemptCounter = 0;
+  let status: SaveSessionState<T>["status"] = "idle";
+  let revision = 0;
+  let failureReason: string | null = null;
+  let snapshot = buildSnapshot();
+
+  function buildSnapshot(): SaveSessionState<T> {
+    return Object.freeze({
+      baseline,
+      current,
+      submitted,
+      status,
+      dirty: !config.equals(current, baseline),
+      revision,
+      failureReason,
+    });
+  }
+
+  return {
+    get state(): SaveSessionState<T> {
+      return snapshot;
+    },
+    edit(next: T): void {
+      current = next;
+      revision += 1;
+      if (status === "failed") {
+        status = "idle";
+      }
+      failureReason = null;
+      snapshot = buildSnapshot();
+    },
+    beginSave(): string | null {
+      if (status === "saving") {
+        return null;
+      }
+      attemptCounter += 1;
+      currentAttempt = `${instanceKey}:s${attemptCounter}`;
+      submitted = current;
+      status = "saving";
+      failureReason = null;
+      // A save submission also moves the value's version: a read issued
+      // before it must not clobber the submitted state when it resolves.
+      revision += 1;
+      snapshot = buildSnapshot();
+      return currentAttempt;
+    },
+    saveCompleted(attempt: string): void {
+      if (attempt !== currentAttempt || submitted === null) {
+        // Superseded or unknown attempt: never advance the baseline.
+        return;
+      }
+      baseline = submitted;
+      submitted = null;
+      currentAttempt = null;
+      status = "idle";
+      failureReason = null;
+      snapshot = buildSnapshot();
+    },
+    saveFailed(attempt: string, reason: string): void {
+      if (attempt !== currentAttempt || submitted === null) {
+        return;
+      }
+      submitted = null;
+      currentAttempt = null;
+      status = "failed";
+      failureReason = reason;
+      snapshot = buildSnapshot();
+    },
+    applyExternalRead(value: T, seenRevision: number): boolean {
+      if (status === "saving" || seenRevision !== revision) {
+        // A save is in flight, or the value moved on since the read was
+        // issued; the read must not overwrite either.
+        return false;
+      }
+      baseline = value;
+      current = value;
+      status = "idle";
+      failureReason = null;
+      snapshot = buildSnapshot();
+      return true;
+    },
+  };
+}

--- a/packages/runtime/dataviews/src/lib/collection/index.ts
+++ b/packages/runtime/dataviews/src/lib/collection/index.ts
@@ -1,0 +1,17 @@
+export type {
+  CollectionCoordinator,
+  CollectionCoordinatorConfig,
+  CollectionCoordinatorState,
+  CompletionResult,
+  DispatchResult,
+  ResultProvenance,
+  ResultState,
+  ResultStatus,
+} from "./createCollectionCoordinator.js";
+export { default as createCollectionCoordinator } from "./createCollectionCoordinator.js";
+export type {
+  SaveSession,
+  SaveSessionConfig,
+  SaveSessionState,
+} from "./createSaveSession.js";
+export { default as createSaveSession } from "./createSaveSession.js";

--- a/packages/runtime/dataviews/src/lib/field/createFieldInteraction.test.ts
+++ b/packages/runtime/dataviews/src/lib/field/createFieldInteraction.test.ts
@@ -1,0 +1,196 @@
+import { describe, expect, it } from "vitest";
+import type { Predicate } from "../query/types.js";
+import type { FieldValidation } from "./createFieldInteraction.js";
+import createFieldInteraction from "./createFieldInteraction.js";
+
+/** Validator for a numeric bound: incomplete while partial, invalid beyond. */
+const validateNumber = (buffer: string): FieldValidation => {
+  if (buffer === "" || buffer === "-") {
+    return { status: "incomplete" };
+  }
+  if (!/^-?\d+(\.\d+)?$/.test(buffer)) {
+    return { status: "invalid", reason: "not a number" };
+  }
+  return { status: "valid", operands: [Number(buffer)] };
+};
+
+const interaction = (
+  overrides: Partial<Parameters<typeof createFieldInteraction>[0]> = {},
+) =>
+  createFieldInteraction({
+    field: "cpu",
+    operator: "gte",
+    validate: validateNumber,
+    ...overrides,
+  });
+
+describe("createFieldInteraction", () => {
+  it("requires a non-empty field name", () => {
+    expect(() =>
+      createFieldInteraction({
+        field: "",
+        operator: "eq",
+        validate: validateNumber,
+      }),
+    ).toThrow("non-empty field");
+    expect(() =>
+      createFieldInteraction({
+        field: "a\u0000b",
+        operator: "eq",
+        validate: validateNumber,
+      }),
+    ).toThrow("NUL");
+  });
+
+  it("returns the addressed replacement command on a valid edit", () => {
+    const field = interaction();
+    const command = field.edit("4");
+    expect(command).toEqual({
+      kind: "replacePredicate",
+      predicate: { field: "cpu", operator: "gte", operands: [4] },
+    });
+    expect(field.state.feedback).toEqual({ kind: "applied" });
+    expect(field.state.applied).toEqual({
+      field: "cpu",
+      operator: "gte",
+      operands: [4],
+    });
+  });
+
+  it("retains the applied predicate on an invalid edit and explains it", () => {
+    const field = interaction();
+    field.edit("4");
+    const command = field.edit("four");
+    expect(command).toBeNull();
+    expect(field.state.applied).toEqual({
+      field: "cpu",
+      operator: "gte",
+      operands: [4],
+    });
+    expect(field.state.feedback).toEqual({
+      kind: "invalid",
+      reason: "not a number",
+      retainsPredicate: true,
+    });
+  });
+
+  it("flags an invalid edit without a prior predicate as not retaining", () => {
+    const field = interaction();
+    field.edit("nope");
+    expect(field.state.feedback).toEqual({
+      kind: "invalid",
+      reason: "not a number",
+      retainsPredicate: false,
+    });
+    expect(field.state.applied).toBeNull();
+  });
+
+  it("keeps an incomplete new filter out of the query", () => {
+    const field = interaction();
+    const command = field.edit("-");
+    expect(command).toBeNull();
+    expect(field.state.applied).toBeNull();
+    expect(field.state.feedback).toEqual({ kind: "incomplete" });
+  });
+
+  it("retains the applied predicate while incomplete", () => {
+    const field = interaction();
+    field.edit("4");
+    field.edit("-");
+    expect(field.state.applied).toEqual({
+      field: "cpu",
+      operator: "gte",
+      operands: [4],
+    });
+    expect(field.state.feedback).toEqual({ kind: "incomplete" });
+  });
+
+  it("clears explicitly, distinct from invalid input", () => {
+    const field = interaction();
+    field.edit("4");
+    const command = field.clear();
+    expect(command).toEqual({
+      kind: "removePredicate",
+      field: "cpu",
+      operator: "gte",
+    });
+    expect(field.state.applied).toBeNull();
+    expect(field.state.buffer).toBe("");
+    expect(field.state.feedback).toEqual({ kind: "none" });
+  });
+
+  it("still returns the removal command when nothing is applied", () => {
+    const field = interaction();
+    expect(field.clear()).toEqual({
+      kind: "removePredicate",
+      field: "cpu",
+      operator: "gte",
+    });
+  });
+
+  it("discards stale buffers and feedback on an external query change", () => {
+    const field = interaction();
+    field.edit("four");
+    const applied: Predicate = {
+      field: "cpu",
+      operator: "gte",
+      operands: [8],
+    };
+    field.setApplied(applied);
+    expect(field.state.buffer).toBe("");
+    expect(field.state.feedback).toEqual({ kind: "none" });
+    expect(field.state.applied).toEqual(applied);
+  });
+
+  it("adopts external removal without replaying the stale buffer", () => {
+    const field = interaction();
+    field.edit("4");
+    field.edit("nope");
+    field.setApplied(null);
+    expect(field.state.applied).toBeNull();
+    expect(field.state.buffer).toBe("");
+    expect(field.state.feedback).toEqual({ kind: "none" });
+  });
+
+  it("formats the buffer from an external change when configured", () => {
+    const field = interaction({
+      format: (applied) =>
+        applied === null ? "" : String(applied.operands[0] ?? ""),
+    });
+    field.setApplied({
+      field: "cpu",
+      operator: "gte",
+      operands: [8],
+    });
+    expect(field.state.buffer).toBe("8");
+    field.setApplied(null);
+    expect(field.state.buffer).toBe("");
+  });
+
+  it("rejects a misrouted external predicate without side effects", () => {
+    const field = interaction();
+    field.edit("4");
+    const before = field.state;
+    expect(() =>
+      field.setApplied({ field: "zone", operator: "eq", operands: ["north"] }),
+    ).toThrow("zone");
+    expect(() =>
+      field.setApplied({ field: "cpu", operator: "lte", operands: [4] }),
+    ).toThrow("lte");
+    expect(field.state).toBe(before);
+  });
+
+  it("serves a referentially stable snapshot between mutations", () => {
+    const field = interaction();
+    const first = field.state;
+    expect(field.state).toBe(first);
+    field.edit("4");
+    expect(field.state).not.toBe(first);
+  });
+
+  it("gives each record a distinct identity", () => {
+    const a = interaction();
+    const b = interaction();
+    expect(a.identity).not.toBe(b.identity);
+  });
+});

--- a/packages/runtime/dataviews/src/lib/field/createFieldInteraction.ts
+++ b/packages/runtime/dataviews/src/lib/field/createFieldInteraction.ts
@@ -1,0 +1,163 @@
+import createIdentity, { type Identity } from "../createIdentity.js";
+import type {
+  Predicate,
+  PredicateOperand,
+  PredicateOperator,
+  QueryCommand,
+} from "../query/types.js";
+
+/** Result of validating one input buffer. */
+export type FieldValidation =
+  | {
+      readonly status: "valid";
+      readonly operands: readonly PredicateOperand[];
+    }
+  | { readonly status: "incomplete" }
+  | { readonly status: "invalid"; readonly reason: string };
+
+/** Feedback a field control renders beside its buffer. */
+export type FieldFeedback =
+  | { readonly kind: "none" }
+  | { readonly kind: "applied" }
+  | { readonly kind: "incomplete" }
+  | {
+      readonly kind: "invalid";
+      readonly reason: string;
+      /** True when a prior applied predicate is still restricting results. */
+      readonly retainsPredicate: boolean;
+    };
+
+/** Immutable interaction state of one filter field. */
+export type FieldInteractionState = {
+  readonly buffer: string;
+  readonly feedback: FieldFeedback;
+  readonly applied: Predicate | null;
+};
+
+/** Configuration of one filter field interaction record. */
+export type FieldInteractionConfig = {
+  /** Field name the interaction addresses; must not be empty. */
+  readonly field: string;
+  /** Operator the interaction addresses. */
+  readonly operator: PredicateOperator;
+  /**
+   * Validate an input buffer. `incomplete` retains the applied predicate
+   * with local feedback; `invalid` retains it with the prior-restriction
+   * note; `valid` produces the addressed replacement command.
+   */
+  readonly validate: (buffer: string) => FieldValidation;
+  /**
+   * Optional formatter deriving a buffer from an applied predicate on
+   * external query changes. Without it, external changes clear the buffer.
+   */
+  readonly format?: (applied: Predicate | null) => string;
+};
+
+/** Handle of one field interaction record, addressed by field and operator. */
+export type FieldInteraction = {
+  readonly identity: Identity;
+  readonly state: FieldInteractionState;
+  /**
+   * Edit the input buffer. Returns the addressed replacement command when
+   * the buffer is valid, and null when the buffer is invalid or incomplete —
+   * in both cases the applied predicate is retained.
+   */
+  readonly edit: (buffer: string) => QueryCommand | null;
+  /** Explicitly remove the addressed predicate. Always returns the command. */
+  readonly clear: () => QueryCommand;
+  /**
+   * Adopt the authoritative applied predicate (external query or history
+   * change). Stale buffers and feedback are discarded, never replayed; the
+   * predicate must address this record's field and operator.
+   */
+  readonly setApplied: (applied: Predicate | null) => void;
+};
+
+/**
+ * Create the interaction record for one filter field: it owns the input
+ * buffer and its feedback, and produces addressed query commands. It never
+ * owns the applied query — the coordinator does. A valid edit assumes its
+ * returned command is dispatched and accepted; external authoritative
+ * changes arrive through `setApplied`.
+ */
+export default function createFieldInteraction(
+  config: FieldInteractionConfig,
+): FieldInteraction {
+  if (config.field === "" || config.field.includes("\u0000")) {
+    throw new Error(
+      "field interaction requires a non-empty field name without NUL characters",
+    );
+  }
+  const identity = createIdentity();
+  let buffer = "";
+  let feedback: FieldFeedback = { kind: "none" };
+  let applied: Predicate | null = null;
+  let snapshot = buildSnapshot();
+
+  function buildSnapshot(): FieldInteractionState {
+    return Object.freeze({ buffer, feedback, applied });
+  }
+
+  const predicateFrom = (operands: readonly PredicateOperand[]): Predicate => ({
+    field: config.field,
+    operator: config.operator,
+    operands: [...operands],
+  });
+
+  return {
+    identity,
+    get state(): FieldInteractionState {
+      return snapshot;
+    },
+    edit(nextBuffer: string): QueryCommand | null {
+      buffer = nextBuffer;
+      const validation = config.validate(nextBuffer);
+      if (validation.status === "valid") {
+        feedback = { kind: "applied" };
+        applied = predicateFrom(validation.operands);
+        snapshot = buildSnapshot();
+        return {
+          kind: "replacePredicate",
+          predicate: applied,
+        };
+      }
+      if (validation.status === "incomplete") {
+        feedback = { kind: "incomplete" };
+      } else {
+        feedback = {
+          kind: "invalid",
+          reason: validation.reason,
+          retainsPredicate: applied !== null,
+        };
+      }
+      snapshot = buildSnapshot();
+      return null;
+    },
+    clear(): QueryCommand {
+      buffer = "";
+      feedback = { kind: "none" };
+      applied = null;
+      snapshot = buildSnapshot();
+      return {
+        kind: "removePredicate",
+        field: config.field,
+        operator: config.operator,
+      };
+    },
+    setApplied(nextApplied: Predicate | null): void {
+      if (
+        nextApplied !== null &&
+        (nextApplied.field !== config.field ||
+          nextApplied.operator !== config.operator)
+      ) {
+        throw new Error(
+          `setApplied received a predicate for ${nextApplied.field}/${nextApplied.operator} on a ${config.field}/${config.operator} record`,
+        );
+      }
+      applied = nextApplied;
+      buffer = config.format ? config.format(nextApplied) : "";
+      feedback = { kind: "none" };
+      snapshot = buildSnapshot();
+    },
+  };
+}

--- a/packages/runtime/dataviews/src/lib/field/index.ts
+++ b/packages/runtime/dataviews/src/lib/field/index.ts
@@ -1,0 +1,8 @@
+export type {
+  FieldFeedback,
+  FieldInteraction,
+  FieldInteractionConfig,
+  FieldInteractionState,
+  FieldValidation,
+} from "./createFieldInteraction.js";
+export { default as createFieldInteraction } from "./createFieldInteraction.js";

--- a/packages/runtime/dataviews/src/lib/index.ts
+++ b/packages/runtime/dataviews/src/lib/index.ts
@@ -1,3 +1,7 @@
+export * from "./collection/index.js";
 export type { Identity } from "./createIdentity.js";
 export { default as createIdentity } from "./createIdentity.js";
+export * from "./field/index.js";
 export { default as isIdentity } from "./isIdentity.js";
+export * from "./operation/index.js";
+export * from "./query/index.js";

--- a/packages/runtime/dataviews/src/lib/operation/createOperation.test.ts
+++ b/packages/runtime/dataviews/src/lib/operation/createOperation.test.ts
@@ -1,0 +1,235 @@
+import { describe, expect, it } from "vitest";
+import createOperation from "./createOperation.js";
+
+describe("createOperation", () => {
+  it("requires at least one captured target", () => {
+    expect(() =>
+      createOperation({ targets: [], payload: null, selectionRevision: 1 }),
+    ).toThrow("at least one");
+  });
+
+  it("captures targets immutably at construction", () => {
+    const targets = ["machine-1", "machine-2"];
+    const payload = { action: "restart" };
+    const operation = createOperation({
+      targets,
+      payload,
+      selectionRevision: 7,
+    });
+    targets.push("machine-3");
+    expect(operation.state.targets).toEqual(["machine-1", "machine-2"]);
+    // Payload is captured by reference, as documented.
+    expect(operation.state.payload).toBe(payload);
+    expect(operation.state.selectionRevision).toBe(7);
+    expect(operation.state.status).toBe("pending");
+    expect(operation.state.remaining).toEqual(["machine-1", "machine-2"]);
+  });
+
+  it("deduplicates repeated targets at construction", () => {
+    const operation = createOperation({
+      targets: ["machine-1", "machine-1", "machine-2"],
+      payload: null,
+      selectionRevision: 1,
+    });
+    expect(operation.state.targets).toEqual(["machine-1", "machine-2"]);
+  });
+
+  it("never retargets: only captured targets can receive outcomes", () => {
+    const operation = createOperation({
+      targets: ["machine-1"],
+      payload: null,
+      selectionRevision: 1,
+    });
+    // The user changes selection after construction; execution stays captured.
+    operation.recordOutcome([
+      { target: "machine-2", status: "success" },
+      { target: "machine-1", status: "success" },
+    ]);
+    expect(operation.state.succeeded).toEqual(["machine-1"]);
+    expect(operation.state.status).toBe("success");
+  });
+
+  it("keeps the snapshot when an outcome batch settles nothing", () => {
+    const operation = createOperation({
+      targets: ["machine-1"],
+      payload: null,
+      selectionRevision: 1,
+    });
+    const before = operation.state;
+    operation.recordOutcome([{ target: "machine-9", status: "success" }]);
+    expect(operation.state).toBe(before);
+  });
+
+  it("settles a target at most once per attempt", () => {
+    const operation = createOperation({
+      targets: ["machine-1", "machine-2"],
+      payload: null,
+      selectionRevision: 1,
+    });
+    operation.recordOutcome([
+      { target: "machine-1", status: "success" },
+      { target: "machine-1", status: "failure", reason: "contradiction" },
+    ]);
+    expect(operation.state.succeeded).toEqual(["machine-1"]);
+    expect(operation.state.failed).toEqual([]);
+  });
+
+  it("records partial outcomes and stays partial with targets remaining", () => {
+    const operation = createOperation({
+      targets: ["machine-1", "machine-2", "machine-3"],
+      payload: null,
+      selectionRevision: 1,
+    });
+    operation.recordOutcome([
+      { target: "machine-1", status: "success" },
+      { target: "machine-2", status: "failure", reason: "locked" },
+    ]);
+    expect(operation.state.status).toBe("partial");
+    expect(operation.state.succeeded).toEqual(["machine-1"]);
+    expect(operation.state.failed).toEqual([
+      { target: "machine-2", reason: "locked" },
+    ]);
+    expect(operation.state.remaining).toEqual(["machine-3"]);
+  });
+
+  it("ends in failure when every captured target failed", () => {
+    const operation = createOperation({
+      targets: ["machine-1"],
+      payload: null,
+      selectionRevision: 1,
+    });
+    operation.recordOutcome([
+      { target: "machine-1", status: "failure", reason: "forbidden" },
+    ]);
+    expect(operation.state.status).toBe("failure");
+    expect(operation.state.remaining).toEqual([]);
+  });
+
+  it("ends in success when every captured target succeeded", () => {
+    const operation = createOperation({
+      targets: ["machine-1", "machine-2"],
+      payload: null,
+      selectionRevision: 1,
+    });
+    operation.recordOutcome([{ target: "machine-1", status: "success" }]);
+    expect(operation.state.status).toBe("partial");
+    operation.recordOutcome([{ target: "machine-2", status: "success" }]);
+    expect(operation.state.status).toBe("success");
+    expect(operation.state.failed).toEqual([]);
+  });
+
+  it("records multiple failures in one partial result", () => {
+    const operation = createOperation({
+      targets: ["machine-1", "machine-2"],
+      payload: null,
+      selectionRevision: 1,
+    });
+    operation.recordOutcome([
+      { target: "machine-1", status: "failure", reason: "locked" },
+      { target: "machine-2", status: "failure", reason: "offline" },
+    ]);
+    expect(operation.state.failed).toEqual([
+      { target: "machine-1", reason: "locked" },
+      { target: "machine-2", reason: "offline" },
+    ]);
+    expect(operation.state.status).toBe("failure");
+  });
+
+  it("retries only the failed captured targets under the same identity", () => {
+    const operation = createOperation({
+      targets: ["machine-1", "machine-2"],
+      payload: null,
+      selectionRevision: 3,
+    });
+    operation.recordOutcome([
+      { target: "machine-1", status: "success" },
+      { target: "machine-2", status: "failure", reason: "timeout" },
+    ]);
+    const identityBefore = operation.identity;
+    operation.retry();
+    expect(operation.identity).toBe(identityBefore);
+    // The original capture stays on the record for reporting.
+    expect(operation.state.targets).toEqual(["machine-1", "machine-2"]);
+    expect(operation.state.remaining).toEqual(["machine-2"]);
+    expect(operation.state.status).toBe("pending");
+    expect(operation.state.attempts).toBe(2);
+    expect(operation.state.succeeded).toEqual([]);
+    expect(operation.state.failed).toEqual([]);
+  });
+
+  it("ignores an outcome for an already-settled target after retry", () => {
+    const operation = createOperation({
+      targets: ["machine-1", "machine-2"],
+      payload: null,
+      selectionRevision: 1,
+    });
+    operation.recordOutcome([{ target: "machine-1", status: "success" }]);
+    operation.recordOutcome([
+      { target: "machine-2", status: "failure", reason: "timeout" },
+    ]);
+    operation.retry();
+    operation.recordOutcome([{ target: "machine-1", status: "success" }]);
+    expect(operation.state.succeeded).toEqual([]);
+    expect(operation.state.remaining).toEqual(["machine-2"]);
+  });
+
+  it("ignores retry when nothing failed", () => {
+    const operation = createOperation({
+      targets: ["machine-1"],
+      payload: null,
+      selectionRevision: 1,
+    });
+    operation.recordOutcome([{ target: "machine-1", status: "success" }]);
+    operation.retry();
+    expect(operation.state.status).toBe("success");
+    expect(operation.state.attempts).toBe(1);
+  });
+
+  it("ignores retry while pending or partial", () => {
+    const pending = createOperation({
+      targets: ["machine-1"],
+      payload: null,
+      selectionRevision: 1,
+    });
+    pending.retry();
+    expect(pending.state.attempts).toBe(1);
+
+    const partial = createOperation({
+      targets: ["machine-1", "machine-2"],
+      payload: null,
+      selectionRevision: 1,
+    });
+    partial.recordOutcome([
+      { target: "machine-1", status: "failure", reason: "locked" },
+    ]);
+    partial.retry();
+    expect(partial.state.status).toBe("partial");
+    expect(partial.state.attempts).toBe(1);
+  });
+
+  it("serves a referentially stable snapshot between mutations", () => {
+    const operation = createOperation({
+      targets: ["machine-1"],
+      payload: null,
+      selectionRevision: 1,
+    });
+    const first = operation.state;
+    expect(operation.state).toBe(first);
+    operation.recordOutcome([{ target: "machine-1", status: "success" }]);
+    expect(operation.state).not.toBe(first);
+  });
+
+  it("keeps a stable identity per invocation", () => {
+    const a = createOperation({
+      targets: ["machine-1"],
+      payload: null,
+      selectionRevision: 0,
+    });
+    const b = createOperation({
+      targets: ["machine-2"],
+      payload: null,
+      selectionRevision: 0,
+    });
+    expect(a.identity).not.toBe(b.identity);
+  });
+});

--- a/packages/runtime/dataviews/src/lib/operation/createOperation.ts
+++ b/packages/runtime/dataviews/src/lib/operation/createOperation.ts
@@ -1,0 +1,141 @@
+import createIdentity, { type Identity } from "../createIdentity.js";
+
+/** Per-target outcome of a partial operation result. */
+export type OperationOutcome =
+  | { readonly target: string; readonly status: "success" }
+  | {
+      readonly target: string;
+      readonly status: "failure";
+      readonly reason: string;
+    };
+
+/** Failure detail retained for retry and reporting. */
+export type OperationFailure = {
+  readonly target: string;
+  readonly reason: string;
+};
+
+/** Immutable state of one operation invocation. */
+export type OperationState = {
+  /** Immutable captured targets, deduplicated at construction. */
+  readonly targets: readonly string[];
+  /** Caller-defined payload, captured by reference at construction. */
+  readonly payload: unknown;
+  /** Selection revision captured at construction. */
+  readonly selectionRevision: number;
+  readonly status: "pending" | "partial" | "success" | "failure";
+  readonly succeeded: readonly string[];
+  readonly failed: readonly OperationFailure[];
+  /** Captured targets without a reported outcome yet. */
+  readonly remaining: readonly string[];
+  readonly attempts: number;
+};
+
+/** Configuration of one invocation; the capture happens at construction. */
+export type OperationConfig = {
+  readonly targets: readonly string[];
+  readonly payload?: unknown;
+  readonly selectionRevision: number;
+};
+
+/** Handle of one operation invocation record. */
+export type Operation = {
+  readonly identity: Identity;
+  readonly state: OperationState;
+  /**
+   * Record a partial result. Outcomes apply only to captured targets still
+   * awaiting one: successful targets leave the record, failures are retained
+   * with their reasons, and outcomes for unknown, already-settled or foreign
+   * targets are ignored.
+   */
+  readonly recordOutcome: (outcomes: readonly OperationOutcome[]) => void;
+  /**
+   * Retry the failed captured targets under the same operation identity,
+   * keeping the original capture. No-op unless the last attempt ended in
+   * failure.
+   */
+  readonly retry: () => void;
+};
+
+/**
+ * Create one operation invocation: targets, payload and the selection
+ * revision are captured at construction, so later selection changes can
+ * never retarget execution. At least one target is required. Payload is
+ * captured by reference; callers must not mutate it after construction.
+ */
+export default function createOperation(config: OperationConfig): Operation {
+  if (config.targets.length === 0) {
+    throw new Error("operation requires at least one captured target");
+  }
+  const identity = createIdentity();
+  const targets = Object.freeze([...new Set(config.targets)]);
+  let succeeded: string[] = [];
+  let failed: OperationFailure[] = [];
+  let remaining = [...targets];
+  let status: OperationState["status"] = "pending";
+  let attempts = 1;
+  let snapshot = buildSnapshot();
+
+  function settle(): void {
+    if (remaining.length === 0) {
+      status = failed.length > 0 ? "failure" : "success";
+    } else {
+      status = "partial";
+    }
+  }
+
+  function buildSnapshot(): OperationState {
+    return Object.freeze({
+      targets,
+      payload: config.payload,
+      selectionRevision: config.selectionRevision,
+      status,
+      succeeded: Object.freeze([...succeeded]),
+      failed: Object.freeze([...failed]),
+      remaining: Object.freeze([...remaining]),
+      attempts,
+    });
+  }
+
+  return {
+    identity,
+    get state(): OperationState {
+      return snapshot;
+    },
+    recordOutcome(outcomes: readonly OperationOutcome[]): void {
+      const open = new Set(remaining);
+      let settled = false;
+      for (const entry of outcomes) {
+        if (!open.has(entry.target)) {
+          continue;
+        }
+        settled = true;
+        // A target settles at most once per attempt: it leaves `open`, so a
+        // later outcome for it cannot arrive through this path.
+        open.delete(entry.target);
+        if (entry.status === "success") {
+          succeeded.push(entry.target);
+        } else {
+          failed.push({ target: entry.target, reason: entry.reason });
+        }
+      }
+      if (!settled) {
+        return;
+      }
+      remaining = [...open];
+      settle();
+      snapshot = buildSnapshot();
+    },
+    retry(): void {
+      if (status !== "failure") {
+        return;
+      }
+      remaining = failed.map((failure) => failure.target);
+      succeeded = [];
+      failed = [];
+      attempts += 1;
+      status = "pending";
+      snapshot = buildSnapshot();
+    },
+  };
+}

--- a/packages/runtime/dataviews/src/lib/operation/index.ts
+++ b/packages/runtime/dataviews/src/lib/operation/index.ts
@@ -1,0 +1,8 @@
+export type {
+  Operation,
+  OperationConfig,
+  OperationFailure,
+  OperationOutcome,
+  OperationState,
+} from "./createOperation.js";
+export { default as createOperation } from "./createOperation.js";

--- a/packages/runtime/dataviews/src/lib/query/applyQueryCommand.test.ts
+++ b/packages/runtime/dataviews/src/lib/query/applyQueryCommand.test.ts
@@ -1,0 +1,334 @@
+import { describe, expect, it } from "vitest";
+import applyQueryCommand from "./applyQueryCommand.js";
+import type { ResultWindow, Slice } from "./types.js";
+
+const slice = (overrides: Partial<Slice> = {}): Slice => ({
+  filter: [],
+  search: null,
+  sort: [],
+  group: null,
+  ...overrides,
+});
+
+const window = (page = 1, size = 50): ResultWindow => ({ page, size });
+
+describe("applyQueryCommand", () => {
+  it("replaces only the addressed predicate and preserves other clauses", () => {
+    const base = slice({
+      filter: [
+        { field: "status", operator: "eq", operands: ["failed"] },
+        { field: "zone", operator: "eq", operands: ["north"] },
+      ],
+      sort: [{ field: "name", direction: "asc" }],
+    });
+    const result = applyQueryCommand(base, window(), {
+      kind: "replacePredicate",
+      predicate: { field: "status", operator: "eq", operands: ["cancelled"] },
+    });
+    if (result.status !== "accepted") {
+      throw new Error("expected acceptance");
+    }
+    expect(result.slice.filter).toEqual([
+      { field: "zone", operator: "eq", operands: ["north"] },
+      { field: "status", operator: "eq", operands: ["cancelled"] },
+    ]);
+    expect(result.slice.sort).toEqual(base.sort);
+    expect(result.queryChanged).toBe(true);
+  });
+
+  it("appends a predicate for an unaddressed field", () => {
+    const result = applyQueryCommand(slice(), window(), {
+      kind: "replacePredicate",
+      predicate: { field: "status", operator: "eq", operands: ["failed"] },
+    });
+    if (result.status !== "accepted") {
+      throw new Error("expected acceptance");
+    }
+    expect(result.slice.filter).toHaveLength(1);
+  });
+
+  it("accepts bound and zero-value predicates with their exact arities", () => {
+    for (const predicate of [
+      { field: "updated", operator: "gte", operands: ["2026-01-01"] },
+      { field: "updated", operator: "lte", operands: ["2026-12-31"] },
+      { field: "owner", operator: "isSet", operands: [] },
+    ] as const) {
+      const result = applyQueryCommand(slice(), window(), {
+        kind: "replacePredicate",
+        predicate,
+      });
+      expect(result.status).toBe("accepted");
+    }
+  });
+
+  it("resets the window to the first page on a query change", () => {
+    const result = applyQueryCommand(slice(), window(4), {
+      kind: "replacePredicate",
+      predicate: { field: "status", operator: "eq", operands: ["failed"] },
+    });
+    if (result.status !== "accepted") {
+      throw new Error("expected acceptance");
+    }
+    expect(result.window.page).toBe(1);
+    expect(result.windowChanged).toBe(true);
+  });
+
+  it("removes exactly the addressed predicate and resets the window", () => {
+    const base = slice({
+      filter: [
+        { field: "status", operator: "eq", operands: ["failed"] },
+        { field: "status", operator: "isSet", operands: [] },
+      ],
+    });
+    const result = applyQueryCommand(base, window(3), {
+      kind: "removePredicate",
+      field: "status",
+      operator: "eq",
+    });
+    if (result.status !== "accepted") {
+      throw new Error("expected acceptance");
+    }
+    expect(result.slice.filter).toEqual([
+      { field: "status", operator: "isSet", operands: [] },
+    ]);
+    expect(result.window.page).toBe(1);
+  });
+
+  it("reports no change when removing an absent predicate", () => {
+    const base = slice({
+      filter: [{ field: "zone", operator: "eq", operands: ["north"] }],
+    });
+    const result = applyQueryCommand(base, window(2), {
+      kind: "removePredicate",
+      field: "status",
+      operator: "eq",
+    });
+    if (result.status !== "accepted") {
+      throw new Error("expected acceptance");
+    }
+    expect(result.queryChanged).toBe(false);
+    expect(result.window.page).toBe(2);
+    expect(result.windowChanged).toBe(false);
+  });
+
+  it("treats an empty search replacement as clearing the search", () => {
+    const result = applyQueryCommand(slice({ search: "yak" }), window(2), {
+      kind: "replaceSearch",
+      search: "",
+    });
+    if (result.status !== "accepted") {
+      throw new Error("expected acceptance");
+    }
+    expect(result.slice.search).toBeNull();
+    expect(result.queryChanged).toBe(true);
+    expect(result.window.page).toBe(1);
+  });
+
+  it("replaces the complete sort and resets the window", () => {
+    const base = slice({ sort: [{ field: "name", direction: "asc" }] });
+    const result = applyQueryCommand(base, window(2), {
+      kind: "replaceSort",
+      sort: [
+        { field: "updated", direction: "desc" },
+        { field: "name", direction: "asc" },
+      ],
+    });
+    if (result.status !== "accepted") {
+      throw new Error("expected acceptance");
+    }
+    expect(result.slice.sort).toEqual([
+      { field: "updated", direction: "desc" },
+      { field: "name", direction: "asc" },
+    ]);
+    expect(result.window.page).toBe(1);
+  });
+
+  it("sets and clears the group", () => {
+    const grouped = applyQueryCommand(slice(), window(2), {
+      kind: "setGroup",
+      group: "status",
+    });
+    if (grouped.status !== "accepted") {
+      throw new Error("expected acceptance");
+    }
+    expect(grouped.slice.group).toBe("status");
+    expect(grouped.window.page).toBe(1);
+    const cleared = applyQueryCommand(grouped.slice, window(), {
+      kind: "setGroup",
+      group: null,
+    });
+    if (cleared.status !== "accepted") {
+      throw new Error("expected acceptance");
+    }
+    expect(cleared.slice.group).toBeNull();
+  });
+
+  it("navigates the window without touching the query", () => {
+    const base = slice({ search: "yak" });
+    const result = applyQueryCommand(base, window(1, 50), {
+      kind: "navigateWindow",
+      page: 2,
+      size: 25,
+    });
+    if (result.status !== "accepted") {
+      throw new Error("expected acceptance");
+    }
+    expect(result.slice).toBe(base);
+    expect(result.window).toEqual({ page: 2, size: 25 });
+    expect(result.queryChanged).toBe(false);
+    expect(result.windowChanged).toBe(true);
+  });
+
+  it("reports no change when navigating to the current window", () => {
+    const result = applyQueryCommand(slice(), window(2, 25), {
+      kind: "navigateWindow",
+      page: 2,
+      size: 25,
+    });
+    if (result.status !== "accepted") {
+      throw new Error("expected acceptance");
+    }
+    expect(result.windowChanged).toBe(false);
+  });
+
+  it("treats a semantically unchanged edit as no change at all", () => {
+    const base = slice({
+      filter: [
+        { field: "status", operator: "eq", operands: ["failed", "cancelled"] },
+      ],
+      sort: [{ field: "name", direction: "asc" }],
+    });
+    const result = applyQueryCommand(base, window(2), {
+      kind: "replacePredicate",
+      predicate: {
+        field: "status",
+        operator: "eq",
+        operands: ["cancelled", "failed"],
+      },
+    });
+    if (result.status !== "accepted") {
+      throw new Error("expected acceptance");
+    }
+    expect(result.queryChanged).toBe(false);
+    expect(result.windowChanged).toBe(false);
+    expect(result.window.page).toBe(2);
+  });
+
+  it("rejects a predicate with an empty field", () => {
+    const result = applyQueryCommand(slice(), window(), {
+      kind: "replacePredicate",
+      predicate: { field: "", operator: "eq", operands: ["failed"] },
+    });
+    expect(result.status).toBe("rejected");
+  });
+
+  it("rejects non-positive or fractional window values", () => {
+    for (const command of [
+      { kind: "navigateWindow", page: 0 },
+      { kind: "navigateWindow", page: -1 },
+      { kind: "navigateWindow", page: 1.5 },
+      { kind: "navigateWindow", page: Number.NaN },
+      { kind: "navigateWindow", size: 0 },
+      { kind: "navigateWindow", size: -3 },
+      { kind: "navigateWindow", size: 2.5 },
+      { kind: "navigateWindow", size: Number.POSITIVE_INFINITY },
+    ] as const) {
+      const result = applyQueryCommand(slice(), window(), command);
+      expect(result.status).toBe("rejected");
+    }
+  });
+
+  it("rejects an empty group string", () => {
+    const result = applyQueryCommand(slice(), window(), {
+      kind: "setGroup",
+      group: "",
+    });
+    if (result.status !== "rejected") {
+      throw new Error("expected rejection");
+    }
+    expect(result.reason).toBe("group must not be empty; use null to clear it");
+  });
+
+  it("clears the sort through an empty replacement", () => {
+    const base = slice({ sort: [{ field: "name", direction: "asc" }] });
+    const result = applyQueryCommand(base, window(), {
+      kind: "replaceSort",
+      sort: [],
+    });
+    if (result.status !== "accepted") {
+      throw new Error("expected acceptance");
+    }
+    expect(result.slice.sort).toEqual([]);
+    expect(result.queryChanged).toBe(true);
+  });
+
+  it("rejects predicates that violate the bounded grammar", () => {
+    const cases = [
+      {
+        kind: "replacePredicate",
+        predicate: { field: "status", operator: "eq", operands: [] },
+      },
+      {
+        kind: "replacePredicate",
+        predicate: { field: "cpu", operator: "gte", operands: [1, 2] },
+      },
+      {
+        kind: "replacePredicate",
+        predicate: { field: "cpu", operator: "gte", operands: [] },
+      },
+      {
+        kind: "replacePredicate",
+        predicate: { field: "owner", operator: "isSet", operands: ["x"] },
+      },
+      {
+        kind: "replacePredicate",
+        predicate: { field: "cpu", operator: "gte", operands: [Number.NaN] },
+      },
+      {
+        kind: "replacePredicate",
+        predicate: {
+          field: "cpu",
+          operator: "lte",
+          operands: [Number.POSITIVE_INFINITY],
+        },
+      },
+      {
+        kind: "replaceSort",
+        sort: [{ field: "", direction: "asc" }],
+      },
+    ] as const;
+    for (const command of cases) {
+      const result = applyQueryCommand(slice(), window(), command);
+      expect(result.status).toBe("rejected");
+    }
+  });
+
+  it("rejects predicate fields containing NUL characters on creation only", () => {
+    const result = applyQueryCommand(slice(), window(), {
+      kind: "replacePredicate",
+      predicate: { field: "a\u0000b", operator: "eq", operands: ["x"] },
+    });
+    expect(result.status).toBe("rejected");
+    // Removal may address out-of-grammar predicates to clean them up.
+    const removal = applyQueryCommand(slice(), window(), {
+      kind: "removePredicate",
+      field: "a\u0000b",
+      operator: "eq",
+    });
+    expect(removal.status).toBe("accepted");
+  });
+
+  it("keeps state unchanged on rejection", () => {
+    const base = slice({ search: "yak" });
+    const result = applyQueryCommand(base, window(2), {
+      kind: "navigateWindow",
+      page: 0,
+    });
+    if (result.status !== "rejected") {
+      throw new Error("expected rejection");
+    }
+    expect(result.slice).toBe(base);
+    expect(result.window.page).toBe(2);
+    expect(result.reason).toBe("page must be a positive integer");
+  });
+});

--- a/packages/runtime/dataviews/src/lib/query/applyQueryCommand.ts
+++ b/packages/runtime/dataviews/src/lib/query/applyQueryCommand.ts
@@ -1,0 +1,174 @@
+import { predicateAddress } from "./canonicalSlice.js";
+import sliceEquals from "./sliceEquals.js";
+import type {
+  Predicate,
+  QueryCommand,
+  QueryCommandResult,
+  ResultWindow,
+  Slice,
+} from "./types.js";
+
+/** Commands that address the query rather than the window. */
+type QueryMemberCommand = Exclude<QueryCommand, { kind: "navigateWindow" }>;
+
+/** Validate one predicate against the bounded grammar. */
+const predicateRejection = (predicate: Predicate): string | null => {
+  if (predicate.field === "") {
+    return "predicate field must not be empty";
+  }
+  if (predicate.field.includes("\u0000")) {
+    return "predicate field must not contain NUL characters";
+  }
+  if (
+    predicate.operands.some(
+      (operand) => typeof operand === "number" && !Number.isFinite(operand),
+    )
+  ) {
+    return "predicate operands must be finite numbers";
+  }
+  switch (predicate.operator) {
+    case "eq":
+      return predicate.operands.length > 0
+        ? null
+        : "eq predicate needs at least one operand";
+    case "gte":
+    case "lte":
+      return predicate.operands.length === 1
+        ? null
+        : `${predicate.operator} predicate needs exactly one operand`;
+    case "isSet":
+      return predicate.operands.length === 0
+        ? null
+        : "isSet predicate takes no operands";
+  }
+};
+
+const firstPage = (window: ResultWindow): ResultWindow => ({
+  ...window,
+  page: 1,
+});
+
+const replacePredicate = (slice: Slice, predicate: Predicate): Slice => ({
+  ...slice,
+  filter: [
+    ...slice.filter.filter(
+      (existing) =>
+        predicateAddress(existing.field, existing.operator) !==
+        predicateAddress(predicate.field, predicate.operator),
+    ),
+    predicate,
+  ],
+});
+
+/**
+ * Apply one addressed query command as a coherent transition: a changed
+ * query resets the window to the first page, window-only commands leave the
+ * query untouched, and a semantically unchanged edit changes nothing.
+ * Commands that violate the bounded grammar (empty fields, wrong arities,
+ * non-finite numbers, non-positive or fractional window values) are rejected
+ * with the input state unchanged.
+ */
+export default function applyQueryCommand(
+  slice: Slice,
+  window: ResultWindow,
+  command: QueryCommand,
+): QueryCommandResult {
+  if (command.kind === "navigateWindow") {
+    const page = command.page ?? window.page;
+    const size = command.size ?? window.size;
+    if (!Number.isInteger(page) || page < 1) {
+      return rejected(slice, window, "page must be a positive integer");
+    }
+    if (!Number.isInteger(size) || size < 1) {
+      return rejected(slice, window, "size must be a positive integer");
+    }
+    return {
+      status: "accepted",
+      slice,
+      window: { page, size },
+      queryChanged: false,
+      windowChanged: page !== window.page || size !== window.size,
+    };
+  }
+
+  const rejection = commandRejection(command);
+  if (rejection !== null) {
+    return rejected(slice, window, rejection);
+  }
+
+  const nextSlice = applyToSlice(slice, command);
+  if (sliceEquals(slice, nextSlice)) {
+    // A semantically unchanged edit is not a request and not a history entry.
+    return {
+      status: "accepted",
+      slice,
+      window,
+      queryChanged: false,
+      windowChanged: false,
+    };
+  }
+  return {
+    status: "accepted",
+    slice: nextSlice,
+    window: firstPage(window),
+    queryChanged: true,
+    windowChanged: window.page !== 1,
+  };
+}
+const commandRejection = (command: QueryMemberCommand): string | null => {
+  switch (command.kind) {
+    case "replacePredicate":
+      return predicateRejection(command.predicate);
+    case "removePredicate":
+      // Removal may address out-of-grammar predicates (for example one
+      // installed by an unvalidated adopt): it cleans up by exact address
+      // and cannot create a collision.
+      return null;
+    case "replaceSort":
+      return command.sort.some((term) => term.field === "")
+        ? "sort term field must not be empty"
+        : null;
+    case "setGroup":
+      return command.group === ""
+        ? "group must not be empty; use null to clear it"
+        : null;
+    default:
+      return null;
+  }
+};
+const applyToSlice = (slice: Slice, command: QueryMemberCommand): Slice => {
+  switch (command.kind) {
+    case "replacePredicate":
+      return replacePredicate(slice, command.predicate);
+    case "removePredicate": {
+      const address = predicateAddress(command.field, command.operator);
+      return {
+        ...slice,
+        filter: slice.filter.filter(
+          (predicate) =>
+            predicateAddress(predicate.field, predicate.operator) !== address,
+        ),
+      };
+    }
+    case "replaceSearch":
+      return {
+        ...slice,
+        search: command.search === "" ? null : command.search,
+      };
+    case "replaceSort":
+      return { ...slice, sort: [...command.sort] };
+    case "setGroup":
+      return { ...slice, group: command.group };
+  }
+};
+
+const rejected = (
+  slice: Slice,
+  window: ResultWindow,
+  reason: string,
+): QueryCommandResult => ({
+  status: "rejected",
+  reason,
+  slice,
+  window,
+});

--- a/packages/runtime/dataviews/src/lib/query/canonicalSlice.test.ts
+++ b/packages/runtime/dataviews/src/lib/query/canonicalSlice.test.ts
@@ -1,0 +1,177 @@
+import { describe, expect, it } from "vitest";
+import canonicalSlice from "./canonicalSlice.js";
+import type { Slice } from "./types.js";
+
+const slice = (overrides: Partial<Slice> = {}): Slice => ({
+  filter: [],
+  search: null,
+  sort: [],
+  group: null,
+  ...overrides,
+});
+
+describe("canonicalSlice", () => {
+  it("is idempotent", () => {
+    const input = slice({
+      filter: [
+        { field: "status", operator: "eq", operands: ["failed", "cancelled"] },
+      ],
+      sort: [
+        { field: "updated", direction: "desc" },
+        { field: "name", direction: "asc" },
+      ],
+    });
+    const once = canonicalSlice(input);
+    expect(canonicalSlice(once)).toEqual(once);
+  });
+
+  it("treats equality operands as a set regardless of order", () => {
+    const left = canonicalSlice(
+      slice({
+        filter: [
+          {
+            field: "status",
+            operator: "eq",
+            operands: ["failed", "cancelled"],
+          },
+        ],
+      }),
+    );
+    const right = canonicalSlice(
+      slice({
+        filter: [
+          {
+            field: "status",
+            operator: "eq",
+            operands: ["cancelled", "failed"],
+          },
+        ],
+      }),
+    );
+    expect(left).toEqual(right);
+  });
+
+  it("deduplicates repeated equality operands", () => {
+    const result = canonicalSlice(
+      slice({
+        filter: [
+          { field: "status", operator: "eq", operands: ["failed", "failed"] },
+        ],
+      }),
+    );
+    expect(result.filter[0]?.operands).toEqual(["failed"]);
+  });
+
+  it("keeps sort term order untouched", () => {
+    const input = slice({
+      sort: [
+        { field: "updated", direction: "desc" },
+        { field: "status", direction: "asc" },
+      ],
+    });
+    expect(canonicalSlice(input).sort).toEqual(input.sort);
+  });
+
+  it("collapses duplicate predicate addresses, keeping the last", () => {
+    const result = canonicalSlice(
+      slice({
+        filter: [
+          { field: "status", operator: "eq", operands: ["failed"] },
+          { field: "status", operator: "eq", operands: ["cancelled"] },
+        ],
+      }),
+    );
+    expect(result.filter).toEqual([
+      { field: "status", operator: "eq", operands: ["cancelled"] },
+    ]);
+  });
+
+  it("orders predicates by field then operator", () => {
+    const result = canonicalSlice(
+      slice({
+        filter: [
+          { field: "zone", operator: "eq", operands: ["north"] },
+          { field: "status", operator: "eq", operands: ["failed"] },
+          { field: "status", operator: "isSet", operands: [] },
+        ],
+      }),
+    );
+    expect(result.filter.map((predicate) => predicate.field)).toEqual([
+      "status",
+      "status",
+      "zone",
+    ]);
+    expect(result.filter.map((predicate) => predicate.operator)).toEqual([
+      "eq",
+      "isSet",
+      "eq",
+    ]);
+  });
+
+  it("treats an empty search as no search", () => {
+    expect(canonicalSlice(slice({ search: "" })).search).toBeNull();
+    expect(canonicalSlice(slice({ search: "yak" })).search).toBe("yak");
+  });
+
+  it("orders equality operands identically regardless of input order", () => {
+    // Distinct strings that locale collation may tie (é NFC vs e + combining
+    // acute) must still canonicalize to one deterministic order.
+    const left = canonicalSlice(
+      slice({
+        filter: [
+          { field: "owner", operator: "eq", operands: ["e\u0301", "é", "ed"] },
+        ],
+      }),
+    );
+    const right = canonicalSlice(
+      slice({
+        filter: [
+          { field: "owner", operator: "eq", operands: ["ed", "é", "e\u0301"] },
+        ],
+      }),
+    );
+    expect(left).toEqual(right);
+  });
+
+  it("keeps mixed-type operands distinct with a stable cross-type order", () => {
+    const result = canonicalSlice(
+      slice({
+        filter: [
+          {
+            field: "value",
+            operator: "eq",
+            operands: [1, "1", null, "null", true, "true"],
+          },
+        ],
+      }),
+    );
+    // The typeof tag keeps every operand distinct; nothing is deduped away.
+    expect(result.filter[0]?.operands).toHaveLength(6);
+    // Canonical order is total regardless of input order.
+    const reordered = canonicalSlice(
+      slice({
+        filter: [
+          {
+            field: "value",
+            operator: "eq",
+            operands: ["true", true, "null", null, "1", 1],
+          },
+        ],
+      }),
+    );
+    expect(reordered).toEqual(result);
+  });
+
+  it("keeps bound and zero-value operand shapes, ordered by address", () => {
+    const input = slice({
+      filter: [
+        { field: "updated", operator: "gte", operands: ["2026-01-01"] },
+        { field: "owner", operator: "isSet", operands: [] },
+      ],
+    });
+    expect(canonicalSlice(input).filter).toEqual([
+      { field: "owner", operator: "isSet", operands: [] },
+      { field: "updated", operator: "gte", operands: ["2026-01-01"] },
+    ]);
+  });
+});

--- a/packages/runtime/dataviews/src/lib/query/canonicalSlice.ts
+++ b/packages/runtime/dataviews/src/lib/query/canonicalSlice.ts
@@ -1,0 +1,82 @@
+import type {
+  Predicate,
+  PredicateOperand,
+  PredicateOperator,
+  Slice,
+} from "./types.js";
+
+/** Stable address of a predicate: its field and operator pair. */
+export const predicateAddress = (
+  field: string,
+  operator: PredicateOperator,
+): string => `${field}\u0000${operator}`;
+
+/**
+ * Total order over operand values: type tag first, then value within type.
+ * Plain code-point comparison, not locale collation, so canonical order is
+ * environment-stable and never ties on distinct strings.
+ */
+export const operandRankOf = (operand: PredicateOperand): string =>
+  `${typeof operand}:${String(operand)}`;
+
+/** Canonicalize one predicate: equality operands become an ordered set. */
+const canonicalPredicate = (predicate: Predicate): Predicate => {
+  if (predicate.operator !== "eq") {
+    return {
+      field: predicate.field,
+      operator: predicate.operator,
+      operands: [...predicate.operands],
+    };
+  }
+  const sorted = [...predicate.operands].sort((a, b) => {
+    const left = operandRankOf(a);
+    const right = operandRankOf(b);
+    return left < right ? -1 : left > right ? 1 : 0;
+  });
+  const operands: PredicateOperand[] = [];
+  for (const operand of sorted) {
+    const last = operands.at(-1);
+    if (last === undefined || operandRankOf(last) !== operandRankOf(operand)) {
+      operands.push(operand);
+    }
+  }
+  // Rebuild in a fixed key order so fingerprints are invariant under
+  // key-order respelling of the input.
+  return { field: predicate.field, operator: predicate.operator, operands };
+};
+
+/**
+ * Order predicates by address. Addresses are unique after collapse, so this
+ * strict comparison is a total order and never returns 0.
+ */
+const compareByAddress = (a: Predicate, b: Predicate): number =>
+  predicateAddress(a.field, a.operator) > predicateAddress(b.field, b.operator)
+    ? 1
+    : -1;
+
+/**
+ * Normalize a slice to its canonical form: equality operands are sets,
+ * predicates are ordered by address, sort terms keep their order, and an
+ * empty search is no search. Idempotent: `canonicalSlice(canonicalSlice(x))`
+ * equals `canonicalSlice(x)`.
+ */
+export default function canonicalSlice(slice: Slice): Slice {
+  const byAddress = new Map<string, Predicate>();
+  for (const predicate of slice.filter) {
+    byAddress.set(
+      predicateAddress(predicate.field, predicate.operator),
+      predicate,
+    );
+  }
+  return {
+    filter: [...byAddress.values()]
+      .map(canonicalPredicate)
+      .sort(compareByAddress),
+    search: slice.search === "" ? null : slice.search,
+    sort: slice.sort.map((term) => ({
+      field: term.field,
+      direction: term.direction,
+    })),
+    group: slice.group,
+  };
+}

--- a/packages/runtime/dataviews/src/lib/query/index.ts
+++ b/packages/runtime/dataviews/src/lib/query/index.ts
@@ -1,0 +1,3 @@
+export { default as canonicalSlice } from "./canonicalSlice.js";
+export { default as sliceEquals } from "./sliceEquals.js";
+export type * from "./types.js";

--- a/packages/runtime/dataviews/src/lib/query/sliceEquals.test.ts
+++ b/packages/runtime/dataviews/src/lib/query/sliceEquals.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it } from "vitest";
+import applyQueryCommand from "./applyQueryCommand.js";
+import sliceEquals from "./sliceEquals.js";
+import type { Slice } from "./types.js";
+
+const slice = (overrides: Partial<Slice> = {}): Slice => ({
+  filter: [],
+  search: null,
+  sort: [],
+  group: null,
+  ...overrides,
+});
+
+describe("sliceEquals", () => {
+  it("is true for identical slices", () => {
+    const value = slice({ search: "yak" });
+    expect(sliceEquals(value, slice({ search: "yak" }))).toBe(true);
+  });
+
+  it("is true when only equality operand order differs", () => {
+    const left = slice({
+      filter: [
+        { field: "status", operator: "eq", operands: ["failed", "cancelled"] },
+      ],
+    });
+    const right = slice({
+      filter: [
+        { field: "status", operator: "eq", operands: ["cancelled", "failed"] },
+      ],
+    });
+    expect(sliceEquals(left, right)).toBe(true);
+  });
+
+  it("is true when only predicate list order differs", () => {
+    const left = slice({
+      filter: [
+        { field: "status", operator: "eq", operands: ["failed"] },
+        { field: "zone", operator: "eq", operands: ["north"] },
+      ],
+    });
+    const right = slice({
+      filter: [
+        { field: "zone", operator: "eq", operands: ["north"] },
+        { field: "status", operator: "eq", operands: ["failed"] },
+      ],
+    });
+    expect(sliceEquals(left, right)).toBe(true);
+  });
+
+  it("is false when sort order differs", () => {
+    const left = slice({
+      sort: [
+        { field: "status", direction: "asc" },
+        { field: "updated", direction: "desc" },
+      ],
+    });
+    const right = slice({
+      sort: [
+        { field: "updated", direction: "desc" },
+        { field: "status", direction: "asc" },
+      ],
+    });
+    expect(sliceEquals(left, right)).toBe(false);
+  });
+
+  it("is false when sort direction differs", () => {
+    const left = slice({ sort: [{ field: "name", direction: "asc" }] });
+    const right = slice({ sort: [{ field: "name", direction: "desc" }] });
+    expect(sliceEquals(left, right)).toBe(false);
+  });
+
+  it("is false when an operand differs", () => {
+    const left = slice({
+      filter: [{ field: "status", operator: "eq", operands: ["failed"] }],
+    });
+    const right = slice({
+      filter: [{ field: "status", operator: "eq", operands: ["cancelled"] }],
+    });
+    expect(sliceEquals(left, right)).toBe(false);
+  });
+
+  it("is false when search or group differ", () => {
+    expect(sliceEquals(slice({ search: "yak" }), slice())).toBe(false);
+    expect(
+      sliceEquals(slice({ group: "status" }), slice({ group: "zone" })),
+    ).toBe(false);
+  });
+
+  it("treats an empty search as equal to no search", () => {
+    expect(sliceEquals(slice({ search: "" }), slice({ search: null }))).toBe(
+      true,
+    );
+  });
+
+  it("compares operands exactly as request fingerprints do", () => {
+    const withOperands = (operands: (string | number)[]) =>
+      slice({
+        filter: [{ field: "cpu", operator: "gte", operands }],
+      });
+    // The string "0" never equals the number 0.
+    expect(sliceEquals(withOperands([0]), withOperands(["0"]))).toBe(false);
+    // Negative zero and zero are the same value to a fingerprint.
+    expect(sliceEquals(withOperands([-0]), withOperands([0]))).toBe(true);
+    // NaN equals itself, exactly like the fingerprint marker.
+    expect(
+      sliceEquals(withOperands([Number.NaN]), withOperands([Number.NaN])),
+    ).toBe(true);
+  });
+
+  it("treats a negative-zero replacement as a semantic no-op", () => {
+    const base = slice({
+      filter: [{ field: "cpu", operator: "gte", operands: [0] }],
+    });
+    const result = applyQueryCommand(
+      base,
+      { page: 2, size: 50 },
+      {
+        kind: "replacePredicate",
+        predicate: { field: "cpu", operator: "gte", operands: [-0] },
+      },
+    );
+    if (result.status !== "accepted") {
+      throw new Error("expected acceptance");
+    }
+    expect(result.queryChanged).toBe(false);
+    expect(result.window.page).toBe(2);
+  });
+});

--- a/packages/runtime/dataviews/src/lib/query/sliceEquals.ts
+++ b/packages/runtime/dataviews/src/lib/query/sliceEquals.ts
@@ -1,0 +1,48 @@
+import canonicalSlice, { operandRankOf } from "./canonicalSlice.js";
+import type { Slice } from "./types.js";
+
+/**
+ * Operands are equal when their rank strings match, keeping slice equality
+ * exactly consistent with request fingerprints (NaN equals NaN; the string
+ * "0" never equals the number 0).
+ */
+const operandEquals = (
+  a: Slice["filter"][number]["operands"][number],
+  b: Slice["filter"][number]["operands"][number],
+): boolean => operandRankOf(a) === operandRankOf(b);
+
+const predicatesEqual = (a: Slice["filter"], b: Slice["filter"]): boolean =>
+  a.length === b.length &&
+  a.every((predicate, index) => {
+    const other = b[index];
+    return (
+      predicate.field === other.field &&
+      predicate.operator === other.operator &&
+      predicate.operands.length === other.operands.length &&
+      predicate.operands.every((operand, operandIndex) =>
+        operandEquals(operand, other.operands[operandIndex]),
+      )
+    );
+  });
+
+const sortsEqual = (a: Slice["sort"], b: Slice["sort"]): boolean =>
+  a.length === b.length &&
+  a.every(
+    (term, index) =>
+      term.field === b[index].field && term.direction === b[index].direction,
+  );
+
+/**
+ * Semantic slice equality: two slices are equal when their canonical forms
+ * match. Equality operand order does not matter; sort order always does.
+ */
+export default function sliceEquals(a: Slice, b: Slice): boolean {
+  const left = canonicalSlice(a);
+  const right = canonicalSlice(b);
+  return (
+    left.search === right.search &&
+    left.group === right.group &&
+    predicatesEqual(left.filter, right.filter) &&
+    sortsEqual(left.sort, right.sort)
+  );
+}

--- a/packages/runtime/dataviews/src/lib/query/types.ts
+++ b/packages/runtime/dataviews/src/lib/query/types.ts
@@ -1,0 +1,85 @@
+/**
+ * The bounded collection grammar: AND-ed filter predicates, text search,
+ * ordered sort terms and one grouping field.
+ */
+
+/** Bounded predicate operators. */
+export type PredicateOperator = "eq" | "gte" | "lte" | "isSet";
+
+/** A semantic operand value. Field metadata owns coercion; core never guesses. */
+export type PredicateOperand = string | number | boolean | null;
+
+/**
+ * One filter clause, addressed by its field and operator. `eq` operands are
+ * a non-empty set; `gte` and `lte` carry exactly one operand; `isSet`
+ * carries none. Numbers must be finite.
+ */
+export type Predicate = {
+  readonly field: string;
+  readonly operator: PredicateOperator;
+  readonly operands: readonly PredicateOperand[];
+};
+
+/** Sort direction of a single ordered term. */
+export type SortDirection = "asc" | "desc";
+
+/** One sort term; term order carries sort precedence and is never reordered. */
+export type SortTerm = {
+  readonly field: string;
+  readonly direction: SortDirection;
+};
+
+/**
+ * The applied collection query: filters, text search, ordering and grouping,
+ * independent of renderer presentation and the result window.
+ */
+export type Slice = {
+  readonly filter: readonly Predicate[];
+  readonly search: string | null;
+  readonly sort: readonly SortTerm[];
+  readonly group: string | null;
+};
+
+/** One-based offset over the result set. */
+export type ResultWindow = {
+  readonly page: number;
+  readonly size: number;
+};
+
+/** An addressed query command. `navigateWindow` addresses the window only. */
+export type QueryCommand =
+  | {
+      readonly kind: "replacePredicate";
+      readonly predicate: Predicate;
+    }
+  | {
+      readonly kind: "removePredicate";
+      readonly field: string;
+      readonly operator: PredicateOperator;
+    }
+  | { readonly kind: "replaceSearch"; readonly search: string }
+  | { readonly kind: "replaceSort"; readonly sort: readonly SortTerm[] }
+  | { readonly kind: "setGroup"; readonly group: string | null }
+  | {
+      readonly kind: "navigateWindow";
+      readonly page?: number;
+      readonly size?: number;
+    };
+
+/** Outcome of applying a query command: accepted change or explicit rejection. */
+export type QueryCommandResult =
+  | {
+      readonly status: "accepted";
+      readonly slice: Slice;
+      readonly window: ResultWindow;
+      /** True when the semantic query changed (dirty comparisons, history). */
+      readonly queryChanged: boolean;
+      /** True when the result window changed (window is part of request identity). */
+      readonly windowChanged: boolean;
+    }
+  | {
+      readonly status: "rejected";
+      readonly reason: string;
+      readonly slice: Slice;
+      readonly window: ResultWindow;
+    };


### PR DESCRIPTION
## Done

- Adds the framework-neutral transition layer to `@canonical/dataviews-core`: the bounded query grammar with addressed commands, field-interaction, operation and save-race records, and the collection coordinator that owns query/window coherence and the request lifecycle.
- Public surface: `canonicalSlice`/`sliceEquals` (semantic equality — equality operands are sets, sort order never reorders), `createFieldInteraction`, `createOperation`, `createCollectionCoordinator`, `createSaveSession`, plus the identity tokens from the scaffold PR. `applyQueryCommand` and the address helper stay internal: commands flow through the coordinator.
- The stage-one counterexample suite is the product of this PR and pins the load-bearing behaviors:
  - **Invalid retention**: invalid and incomplete edits retain the applied predicate with distinguishable feedback; explicit removal is a different transition.
  - **Stale completions**: superseded requests, rotated scopes, disposed coordinators and duplicate deliveries never publish; each request publishes at most once; rows/provenance/count publish together.
  - **Captured targets**: operations capture targets and the selection revision immutably at construction; later selection changes never retarget execution; retry re-runs only failed targets under the same identity; a target settles at most once per attempt.
  - **Save races**: a completion updates only the submitted baseline (edits while saving stay dirty); attempt tokens make completions one-shot across retries; delayed external reads never overwrite newer local state or an in-flight save.
  - **Window coherence**: a query change resets the page; semantically unchanged edits (including operand reorder, key-order respelling and -0/0) issue no request; window-only changes issue one; `adopt` ingests externally authoritative state (back/forward, restored views) and supersedes pending requests.
- Design notes: all machines serve cached, referentially-stable snapshots rebuilt only at mutation sites (safe for `useSyncExternalStore`-style reads); request identities are instance-unique so mis-routed completions mismatch loudly; caller-supplied slices/windows are defensively deep-copied; non-finite operands get a collision-free fingerprint marker; the grammar validation (empty/NUL fields, exact operator arities, finite numbers, positive-integer windows) rejects with reasons.

Stacked on #1194 (the scaffold PR) — merge that first; this PR's base is that branch.

## QA

- `bun run check` green at the root (biome + tsc + webarchitect for the package).
- `vitest run --coverage` in the package: 140/140 tests, 100% branch/function/line/statement coverage (coverage rides the package's standard `test` target).
- `tsc -p tsconfig.build.json` emits declarations cleanly.
- `nx affected -t test`: `@canonical/dataviews-core` green; two svelte browser-mode packages fail on this host only because Playwright OS dependencies are absent (`sudo npx playwright install-deps` — not installable here); CI runners carry them and are unaffected by this diff.

### PR readiness check

- [x] PR title follows the Conventional Commits format.
- [x] The code follows the appropriate code standards.
- [x] The package defines `check`, `check:fix`, `test`, `build`, `build:all`.
- [x] No visual surface — Chromatic: skip label applied.

Chromatic: skip