### PR TITLE
feat(dataviews): schema inference, observation channels and window projection

### DIFF
--- a/packages/runtime/dataviews/README.md
+++ b/packages/runtime/dataviews/README.md
@@ -1,6 +1,6 @@
 # @canonical/dataviews-core
 
-Framework-agnostic core for Canonical collection views. It holds the bounded query grammar and addressed commands, the field/operation/save-race interaction records, and the collection coordinator that owns query/window coherence and the request lifecycle — logic, never markup. Framework bindings, URL transport and data-source adapters are wired above this layer.
+Framework-agnostic core for Canonical collection views. It holds the bounded query grammar with its window projection, the schema layer — field definitions with inferred types and enforced semantics — observation channels and explicit-ID selection, the field/operation/save-race interaction records, and the collection coordinator that owns query/window coherence and the request lifecycle. Logic, never markup; framework bindings, URL transport and data-source adapters are wired above this layer.
 
 > **Stability: pre-1.0 / experimental.** The API is still consolidating and breaking changes may land between minor versions. Every breaking change ships with a conventional-commit subject and a CHANGELOG entry — those are the migration record. Pin a minor version if you need stability today.
 
@@ -12,10 +12,12 @@ bun add @canonical/dataviews-core
 
 ## Status
 
-Under active development; the public surface grows change by change. The current runtime exports are `createIdentity`, `isIdentity`, `canonicalSlice`, `sliceEquals`, `createFieldInteraction`, `createOperation`, `createCollectionCoordinator` and `createSaveSession`, together with their config, state, result and grammar types (`Slice`, `ResultWindow`, `QueryCommand`, `CompletionResult` and friends re-exported from the package root):
+Under active development; the public surface grows change by change. The current runtime exports are `createIdentity`, `isIdentity`, `canonicalSlice`, `sliceEquals`, `applyWindow`, `createSchema`, `createChannel`, `createSelection`, `createFieldInteraction`, `createOperation`, `createCollectionCoordinator` and `createSaveSession`, together with their config, state, result, grammar and schema types (`Slice`, `ResultWindow`, `QueryCommand`, `CompletionResult`, `Schema`, `Channel`, `Selection` and friends re-exported from the package root):
 
 - **Identity tokens** — `createIdentity`, `isIdentity`: referential scope markers; structural copies and forged-key look-alikes are rejected.
-- **Query grammar** — `Slice`/`ResultWindow` types, `canonicalSlice` (equality operands are sets, sort order is never reordered, empty search is no search), `sliceEquals` for semantic equality.
+- **Query grammar** — `Slice`/`ResultWindow` types, `canonicalSlice` (equality operands are sets, sort order is never reordered, empty search is no search), `sliceEquals` for semantic equality, `applyWindow` for the displayed-window projection.
+- **Schema** — `createSchema`: the one coherent construction path; field kinds (`choices`, `number`, `flag`, `date`) decide legal operators and inferred applied types; buffers and direct operands are validated against option membership, numeric range and ISO-8601 dates.
+- **Observation** — `createChannel`: observation channels with equality-guarded notification; the caller keys one channel per state category; `createSelection`: explicit record identities with a valid empty state.
 - **Field interaction** — `createFieldInteraction`: input buffer and feedback for one filter field; invalid or incomplete edits retain the applied predicate; explicit `clear` is distinct from invalid input.
 - **Operation record** — `createOperation`: captures targets and selection revision immutably at construction so later selection changes never retarget execution; partial outcomes settle each target once; retry re-runs only failed targets.
 - **Collection coordinator** — `createCollectionCoordinator`: addressed commands as coherent query+window transitions (a query change resets the page), request identities whose stale completions are ignored, atomic publication of rows/provenance/count, scope rotation, and `adopt` for externally authoritative state such as back/forward navigation.

--- a/packages/runtime/dataviews/package.json
+++ b/packages/runtime/dataviews/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@canonical/dataviews-core",
-  "description": "Framework-agnostic collection-views core for Canonical apps: query grammar, lifecycle transition records, and the request-lifecycle coordinator",
+  "description": "Framework-agnostic collection-views core for Canonical apps: query grammar, schema-enforced field validation, observation channels, selection and window projection, lifecycle transition records, and the request-lifecycle coordinator",
   "version": "0.37.0",
   "type": "module",
   "module": "dist/esm/index.js",

--- a/packages/runtime/dataviews/src/index.test.ts
+++ b/packages/runtime/dataviews/src/index.test.ts
@@ -4,12 +4,16 @@ import * as dataviews from "./index.js";
 describe("public surface", () => {
   it("exports exactly the public API", () => {
     expect(Object.keys(dataviews).sort()).toEqual([
+      "applyWindow",
       "canonicalSlice",
+      "createChannel",
       "createCollectionCoordinator",
       "createFieldInteraction",
       "createIdentity",
       "createOperation",
       "createSaveSession",
+      "createSchema",
+      "createSelection",
       "isIdentity",
       "sliceEquals",
     ]);
@@ -21,25 +25,10 @@ describe("public surface", () => {
       "idle",
     );
     expect(
-      dataviews.createSaveSession({
-        initial: 0,
-        equals: (a: number, b: number) => a === b,
-      }).state.dirty,
-    ).toBe(false);
-  });
-
-  it("keeps save attempts one-shot", () => {
-    const save = dataviews.createSaveSession({
-      initial: 0,
-      equals: (a: number, b: number) => a === b,
-    });
-    save.edit(1);
-    const attempt = save.beginSave();
-    if (attempt === null) {
-      throw new Error("expected a save attempt");
-    }
-    save.saveCompleted(attempt);
-    save.saveCompleted(attempt);
-    expect(save.state.baseline).toBe(1);
+      dataviews.createSchema([{ field: "owner", kind: "flag" }]).fieldNames,
+    ).toEqual(["owner"]);
+    expect(dataviews.createChannel(0).get()).toBe(0);
+    expect(dataviews.createSelection().state.ids.size).toBe(0);
+    expect(dataviews.applyWindow(["a"], { page: 1, size: 10 })).toEqual(["a"]);
   });
 });

--- a/packages/runtime/dataviews/src/index.ts
+++ b/packages/runtime/dataviews/src/index.ts
@@ -1,10 +1,12 @@
 /**
  * @canonical/dataviews-core — collection-views core for Canonical apps:
  * runtime identity tokens, the bounded query grammar with addressed
- * commands, field interaction, operation and save-race records, and the
- * collection coordinator owning query/window coherence and the request
- * lifecycle. React/Svelte bindings, URL transport and adapters are wired
- * above this layer.
+ * commands and window projection, field interaction, operation and
+ * save-race records, the collection coordinator owning query/window
+ * coherence and the request lifecycle, and the schema/observation layer —
+ * field definitions with inferred types and enforced semantics,
+ * observation channels and explicit-ID selection. React/Svelte bindings,
+ * URL transport and adapters are wired above this layer.
  *
  * @packageDocumentation
  */

--- a/packages/runtime/dataviews/src/index.types.test.ts
+++ b/packages/runtime/dataviews/src/index.types.test.ts
@@ -8,17 +8,24 @@
 
 import { describe, expectTypeOf, it } from "vitest";
 import type {
+  AppliedOf,
+  Channel,
+  ChannelConfig,
+  ChoicesField,
   CollectionCoordinator,
   CollectionCoordinatorConfig,
   CollectionCoordinatorState,
   CompletionResult,
+  DateField,
   DispatchResult,
   FieldFeedback,
   FieldInteraction,
   FieldInteractionConfig,
   FieldInteractionState,
   FieldValidation,
+  FlagField,
   Identity,
+  NumberField,
   Operation,
   OperationConfig,
   OperationFailure,
@@ -36,6 +43,12 @@ import type {
   SaveSession,
   SaveSessionConfig,
   SaveSessionState,
+  Schema,
+  SchemaFieldDefinition,
+  SchemaFields,
+  SchemaPredicateResult,
+  Selection,
+  SelectionState,
   Slice,
   SortDirection,
   SortTerm,
@@ -44,17 +57,24 @@ import * as dataviews from "./index.js";
 
 /** Every type the package root re-exports, as one enumerable tuple. */
 type EveryPublicType = [
+  AppliedOf<FlagField>,
+  Channel<unknown>,
+  ChannelConfig<unknown>,
+  ChoicesField,
   CollectionCoordinator,
   CollectionCoordinatorConfig,
   CollectionCoordinatorState,
   CompletionResult,
+  DateField,
   DispatchResult,
   FieldFeedback,
   FieldInteraction,
   FieldInteractionConfig,
   FieldInteractionState,
   FieldValidation,
+  FlagField,
   Identity,
+  NumberField,
   Operation,
   OperationConfig,
   OperationFailure,
@@ -72,6 +92,12 @@ type EveryPublicType = [
   SaveSession<unknown>,
   SaveSessionConfig<unknown>,
   SaveSessionState<unknown>,
+  Schema<readonly SchemaFieldDefinition[]>,
+  SchemaFieldDefinition,
+  SchemaFields<readonly SchemaFieldDefinition[]>,
+  SchemaPredicateResult,
+  Selection,
+  SelectionState,
   Slice,
   SortDirection,
   SortTerm,
@@ -80,7 +106,7 @@ type EveryPublicType = [
 describe("public surface types", () => {
   it("re-exports the full type surface from the barrel", () => {
     expectTypeOf<EveryPublicType>().not.toBeAny();
-    expectTypeOf<EveryPublicType["length"]>().toEqualTypeOf<31>();
+    expectTypeOf<EveryPublicType["length"]>().toEqualTypeOf<44>();
   });
 
   it("exports the identity functions with the declared shapes", () => {
@@ -133,5 +159,19 @@ describe("public surface types", () => {
       "success" | "failure"
     >();
     expectTypeOf<ResultWindow["page"]>().toEqualTypeOf<number>();
+  });
+
+  it("infers applied types from one schema construction", () => {
+    const machines = dataviews.createSchema([
+      { field: "status", kind: "choices", options: ["failed", "cancelled"] },
+      { field: "cpu", kind: "number" },
+      { field: "owner", kind: "flag" },
+    ]);
+    type Machines = SchemaFields<typeof machines.fields>;
+    expectTypeOf<Machines["status"]>().toEqualTypeOf<
+      ReadonlySet<"failed" | "cancelled">
+    >();
+    expectTypeOf<Machines["cpu"]>().toEqualTypeOf<number>();
+    expectTypeOf<Machines["owner"]>().toEqualTypeOf<boolean>();
   });
 });

--- a/packages/runtime/dataviews/src/lib/collection/createCollectionCoordinator.test.ts
+++ b/packages/runtime/dataviews/src/lib/collection/createCollectionCoordinator.test.ts
@@ -538,6 +538,22 @@ describe("createCollectionCoordinator", () => {
     expect(coordinator.state.result.rows).toBeNull();
   });
 
+  it("rejects invalid seed and adopted windows at intake", () => {
+    expect(() =>
+      createCollectionCoordinator({ window: { page: 0, size: 25 } }),
+    ).toThrow("page must be a positive integer");
+    expect(() =>
+      createCollectionCoordinator({ window: { page: 2, size: 0 } }),
+    ).toThrow("size must be a positive integer");
+    const coordinator = createCollectionCoordinator();
+    expect(() => coordinator.adopt(slice(), { page: -1, size: 25 })).toThrow(
+      "page must be a positive integer",
+    );
+    expect(() => coordinator.adopt(slice(), { page: 1, size: 1.5 })).toThrow(
+      "size must be a positive integer",
+    );
+  });
+
   it("keeps the configured seed immune to caller mutations", () => {
     const seed = slice({
       filter: [statusPredicate("failed")],

--- a/packages/runtime/dataviews/src/lib/collection/createCollectionCoordinator.ts
+++ b/packages/runtime/dataviews/src/lib/collection/createCollectionCoordinator.ts
@@ -85,9 +85,11 @@ export type CollectionCoordinator = {
   readonly refresh: () => string | null;
   /**
    * Adopt an externally authoritative slice and window together, as on
-   * back/forward navigation or a restored view. Supersedes any pending
-   * request, discards stale input sessions above this layer, and returns a
-   * request identity when the adopted state differs from the current one.
+   * back/forward navigation or a restored view. Invalid windows throw, the
+   * same rejections the addressed command layer applies. Supersedes any
+   * pending request, discards stale input sessions above this layer, and
+   * returns a request identity when the adopted state differs from the
+   * current one.
    */
   readonly adopt: (slice: Slice, window: ResultWindow) => string | null;
   /**
@@ -162,8 +164,15 @@ const copySlice = (slice: Slice): Slice =>
     group: slice.group,
   });
 
-const copyWindow = (window: ResultWindow): ResultWindow =>
-  Object.freeze({ page: window.page, size: window.size });
+const copyWindow = (window: ResultWindow): ResultWindow => {
+  if (!Number.isInteger(window.page) || window.page < 1) {
+    throw new Error("page must be a positive integer");
+  }
+  if (!Number.isInteger(window.size) || window.size < 1) {
+    throw new Error("size must be a positive integer");
+  }
+  return Object.freeze({ page: window.page, size: window.size });
+};
 
 /**
  * Create the collection coordinator: one owner of query/window coherence
@@ -177,10 +186,9 @@ export default function createCollectionCoordinator(
 ): CollectionCoordinator {
   const seedSlice =
     config.slice === undefined ? emptySlice : copySlice(config.slice);
-  const seedWindow = Object.freeze({
-    page: config.window?.page ?? defaultWindow.page,
-    size: config.window?.size ?? defaultWindow.size,
-  });
+  const seedWindow = copyWindow(
+    config.window === undefined ? defaultWindow : config.window,
+  );
 
   let scope = createIdentity();
   // Instance-unique request ids: a completion routed to the wrong

--- a/packages/runtime/dataviews/src/lib/index.ts
+++ b/packages/runtime/dataviews/src/lib/index.ts
@@ -3,5 +3,8 @@ export type { Identity } from "./createIdentity.js";
 export { default as createIdentity } from "./createIdentity.js";
 export * from "./field/index.js";
 export { default as isIdentity } from "./isIdentity.js";
+export * from "./observable/index.js";
 export * from "./operation/index.js";
 export * from "./query/index.js";
+export * from "./schema/index.js";
+export * from "./selection/index.js";

--- a/packages/runtime/dataviews/src/lib/observable/createChannel.test.ts
+++ b/packages/runtime/dataviews/src/lib/observable/createChannel.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it } from "vitest";
+import createChannel from "./createChannel.js";
+
+describe("createChannel", () => {
+  it("holds the initial snapshot until a set", () => {
+    const channel = createChannel(1);
+    expect(channel.get()).toBe(1);
+  });
+
+  it("notifies subscribers on set, in subscription order", () => {
+    const channel = createChannel(0);
+    const calls: string[] = [];
+    channel.subscribe(() => calls.push("first"));
+    channel.subscribe(() => calls.push("second"));
+    channel.set(1);
+    expect(calls).toEqual(["first", "second"]);
+    expect(channel.get()).toBe(1);
+  });
+
+  it("makes the new value readable during its own notification", () => {
+    const channel = createChannel(0);
+    const observed: number[] = [];
+    channel.subscribe(() => observed.push(channel.get()));
+    channel.set(42);
+    expect(observed).toEqual([42]);
+  });
+
+  it("keeps the previous reference when a set is equality-rejected", () => {
+    const channel = createChannel(
+      { value: 1 },
+      {
+        equals: (a, b) => a.value === b.value,
+      },
+    );
+    const before = channel.get();
+    channel.set({ value: 1 });
+    expect(channel.get()).toBe(before);
+  });
+
+  it("skips notification when the equality guard says unchanged", () => {
+    const channel = createChannel(
+      { value: 1 },
+      {
+        equals: (a, b) => a.value === b.value,
+      },
+    );
+    let notifications = 0;
+    channel.subscribe(() => {
+      notifications += 1;
+    });
+    expect(channel.set({ value: 1 })).toBe(false);
+    expect(notifications).toBe(0);
+    expect(channel.set({ value: 2 })).toBe(true);
+    expect(notifications).toBe(1);
+  });
+
+  it("uses reference equality by default", () => {
+    const channel = createChannel({ value: 1 });
+    let notifications = 0;
+    channel.subscribe(() => {
+      notifications += 1;
+    });
+    expect(channel.set({ value: 1 })).toBe(true);
+    expect(notifications).toBe(1);
+  });
+
+  it("unsubscribes through the returned function", () => {
+    const channel = createChannel(0);
+    let notifications = 0;
+    const unsubscribe = channel.subscribe(() => {
+      notifications += 1;
+    });
+    channel.set(1);
+    unsubscribe();
+    channel.set(2);
+    expect(notifications).toBe(1);
+  });
+
+  it("supports unsubscribing from inside a notification", () => {
+    const channel = createChannel(0);
+    const calls: number[] = [];
+    const unsubscribe = channel.subscribe(() => {
+      calls.push(1);
+      unsubscribe();
+    });
+    channel.subscribe(() => calls.push(2));
+    channel.set(1);
+    channel.set(2);
+    expect(calls).toEqual([1, 2, 2]);
+  });
+
+  it("still delivers to a later listener unsubscribed mid-notification", () => {
+    const channel = createChannel(0);
+    const calls: string[] = [];
+    let unsubscribeLate: () => void = () => {};
+    channel.subscribe(() => {
+      calls.push("first");
+      unsubscribeLate();
+    });
+    unsubscribeLate = channel.subscribe(() => calls.push("late"));
+    // The first listener unsubscribes the late one during a notification;
+    // the snapshot iteration still delivers to it that round.
+    channel.set(1);
+    expect(calls).toEqual(["first", "late"]);
+    calls.length = 0;
+    channel.set(2);
+    expect(calls).toEqual(["first"]);
+  });
+
+  it("does not deliver to a listener subscribed during a notification", () => {
+    const channel = createChannel(0);
+    const calls: string[] = [];
+    channel.subscribe(() => {
+      calls.push("existing");
+      channel.subscribe(() => calls.push("late-addition"));
+    });
+    channel.set(1);
+    // The snapshot was taken before the new subscription existed.
+    expect(calls).toEqual(["existing"]);
+    channel.set(2);
+    expect(calls).toEqual(["existing", "existing", "late-addition"]);
+  });
+
+  it("propagates listener exceptions to the publisher", () => {
+    const channel = createChannel(0);
+    channel.subscribe(() => {
+      throw new Error("listener exploded");
+    });
+    expect(() => channel.set(1)).toThrow("listener exploded");
+    // The new value is committed even though publication aborted.
+    expect(channel.get()).toBe(1);
+  });
+
+  it("keeps the snapshot referentially stable between sets", () => {
+    const channel = createChannel(0);
+    channel.set(1);
+    expect(channel.get()).toBe(channel.get());
+  });
+});

--- a/packages/runtime/dataviews/src/lib/observable/createChannel.ts
+++ b/packages/runtime/dataviews/src/lib/observable/createChannel.ts
@@ -1,0 +1,67 @@
+/**
+ * One observation channel: the smallest observable unit a binding
+ * subscribes to. Keying — one channel per state category — is the wiring
+ * discipline of the layer above, so a notification reaches only the
+ * consumers of that category.
+ */
+
+/** Configuration of one channel. */
+export type ChannelConfig<T> = {
+  /** Equality guard: a set that equals the current value notifies nobody. */
+  readonly equals?: (a: T, b: T) => boolean;
+};
+
+/** Handle of one observation channel. */
+export type Channel<T> = {
+  /** The current snapshot; referentially stable between sets. Values are
+   * caller-owned: pass immutable snapshots, since the same reference is
+   * handed back out. */
+  readonly get: () => T;
+  /**
+   * Publish the next snapshot. Returns false and notifies nobody when the
+   * equality guard says the value did not change; the current reference is
+   * kept in that case. Listeners are invoked over a snapshot of the
+   * subscription set, in subscription order, after the new value is
+   * readable; a listener that throws aborts the remaining publication and
+   * the exception propagates to the publisher.
+   */
+  readonly set: (next: T) => boolean;
+  /** Subscribe to later publications; the return value unsubscribes. The
+   * subscription set is a set: subscribing one function twice registers it
+   * once, and either unsubscribe removes the sole registration. */
+  readonly subscribe: (listener: () => void) => () => void;
+};
+
+const strictEquals = <T>(a: T, b: T): boolean => a === b;
+
+/**
+ * Create an observation channel.
+ */
+export default function createChannel<T>(
+  initial: T,
+  config: ChannelConfig<T> = {},
+): Channel<T> {
+  const equals = config.equals ?? strictEquals;
+  const listeners = new Set<() => void>();
+  let current = initial;
+
+  return {
+    get: () => current,
+    set(next: T): boolean {
+      if (equals(current, next)) {
+        return false;
+      }
+      current = next;
+      for (const listener of [...listeners]) {
+        listener();
+      }
+      return true;
+    },
+    subscribe(listener: () => void): () => void {
+      listeners.add(listener);
+      return () => {
+        listeners.delete(listener);
+      };
+    },
+  };
+}

--- a/packages/runtime/dataviews/src/lib/observable/index.ts
+++ b/packages/runtime/dataviews/src/lib/observable/index.ts
@@ -1,0 +1,2 @@
+export type { Channel, ChannelConfig } from "./createChannel.js";
+export { default as createChannel } from "./createChannel.js";

--- a/packages/runtime/dataviews/src/lib/query/applyQueryCommand.test.ts
+++ b/packages/runtime/dataviews/src/lib/query/applyQueryCommand.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import applyQueryCommand from "./applyQueryCommand.js";
-import type { ResultWindow, Slice } from "./types.js";
+import type { Predicate, ResultWindow, Slice } from "./types.js";
 
 const slice = (overrides: Partial<Slice> = {}): Slice => ({
   filter: [],
@@ -316,6 +316,18 @@ describe("applyQueryCommand", () => {
       operator: "eq",
     });
     expect(removal.status).toBe("accepted");
+  });
+
+  it("rejects a predicate with an unknown operator without losing the reason", () => {
+    const forged = {
+      kind: "replacePredicate",
+      predicate: { field: "status", operator: "contains", operands: ["x"] },
+    } as unknown as { kind: "replacePredicate"; predicate: Predicate };
+    const result = applyQueryCommand(slice(), window(), forged);
+    if (result.status !== "rejected") {
+      throw new Error("expected rejection");
+    }
+    expect(result.reason).toBe("unknown predicate operator contains");
   });
 
   it("keeps state unchanged on rejection", () => {

--- a/packages/runtime/dataviews/src/lib/query/applyQueryCommand.ts
+++ b/packages/runtime/dataviews/src/lib/query/applyQueryCommand.ts
@@ -40,6 +40,8 @@ const predicateRejection = (predicate: Predicate): string | null => {
       return predicate.operands.length === 0
         ? null
         : "isSet predicate takes no operands";
+    default:
+      return `unknown predicate operator ${String(predicate.operator)}`;
   }
 };
 

--- a/packages/runtime/dataviews/src/lib/query/applyWindow.test.ts
+++ b/packages/runtime/dataviews/src/lib/query/applyWindow.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+import applyWindow from "./applyWindow.js";
+
+const rows = ["a", "b", "c", "d", "e", "f", "g"];
+
+describe("applyWindow", () => {
+  it("projects the first page from the start", () => {
+    expect(applyWindow(rows, { page: 1, size: 3 })).toEqual(["a", "b", "c"]);
+  });
+
+  it("projects interior pages with offsets", () => {
+    expect(applyWindow(rows, { page: 2, size: 3 })).toEqual(["d", "e", "f"]);
+    expect(applyWindow(rows, { page: 3, size: 3 })).toEqual(["g"]);
+  });
+
+  it("returns an empty window past the end", () => {
+    expect(applyWindow(rows, { page: 4, size: 3 })).toEqual([]);
+    expect(applyWindow(rows, { page: 9, size: 3 })).toEqual([]);
+  });
+
+  it("handles a window larger than the result set", () => {
+    expect(applyWindow(rows, { page: 1, size: 50 })).toEqual(rows);
+    expect(applyWindow(rows, { page: 2, size: 50 })).toEqual([]);
+  });
+
+  it("returns a fresh array, never the input", () => {
+    const result = applyWindow(rows, { page: 1, size: 50 });
+    expect(result).toEqual(rows);
+    expect(result).not.toBe(rows);
+  });
+
+  it("never mutates the input rows", () => {
+    const input = ["a", "b", "c"];
+    applyWindow(input, { page: 1, size: 2 });
+    expect(input).toEqual(["a", "b", "c"]);
+  });
+
+  it("rejects invalid windows like the addressed command layer", () => {
+    for (const window of [
+      { page: 0, size: 3 },
+      { page: -1, size: 3 },
+      { page: 1.5, size: 3 },
+      { page: 1, size: 0 },
+      { page: 1, size: -5 },
+      { page: 1, size: 2.5 },
+    ]) {
+      expect(() => applyWindow(rows, window)).toThrow(
+        /must be a positive integer/,
+      );
+    }
+  });
+
+  it("projects an empty result set to an empty window", () => {
+    expect(applyWindow([], { page: 1, size: 10 })).toEqual([]);
+  });
+});

--- a/packages/runtime/dataviews/src/lib/query/applyWindow.ts
+++ b/packages/runtime/dataviews/src/lib/query/applyWindow.ts
@@ -1,0 +1,25 @@
+import type { ResultWindow } from "./types.js";
+
+/**
+ * Project the explicitly displayed window out of a full result set:
+ * rows `(page - 1) * size` through `page * size`, one-based pages. The
+ * returned array is a fresh copy; the input is never sliced in place.
+ * Invalid windows (non-positive or fractional pages and sizes) throw, the
+ * same rejections the addressed command layer applies.
+ */
+export default function applyWindow<T>(
+  rows: readonly T[],
+  window: ResultWindow,
+): T[] {
+  if (!Number.isInteger(window.page) || window.page < 1) {
+    throw new Error("page must be a positive integer");
+  }
+  if (!Number.isInteger(window.size) || window.size < 1) {
+    throw new Error("size must be a positive integer");
+  }
+  const start = (window.page - 1) * window.size;
+  if (start >= rows.length) {
+    return [];
+  }
+  return rows.slice(start, start + window.size);
+}

--- a/packages/runtime/dataviews/src/lib/query/index.ts
+++ b/packages/runtime/dataviews/src/lib/query/index.ts
@@ -1,3 +1,4 @@
+export { default as applyWindow } from "./applyWindow.js";
 export { default as canonicalSlice } from "./canonicalSlice.js";
 export { default as sliceEquals } from "./sliceEquals.js";
 export type * from "./types.js";

--- a/packages/runtime/dataviews/src/lib/schema/createSchema.test.ts
+++ b/packages/runtime/dataviews/src/lib/schema/createSchema.test.ts
@@ -1,0 +1,435 @@
+import { describe, expect, it } from "vitest";
+import createSchema from "./createSchema.js";
+
+const schema = createSchema([
+  { field: "status", kind: "choices", options: ["failed", "cancelled"] },
+  { field: "cpu", kind: "number", min: 0, max: 64 },
+  { field: "memory", kind: "number" },
+  { field: "owner", kind: "flag" },
+  { field: "updated", kind: "date" },
+]);
+
+describe("createSchema", () => {
+  it("rejects empty, NUL and duplicate field names at construction", () => {
+    expect(() => createSchema([{ field: "", kind: "flag" }])).toThrow(
+      "non-empty",
+    );
+    expect(() => createSchema([{ field: "a\u0000b", kind: "flag" }])).toThrow(
+      "NUL",
+    );
+    expect(() =>
+      createSchema([
+        { field: "zone", kind: "flag" },
+        { field: "zone", kind: "flag" },
+      ]),
+    ).toThrow("duplicate");
+    expect(() =>
+      createSchema([
+        { field: "zone", kind: "choices", options: ["north"] },
+        { field: "zone", kind: "flag" },
+      ]),
+    ).toThrow("duplicate");
+  });
+
+  it("rejects choices fields without options, non-finite options or colliding options", () => {
+    expect(() =>
+      createSchema([{ field: "status", kind: "choices", options: [] }]),
+    ).toThrow("at least one option");
+    expect(() =>
+      createSchema([{ field: "value", kind: "choices", options: [1, "1"] }]),
+    ).toThrow("colliding string forms");
+    expect(() =>
+      createSchema([
+        {
+          field: "value",
+          kind: "choices",
+          options: [Number.NaN, 2],
+        },
+      ]),
+    ).toThrow("finite number options");
+    expect(() =>
+      createSchema([
+        { field: "value", kind: "choices", options: [Number.NaN] },
+      ]),
+    ).toThrow("finite number options");
+  });
+
+  it("freezes its field list against caller mutations", () => {
+    const schema = createSchema([
+      { field: "status", kind: "choices", options: ["failed"] },
+    ]);
+    const stored = schema.fields as unknown as { push: () => void };
+    expect(() => stored.push()).toThrow();
+  });
+
+  it("rejects number fields with non-finite or inverted bounds", () => {
+    expect(() =>
+      createSchema([{ field: "cpu", kind: "number", min: Number.NaN }]),
+    ).toThrow("finite bounds");
+    expect(() =>
+      createSchema([
+        { field: "cpu", kind: "number", max: Number.POSITIVE_INFINITY },
+      ]),
+    ).toThrow("finite bounds");
+    expect(() =>
+      createSchema([{ field: "cpu", kind: "number", min: 10, max: 0 }]),
+    ).toThrow("inverted range");
+  });
+
+  it("answers lookups from frozen copies, immune to input mutation", () => {
+    const options = ["failed"];
+    const input = [{ field: "status", kind: "choices" as const, options }];
+    const schema = createSchema(input);
+    const numeric = { field: "cpu", kind: "number" as const, min: 0, max: 5 };
+    const withBounds = createSchema([numeric]);
+    // Caller mutations of the originals change nothing: "deployed" stays a
+    // non-option, and the bound copy keeps min 0 / max 5 despite the edit.
+    (options as string[]).push("deployed");
+    (numeric as { max: number }).max = 10;
+    expect(schema.predicateFor("status", "eq", ["deployed"])).toEqual({
+      status: "invalid",
+      reason: '"deployed" is not an option of "status"',
+    });
+    expect(withBounds.predicateFor("cpu", "gte", [4])).toEqual({
+      status: "valid",
+      predicate: { field: "cpu", operator: "gte", operands: [4] },
+    });
+    expect(withBounds.predicateFor("cpu", "gte", [7])).toEqual({
+      status: "invalid",
+      reason: "7 is above the maximum of 5",
+    });
+  });
+
+  it("lists field names in definition order and answers membership", () => {
+    expect(schema.fieldNames).toEqual([
+      "status",
+      "cpu",
+      "memory",
+      "owner",
+      "updated",
+    ]);
+    expect(schema.hasField("cpu")).toBe(true);
+    expect(schema.hasField("zone")).toBe(false);
+    expect(() =>
+      (schema.fieldNames as unknown as { push: () => void }).push(),
+    ).toThrow();
+  });
+
+  it("validates a choices buffer against the option set", () => {
+    expect(schema.validateBuffer("status", "failed")).toEqual({
+      status: "valid",
+      operands: ["failed"],
+    });
+    expect(schema.validateBuffer("status", "deployed")).toEqual({
+      status: "invalid",
+      reason: '"deployed" is not an option of "status"',
+    });
+    expect(schema.validateBuffer("status", " failed ")).toEqual({
+      status: "invalid",
+      reason: '" failed " is not an option of "status"',
+    });
+    expect(schema.validateBuffer("status", "")).toEqual({
+      status: "incomplete",
+    });
+  });
+
+  it("validates number buffers with range enforcement", () => {
+    expect(schema.validateBuffer("cpu", "4")).toEqual({
+      status: "valid",
+      operands: [4],
+    });
+    expect(schema.validateBuffer("cpu", "0")).toEqual({
+      status: "valid",
+      operands: [0],
+    });
+    expect(schema.validateBuffer("cpu", "64")).toEqual({
+      status: "valid",
+      operands: [64],
+    });
+    expect(schema.validateBuffer("cpu", "4.5")).toEqual({
+      status: "valid",
+      operands: [4.5],
+    });
+    expect(schema.validateBuffer("cpu", "")).toEqual({
+      status: "incomplete",
+    });
+    expect(schema.validateBuffer("cpu", "-2")).toEqual({
+      status: "invalid",
+      reason: "-2 is below the minimum of 0",
+    });
+    expect(schema.validateBuffer("cpu", "99")).toEqual({
+      status: "invalid",
+      reason: "99 is above the maximum of 64",
+    });
+    for (const bad of ["four", "1e3", " 4", "+4"]) {
+      expect(schema.validateBuffer("cpu", bad)).toEqual({
+        status: "invalid",
+        reason: "not a number",
+      });
+    }
+  });
+
+  it("accepts any finite number for unbounded number fields", () => {
+    expect(schema.validateBuffer("memory", "-1")).toEqual({
+      status: "valid",
+      operands: [-1],
+    });
+  });
+
+  it("validates date buffers as ISO-8601 calendar dates", () => {
+    expect(schema.validateBuffer("updated", "2026-01-31")).toEqual({
+      status: "valid",
+      operands: ["2026-01-31"],
+    });
+    expect(schema.validateBuffer("updated", "2024-02-29")).toEqual({
+      status: "valid",
+      operands: ["2024-02-29"],
+    });
+    expect(schema.validateBuffer("updated", "2000-02-29")).toEqual({
+      status: "valid",
+      operands: ["2000-02-29"],
+    });
+    expect(schema.validateBuffer("updated", "")).toEqual({
+      status: "incomplete",
+    });
+    for (const invalid of [
+      "2026-02-30",
+      "1900-02-29",
+      "2026-04-31",
+      "2026-06-31",
+      "2026-09-31",
+      "2026-11-31",
+      "2026-13-01",
+      "2026-00-15",
+      "2026-01-00",
+      "yesterday",
+    ]) {
+      expect(schema.validateBuffer("updated", invalid)).toEqual({
+        status: "invalid",
+        reason: `"${invalid}" is not an ISO-8601 calendar date (YYYY-MM-DD)`,
+      });
+    }
+  });
+
+  it("reports unknown fields as invalid", () => {
+    expect(schema.validateBuffer("zone", "north")).toEqual({
+      status: "invalid",
+      reason: 'unknown field "zone"',
+    });
+  });
+
+  it("refuses text-buffer editing for flag fields before other checks", () => {
+    expect(schema.validateBuffer("owner", "1")).toEqual({
+      status: "invalid",
+      reason: "flag fields edit through direct commands",
+    });
+    expect(schema.validateBuffer("owner", "")).toEqual({
+      status: "invalid",
+      reason: "flag fields edit through direct commands",
+    });
+  });
+
+  it("builds predicates with the kind's legal operators", () => {
+    expect(
+      schema.predicateFor("status", "eq", ["failed", "cancelled"]),
+    ).toEqual({
+      status: "valid",
+      predicate: {
+        field: "status",
+        operator: "eq",
+        operands: ["failed", "cancelled"],
+      },
+    });
+    expect(schema.predicateFor("cpu", "gte", [4])).toEqual({
+      status: "valid",
+      predicate: { field: "cpu", operator: "gte", operands: [4] },
+    });
+    expect(schema.predicateFor("cpu", "lte", [64])).toEqual({
+      status: "valid",
+      predicate: { field: "cpu", operator: "lte", operands: [64] },
+    });
+    expect(schema.predicateFor("updated", "gte", ["2026-01-01"])).toEqual({
+      status: "valid",
+      predicate: {
+        field: "updated",
+        operator: "gte",
+        operands: ["2026-01-01"],
+      },
+    });
+    expect(schema.predicateFor("updated", "lte", ["2026-12-31"])).toEqual({
+      status: "valid",
+      predicate: {
+        field: "updated",
+        operator: "lte",
+        operands: ["2026-12-31"],
+      },
+    });
+    expect(schema.predicateFor("owner", "isSet", [])).toEqual({
+      status: "valid",
+      predicate: { field: "owner", operator: "isSet", operands: [] },
+    });
+  });
+
+  it("rejects every operator no field kind accepts", () => {
+    const cases: [
+      string,
+      "eq" | "gte" | "lte" | "isSet",
+      readonly (string | number)[],
+      string,
+    ][] = [
+      [
+        "status",
+        "gte",
+        ["failed"],
+        'choices field "status" does not accept the gte operator',
+      ],
+      [
+        "status",
+        "lte",
+        ["failed"],
+        'choices field "status" does not accept the lte operator',
+      ],
+      [
+        "status",
+        "isSet",
+        [],
+        'choices field "status" does not accept the isSet operator',
+      ],
+      ["cpu", "eq", [4], 'number field "cpu" does not accept the eq operator'],
+      [
+        "cpu",
+        "isSet",
+        [],
+        'number field "cpu" does not accept the isSet operator',
+      ],
+      [
+        "updated",
+        "eq",
+        ["2026-01-01"],
+        'date field "updated" does not accept the eq operator',
+      ],
+      [
+        "updated",
+        "isSet",
+        [],
+        'date field "updated" does not accept the isSet operator',
+      ],
+      [
+        "owner",
+        "eq",
+        ["x"],
+        'flag field "owner" does not accept the eq operator',
+      ],
+      [
+        "owner",
+        "gte",
+        [4],
+        'flag field "owner" does not accept the gte operator',
+      ],
+      [
+        "owner",
+        "lte",
+        [4],
+        'flag field "owner" does not accept the lte operator',
+      ],
+    ];
+    for (const [field, operator, operands, reason] of cases) {
+      expect(schema.predicateFor(field, operator, operands)).toEqual({
+        status: "invalid",
+        reason,
+      });
+    }
+  });
+
+  it("rejects operands that violate the operator's grammar arity", () => {
+    expect(schema.predicateFor("status", "eq", [])).toEqual({
+      status: "invalid",
+      reason: "eq predicate needs at least one operand",
+    });
+    expect(schema.predicateFor("cpu", "gte", [])).toEqual({
+      status: "invalid",
+      reason: "gte predicate needs exactly one operand",
+    });
+    expect(schema.predicateFor("cpu", "lte", [4, 8])).toEqual({
+      status: "invalid",
+      reason: "lte predicate needs exactly one operand",
+    });
+    expect(schema.predicateFor("owner", "isSet", ["x"])).toEqual({
+      status: "invalid",
+      reason: "isSet predicate takes no operands",
+    });
+  });
+
+  it("enforces schema semantics on direct operands", () => {
+    expect(schema.predicateFor("status", "eq", ["deployed"])).toEqual({
+      status: "invalid",
+      reason: '"deployed" is not an option of "status"',
+    });
+    expect(schema.predicateFor("cpu", "gte", [Number.NaN])).toEqual({
+      status: "invalid",
+      reason: "NaN is not a finite number",
+    });
+    expect(
+      schema.predicateFor("cpu", "gte", [Number.POSITIVE_INFINITY]),
+    ).toEqual({
+      status: "invalid",
+      reason: "Infinity is not a finite number",
+    });
+    expect(
+      schema.predicateFor("cpu", "lte", [Number.NEGATIVE_INFINITY]),
+    ).toEqual({
+      status: "invalid",
+      reason: "-Infinity is not a finite number",
+    });
+    expect(schema.predicateFor("cpu", "gte", [0])).toEqual({
+      status: "valid",
+      predicate: { field: "cpu", operator: "gte", operands: [0] },
+    });
+    expect(schema.predicateFor("cpu", "lte", [64])).toEqual({
+      status: "valid",
+      predicate: { field: "cpu", operator: "lte", operands: [64] },
+    });
+    expect(schema.predicateFor("cpu", "lte", [100])).toEqual({
+      status: "invalid",
+      reason: "100 is above the maximum of 64",
+    });
+    expect(schema.predicateFor("owner", "isSet", ["x"])).toEqual({
+      status: "invalid",
+      reason: "isSet predicate takes no operands",
+    });
+    expect(schema.predicateFor("updated", "gte", ["2026-13-01"])).toEqual({
+      status: "invalid",
+      reason: '"2026-13-01" is not an ISO-8601 calendar date (YYYY-MM-DD)',
+    });
+  });
+
+  it("reports unknown fields from the direct path too", () => {
+    expect(schema.predicateFor("zone", "eq", ["north"])).toEqual({
+      status: "invalid",
+      reason: 'unknown field "zone"',
+    });
+  });
+
+  it("accepts number options in choices fields", () => {
+    const numeric = createSchema([
+      { field: "priority", kind: "choices", options: [1, 2, 3] },
+    ]);
+    expect(numeric.validateBuffer("priority", "2")).toEqual({
+      status: "valid",
+      operands: [2],
+    });
+    expect(numeric.predicateFor("priority", "eq", [2, 3])).toEqual({
+      status: "valid",
+      predicate: { field: "priority", operator: "eq", operands: [2, 3] },
+    });
+    // Strict matching: the string "2" is not the number option 2.
+    expect(numeric.predicateFor("priority", "eq", ["2"])).toEqual({
+      status: "invalid",
+      reason: '"2" is not an option of "priority"',
+    });
+    expect(numeric.validateBuffer("priority", " 1")).toEqual({
+      status: "invalid",
+      reason: '" 1" is not an option of "priority"',
+    });
+  });
+});

--- a/packages/runtime/dataviews/src/lib/schema/createSchema.ts
+++ b/packages/runtime/dataviews/src/lib/schema/createSchema.ts
@@ -1,0 +1,307 @@
+import type { FieldValidation } from "../field/createFieldInteraction.js";
+import type {
+  Predicate,
+  PredicateOperand,
+  PredicateOperator,
+} from "../query/types.js";
+import type { SchemaFieldDefinition } from "./types.js";
+
+/** A schema-enforced predicate, or the reason it is not valid. */
+export type SchemaPredicateResult =
+  | { readonly status: "valid"; readonly predicate: Predicate }
+  | { readonly status: "invalid"; readonly reason: string };
+
+/** Handle of one collection schema. */
+export type Schema<TFields extends readonly SchemaFieldDefinition[]> = {
+  /** The field definitions as a frozen copy, in construction order. */
+  readonly fields: TFields;
+  /** All field names, in definition order. */
+  readonly fieldNames: readonly string[];
+  /** Whether a field with this name exists. */
+  readonly hasField: (name: string) => boolean;
+  /**
+   * Validate a text input buffer for the field's single-value editing path.
+   * Flag fields edit through direct commands instead of a text buffer.
+   */
+  readonly validateBuffer: (name: string, buffer: string) => FieldValidation;
+  /**
+   * Build the addressed predicate for a field, enforcing the kind's legal
+   * operators, the operator's grammar arity, and schema semantics beyond
+   * the generic grammar: option membership, numeric range and date format.
+   */
+  readonly predicateFor: (
+    name: string,
+    operator: PredicateOperator,
+    operands: readonly PredicateOperand[],
+  ) => SchemaPredicateResult;
+};
+
+const ISO_DATE = /^\d{4}-\d{2}-\d{2}$/;
+
+const isLeapYear = (year: number): boolean =>
+  (year % 4 === 0 && year % 100 !== 0) || year % 400 === 0;
+
+/**
+ * A real calendar check: `Date.parse` is not portable here — JavaScriptCore
+ * accepts out-of-range dates such as 2026-02-30 by rolling them over.
+ */
+const isCalendarDate = (value: string): boolean => {
+  if (!ISO_DATE.test(value)) {
+    return false;
+  }
+  const year = Number(value.slice(0, 4));
+  const month = Number(value.slice(5, 7));
+  const day = Number(value.slice(8, 10));
+  if (month < 1 || month > 12 || day < 1) {
+    return false;
+  }
+  const daysInMonth = [
+    31,
+    isLeapYear(year) ? 29 : 28,
+    31,
+    30,
+    31,
+    30,
+    31,
+    31,
+    30,
+    31,
+    30,
+    31,
+  ];
+  return day <= daysInMonth[month - 1];
+};
+
+const isFiniteNumber = (value: PredicateOperand): value is number =>
+  typeof value === "number" && Number.isFinite(value);
+
+const operandLabel = (value: PredicateOperand): string =>
+  typeof value === "string" ? `"${value}"` : String(value);
+
+/** The operators each field kind accepts. */
+const legalOperators = (
+  definition: SchemaFieldDefinition,
+): readonly PredicateOperator[] => {
+  switch (definition.kind) {
+    case "choices":
+      return ["eq"];
+    case "number":
+    case "date":
+      return ["gte", "lte"];
+    case "flag":
+      return ["isSet"];
+  }
+};
+
+/** The grammar arity each operator requires. */
+const arityRejection = (
+  operator: PredicateOperator,
+  operandCount: number,
+): string | null => {
+  switch (operator) {
+    case "eq":
+      return operandCount > 0
+        ? null
+        : "eq predicate needs at least one operand";
+    case "gte":
+    case "lte":
+      return operandCount === 1
+        ? null
+        : `${operator} predicate needs exactly one operand`;
+    case "isSet":
+      return operandCount === 0 ? null : "isSet predicate takes no operands";
+  }
+};
+
+/** Validate operands against the field's schema semantics. */
+const operandRejection = (
+  definition: SchemaFieldDefinition,
+  operands: readonly PredicateOperand[],
+): string | null => {
+  switch (definition.kind) {
+    case "flag":
+      // Operand arity is the operator's concern; see `arityRejection`.
+      return null;
+    case "choices":
+      for (const operand of operands) {
+        if (!definition.options.includes(operand as string | number)) {
+          return `${operandLabel(operand)} is not an option of "${definition.field}"`;
+        }
+      }
+      return null;
+    case "number":
+      for (const operand of operands) {
+        if (!isFiniteNumber(operand)) {
+          return `${operandLabel(operand)} is not a finite number`;
+        }
+        if (definition.min !== undefined && operand < definition.min) {
+          return `${operandLabel(operand)} is below the minimum of ${definition.min}`;
+        }
+        if (definition.max !== undefined && operand > definition.max) {
+          return `${operandLabel(operand)} is above the maximum of ${definition.max}`;
+        }
+      }
+      return null;
+    case "date":
+      for (const operand of operands) {
+        if (typeof operand !== "string" || !isCalendarDate(operand)) {
+          return `${operandLabel(operand)} is not an ISO-8601 calendar date (YYYY-MM-DD)`;
+        }
+      }
+      return null;
+  }
+};
+
+/**
+ * Create the collection schema: the one coherent construction path from
+ * which field names, applied semantic types, input validation and schema
+ * enforcement are inferred. Literal field names and options are inferred
+ * without an `as const` annotation.
+ */
+export default function createSchema<
+  const TFields extends readonly SchemaFieldDefinition[],
+>(fields: TFields): Schema<TFields> {
+  // Copy and freeze the caller's definitions so later mutations of the
+  // input cannot desynchronize the public list from the lookups: the
+  // lookups answer from the frozen copies, not the originals.
+  const storedFields = Object.freeze(
+    fields.map((definition) =>
+      definition.kind === "choices"
+        ? Object.freeze({
+            field: definition.field,
+            kind: definition.kind,
+            options: Object.freeze([...definition.options]),
+          })
+        : Object.freeze({ ...definition }),
+    ),
+  ) as TFields;
+  const fieldNames = Object.freeze(
+    storedFields.map((definition) => definition.field),
+  );
+  const byName = new Map<string, SchemaFieldDefinition>();
+  for (const definition of storedFields) {
+    if (definition.field === "" || definition.field.includes("\u0000")) {
+      throw new Error(
+        "schema field names must be non-empty and free of NUL characters",
+      );
+    }
+    if (byName.has(definition.field)) {
+      throw new Error(`duplicate schema field "${definition.field}"`);
+    }
+    if (definition.kind === "number") {
+      const { min, max } = definition;
+      if (
+        (min !== undefined && !Number.isFinite(min)) ||
+        (max !== undefined && !Number.isFinite(max))
+      ) {
+        throw new Error(
+          `number field "${definition.field}" requires finite bounds`,
+        );
+      }
+      if (min !== undefined && max !== undefined && min > max) {
+        throw new Error(
+          `number field "${definition.field}" has an inverted range`,
+        );
+      }
+    }
+    if (definition.kind === "choices") {
+      if (definition.options.length === 0) {
+        throw new Error(
+          `choices field "${definition.field}" requires at least one option`,
+        );
+      }
+      if (
+        definition.options.some(
+          (option) => typeof option === "number" && !Number.isFinite(option),
+        )
+      ) {
+        throw new Error(
+          `choices field "${definition.field}" requires finite number options`,
+        );
+      }
+      if (
+        new Set(definition.options.map((option) => String(option))).size !==
+        definition.options.length
+      ) {
+        throw new Error(
+          `choices field "${definition.field}" has options with colliding string forms`,
+        );
+      }
+    }
+    byName.set(definition.field, definition);
+  }
+
+  return {
+    fields: storedFields,
+    fieldNames,
+    hasField: (name: string) => byName.has(name),
+    validateBuffer(name: string, buffer: string): FieldValidation {
+      const definition = byName.get(name);
+      if (definition === undefined) {
+        return { status: "invalid", reason: `unknown field "${name}"` };
+      }
+      if (definition.kind === "flag") {
+        return {
+          status: "invalid",
+          reason: "flag fields edit through direct commands",
+        };
+      }
+      if (buffer === "") {
+        return { status: "incomplete" };
+      }
+      const parsed: PredicateOperand[] = [];
+      if (definition.kind === "choices") {
+        const operand = definition.options.find(
+          (option) => String(option) === buffer,
+        );
+        if (operand === undefined) {
+          return {
+            status: "invalid",
+            reason: `"${buffer}" is not an option of "${name}"`,
+          };
+        }
+        parsed.push(operand);
+      } else if (definition.kind === "number") {
+        if (!/^-?\d+(\.\d+)?$/.test(buffer)) {
+          return { status: "invalid", reason: "not a number" };
+        }
+        parsed.push(Number(buffer));
+      } else {
+        parsed.push(buffer);
+      }
+      const rejection = operandRejection(definition, parsed);
+      if (rejection !== null) {
+        return { status: "invalid", reason: rejection };
+      }
+      return { status: "valid", operands: parsed };
+    },
+    predicateFor(
+      name: string,
+      operator: PredicateOperator,
+      operands: readonly PredicateOperand[],
+    ): SchemaPredicateResult {
+      const definition = byName.get(name);
+      if (definition === undefined) {
+        return { status: "invalid", reason: `unknown field "${name}"` };
+      }
+      if (!legalOperators(definition).includes(operator)) {
+        return {
+          status: "invalid",
+          reason: `${definition.kind} field "${name}" does not accept the ${operator} operator`,
+        };
+      }
+      const arity = arityRejection(operator, operands.length);
+      if (arity !== null) {
+        return { status: "invalid", reason: arity };
+      }
+      const rejection = operandRejection(definition, operands);
+      if (rejection !== null) {
+        return { status: "invalid", reason: rejection };
+      }
+      return {
+        status: "valid",
+        predicate: { field: name, operator, operands: [...operands] },
+      };
+    },
+  };
+}

--- a/packages/runtime/dataviews/src/lib/schema/index.ts
+++ b/packages/runtime/dataviews/src/lib/schema/index.ts
@@ -1,0 +1,6 @@
+export type {
+  Schema,
+  SchemaPredicateResult,
+} from "./createSchema.js";
+export { default as createSchema } from "./createSchema.js";
+export type * from "./types.js";

--- a/packages/runtime/dataviews/src/lib/schema/types.ts
+++ b/packages/runtime/dataviews/src/lib/schema/types.ts
@@ -1,0 +1,64 @@
+/**
+ * Schema field definitions for the bounded collection grammar. The field
+ * kind decides its legal operators, its applied semantic type and how an
+ * input buffer validates.
+ */
+
+/** A closed-set field: equality over a set of option values. */
+export type ChoicesField = {
+  readonly field: string;
+  readonly kind: "choices";
+  readonly options: readonly (string | number)[];
+};
+
+/** A numeric field: lower/upper bounds with optional limits. */
+export type NumberField = {
+  readonly field: string;
+  readonly kind: "number";
+  readonly min?: number;
+  readonly max?: number;
+};
+
+/** A presence field: the zero-value isSet operator. */
+export type FlagField = {
+  readonly field: string;
+  readonly kind: "flag";
+};
+
+/** A date field: ISO-8601 calendar-date bounds. */
+export type DateField = {
+  readonly field: string;
+  readonly kind: "date";
+};
+
+/** One schema field definition. */
+export type SchemaFieldDefinition =
+  | ChoicesField
+  | NumberField
+  | FlagField
+  | DateField;
+
+/** The applied semantic value a field's predicate carries. */
+export type AppliedOf<TField extends SchemaFieldDefinition> = TField extends {
+  readonly kind: "choices";
+  readonly options: infer TOptions;
+}
+  ? ReadonlySet<
+      TOptions extends readonly (string | number)[] ? TOptions[number] : never
+    >
+  : TField extends { readonly kind: "number" }
+    ? number
+    : TField extends { readonly kind: "flag" }
+      ? boolean
+      : TField extends { readonly kind: "date" }
+        ? string
+        : never;
+
+/**
+ * Maps a field definition list to its applied semantic types, keyed by
+ * field name. Literal field names and options are inferred through the
+ * schema factory's const type parameter, with no `as const` annotation.
+ */
+export type SchemaFields<TFields extends readonly SchemaFieldDefinition[]> = {
+  readonly [TDefinition in TFields[number] as TDefinition["field"]]: AppliedOf<TDefinition>;
+};

--- a/packages/runtime/dataviews/src/lib/schema/types.types.test.ts
+++ b/packages/runtime/dataviews/src/lib/schema/types.types.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import createSchema from "./createSchema.js";
+import type { SchemaFields } from "./types.js";
+
+const machines = createSchema([
+  { field: "status", kind: "choices", options: ["failed", "cancelled"] },
+  { field: "cpu", kind: "number" },
+  { field: "owner", kind: "flag" },
+]);
+
+type MachinesFields = SchemaFields<typeof machines.fields>;
+
+describe("schema type inference", () => {
+  it("infers literal field names from the construction", () => {
+    const names: (keyof MachinesFields)[] = ["status", "cpu", "owner"];
+    expect(names.sort()).toEqual(["cpu", "owner", "status"]);
+  });
+
+  it("infers the applied semantic type per kind", () => {
+    const status: MachinesFields["status"] = new Set(["failed"]);
+    const cpu: MachinesFields["cpu"] = 4;
+    const owner: MachinesFields["owner"] = true;
+    expect(status.has("failed")).toBe(true);
+    expect(cpu).toBe(4);
+    expect(owner).toBe(true);
+  });
+});

--- a/packages/runtime/dataviews/src/lib/selection/createSelection.test.ts
+++ b/packages/runtime/dataviews/src/lib/selection/createSelection.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from "vitest";
+import createSelection from "./createSelection.js";
+
+describe("createSelection", () => {
+  it("starts with the given identities, empty by default", () => {
+    expect(createSelection().state.ids.size).toBe(0);
+    expect(createSelection(["a", "b"]).state.ids).toEqual(new Set(["a", "b"]));
+  });
+
+  it("collapses duplicate identities in the initial set", () => {
+    expect(createSelection(["a", "a", "b"]).state.ids).toEqual(
+      new Set(["a", "b"]),
+    );
+  });
+
+  it("treats the empty set as a valid, observable state", () => {
+    const selection = createSelection();
+    let notifications = 0;
+    selection.subscribe(() => {
+      notifications += 1;
+    });
+    selection.clear();
+    expect(selection.state.ids.size).toBe(0);
+    expect(notifications).toBe(0);
+  });
+
+  it("toggles identities in and out", () => {
+    const selection = createSelection();
+    selection.toggle("machine-1");
+    expect(selection.state.ids).toEqual(new Set(["machine-1"]));
+    selection.toggle("machine-1");
+    expect(selection.state.ids.size).toBe(0);
+  });
+
+  it("replaces, adds and removes identities", () => {
+    const selection = createSelection(["a"]);
+    selection.set(["b", "c"]);
+    expect(selection.state.ids).toEqual(new Set(["b", "c"]));
+    selection.add(["a", "b"]);
+    expect(selection.state.ids).toEqual(new Set(["a", "b", "c"]));
+    selection.remove(["a", "c"]);
+    expect(selection.state.ids).toEqual(new Set(["b"]));
+  });
+
+  it("notifies only when the identity set changes", () => {
+    const selection = createSelection(["a"]);
+    let notifications = 0;
+    selection.subscribe(() => {
+      notifications += 1;
+    });
+    selection.add(["a"]);
+    expect(notifications).toBe(0);
+    selection.add(["b"]);
+    expect(notifications).toBe(1);
+    selection.set(["a", "b"]);
+    expect(notifications).toBe(1);
+    selection.remove(["z"]);
+    expect(notifications).toBe(1);
+    selection.clear();
+    expect(notifications).toBe(2);
+  });
+
+  it("notifies when a same-size replacement changes membership", () => {
+    const selection = createSelection(["a", "b"]);
+    let notifications = 0;
+    selection.subscribe(() => {
+      notifications += 1;
+    });
+    selection.set(["a", "c"]);
+    expect(selection.state.ids).toEqual(new Set(["a", "c"]));
+    expect(notifications).toBe(1);
+  });
+
+  it("serves immutable snapshots between changes", () => {
+    const selection = createSelection(["a"]);
+    const first = selection.state;
+    expect(selection.state).toBe(first);
+    selection.toggle("b");
+    expect(selection.state).not.toBe(first);
+    expect(first.ids).toEqual(new Set(["a"]));
+  });
+
+  it("freezes each published snapshot", () => {
+    const selection = createSelection();
+    selection.toggle("a");
+    expect(Object.isFrozen(selection.state)).toBe(true);
+  });
+
+  it("supports unsubscribe", () => {
+    const selection = createSelection();
+    let notifications = 0;
+    const unsubscribe = selection.subscribe(() => {
+      notifications += 1;
+    });
+    selection.toggle("a");
+    unsubscribe();
+    selection.toggle("a");
+    expect(notifications).toBe(1);
+  });
+});

--- a/packages/runtime/dataviews/src/lib/selection/createSelection.ts
+++ b/packages/runtime/dataviews/src/lib/selection/createSelection.ts
@@ -1,0 +1,95 @@
+import type { Channel } from "../observable/createChannel.js";
+import createChannel from "../observable/createChannel.js";
+
+/** Immutable selection snapshot: an explicit set of record identities. */
+export type SelectionState = {
+  /** The selected record identities; empty is a valid, documented state.
+   * The set is shared by reference between publishes; treat it as
+   * read-only, like every snapshot value this package hands out. */
+  readonly ids: ReadonlySet<string>;
+};
+
+/** Handle of one selection record. */
+export type Selection = {
+  readonly state: SelectionState;
+  /** Observe selection changes; snapshots are immutable between sets. */
+  readonly subscribe: (listener: () => void) => () => void;
+  /** Toggle one identity. */
+  readonly toggle: (id: string) => void;
+  /** Replace the selection with the given identities. */
+  readonly set: (ids: readonly string[]) => void;
+  /** Add identities to the current selection. */
+  readonly add: (ids: readonly string[]) => void;
+  /** Remove identities from the current selection. */
+  readonly remove: (ids: readonly string[]) => void;
+  /** Clear the selection to the documented zero-selection state. */
+  readonly clear: () => void;
+};
+
+const setsEqual = (a: ReadonlySet<string>, b: ReadonlySet<string>): boolean => {
+  if (a.size !== b.size) {
+    return false;
+  }
+  for (const id of a) {
+    if (!b.has(id)) {
+      return false;
+    }
+  }
+  return true;
+};
+
+/**
+ * Create one selection record: explicit record identities with a valid
+ * empty state. The record owns only the identity set; row data, counts and
+ * operations stay with their own owners.
+ */
+export default function createSelection(
+  initial: readonly string[] = [],
+): Selection {
+  const channel = createChannel<SelectionState>(
+    Object.freeze({ ids: new Set(initial) }),
+    {
+      equals: (a, b) => setsEqual(a.ids, b.ids),
+    },
+  );
+
+  const publish = (ids: ReadonlySet<string>): void => {
+    channel.set(Object.freeze({ ids }));
+  };
+
+  return {
+    get state(): SelectionState {
+      return channel.get();
+    },
+    subscribe: (listener: () => void) => channel.subscribe(listener),
+    toggle(id: string): void {
+      const next = new Set(channel.get().ids);
+      if (next.has(id)) {
+        next.delete(id);
+      } else {
+        next.add(id);
+      }
+      publish(next);
+    },
+    set(ids: readonly string[]): void {
+      publish(new Set(ids));
+    },
+    add(ids: readonly string[]): void {
+      const next = new Set(channel.get().ids);
+      for (const id of ids) {
+        next.add(id);
+      }
+      publish(next);
+    },
+    remove(ids: readonly string[]): void {
+      const next = new Set(channel.get().ids);
+      for (const id of ids) {
+        next.delete(id);
+      }
+      publish(next);
+    },
+    clear(): void {
+      publish(new Set());
+    },
+  };
+}

--- a/packages/runtime/dataviews/src/lib/selection/index.ts
+++ b/packages/runtime/dataviews/src/lib/selection/index.ts
@@ -1,0 +1,2 @@
+export type { Selection, SelectionState } from "./createSelection.js";
+export { default as createSelection } from "./createSelection.js";


### PR DESCRIPTION
## Done

- Adds the schema/observation layer to `@canonical/dataviews-core`:
  - **`createSchema`** — the one coherent construction path for field definitions (`choices`/`number`/`flag`/`date` kinds). Literal field names and option values are inferred through a const type parameter (no `as const` burden); `SchemaFields` maps each field to its applied semantic type (`ReadonlySet` of options, `number`, `boolean`, ISO date string). Construction validates and freezes its own deep copies: empty/NUL/duplicate names, option-less choices, non-finite number options or bounds, inverted ranges, and colliding string-forms are rejected. Runtime enforcement shares one point across both editing paths: buffer validation (option membership, numeric range, real calendar-date checking — not `Date.parse`, which is engine-dependent on out-of-range dates) and direct predicate building (`predicateFor` enforcing legal operators per kind, grammar arity, and schema semantics with the command layer's exact messages).
  - **`createChannel`** — observation channels with equality-guarded notification, snapshot-iteration publication (the new value is readable during its own notification; a listener added mid-publication misses it; a listener unsubscribed mid-publication still receives it), documented exception propagation, and set-based subscription semantics.
  - **`createSelection`** — explicit record-identity selection with a valid empty state, frozen immutable snapshots, and notification only when membership actually changes (set equality, including same-size replacements).
  - **`applyWindow`** — the displayed-window projection: one-based offset pages, fresh arrays, and the same positive-integer window rejections as the command layer. The coordinator now validates seed and adopted windows at intake through the same guard, so back/forward can never install a window that crashes at projection time.
- The schema layer cannot mint predicates the grammar layer rejects: `predicateFor` output feeds the coordinator's `replacePredicate` cleanly (arity and finiteness enforced at both layers with matching messages), and the command layer rejects unknown operators with a reason rather than `undefined`.

Stacked on #1195 (merge that first); #1194 below it.

## QA

- `bun run check` green at the root.
- Package: 192/192 tests, 100% branch/function/line/statement coverage through the standard `test` target; `tsc -p tsconfig.build.json` emits cleanly.
- `nx affected -t test`: `@canonical/dataviews-core` green; the two svelte browser-mode packages fail on this host only (missing Playwright OS dependencies, not installable here); CI runners carry them and are unaffected by this diff.

### PR readiness check

- [x] PR title follows the Conventional Commits format.
- [x] The code follows the appropriate code standards.
- [x] The package defines `check`, `check:fix`, `test`, `build`, `build:all`.
- [x] No visual surface — Chromatic: skip label applied.

Chromatic: skip