### PR TITLE
fix(button): center icon in the density-seated Button

### DIFF
--- a/packages/react/ds-global/src/lib/component/Button/styles.css
+++ b/packages/react/ds-global/src/lib/component/Button/styles.css
@@ -173,6 +173,7 @@
   .ds.button > .icon {
     display: inline-flex;
     align-items: center;
+    align-self: center;
     justify-content: center;
     flex-shrink: 0;
     width: var(--icon-size, 1em);


### PR DESCRIPTION
## Done

- Center the Button icon slot on the density-seated line box with `align-self: center`.

The density seat sets `align-items: flex-start` so the label sits on the baseline grid. That also pinned the shorter leading icon to the top of the line box. Centering the icon slot with `align-self` leaves the label seated.

## QA

- [x] `bun run check` from the repo root
- [x] `bun run test` from the repo root
- [ ] Storybook: Button `IconMatrix` and `Loading`, comfortable and dense
- [ ] Icon stays centered next to the label across importance and anticipation; label placement unchanged

### PR readiness check

- [x] PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format, using one of the allowed types: `feat`, `fix`, `docs`, `refactor`, `chore`, `test`, `ci`, `revert`.
  - The matching type label is applied automatically from the title — there is no type label to add by hand.
  - Breaking changes are marked with `!` in the title (e.g. `feat(router)!: …`), which adds the `breaking` label.
- [x] The code follows the appropriate [code standards](https://github.com/canonical/web-code-standards)
- [x] All packages define the required scripts in `package.json`:
  - [x] All packages: `check`, `check:fix`, and `test`.
  - [x] Packages with build steps: `build` to build the package for development or distribution, `build:all` to build **all** artifacts. See [CONTRIBUTING.md](../old/CONTRIBUTING.md#24-full-artifact-builds-buildall) for details.
- [ ] If this PR introduces a **new package**: first-time publish has been done manually from inside the package directory using `npm publish --access public` (first-time publishing is not automated). Run `bun run publish:status` from the repo root to verify. Then configure an OIDC [trusted publisher](https://docs.npmjs.com/trusted-publishers) for the package on npmjs.com (repo `canonical/pragma`, workflow `tag.yml`) and set publishing access to disallow tokens, so the automated release workflow can publish future versions.
- [ ] If this PR does not require visual testing, add the `Chromatic: skip` label to skip Chromatic.

## Screenshots

Before:
<img width="1051" height="919" alt="image" src="https://github.com/user-attachments/assets/7742a118-52a7-473f-8435-600b42892911" />

After:
<img width="1051" height="919" alt="image" src="https://github.com/user-attachments/assets/1a7a2578-a7ba-46d1-a462-5cda0aa2a386" />

