### PR TITLE
feat(dataviews): shared geometry solver with local resize preview

### DIFF
--- a/packages/runtime/dataviews/src/index.test.ts
+++ b/packages/runtime/dataviews/src/index.test.ts
@@ -10,14 +10,17 @@ describe("public surface", () => {
       "createCollectionCoordinator",
       "createDataViewsProvider",
       "createFieldInteraction",
+      "createGridInteraction",
       "createIdentity",
       "createMemoryLocation",
       "createOperation",
       "createPlatformLocation",
+      "createPresentation",
       "createSaveSession",
       "createSchema",
       "createSelection",
       "isIdentity",
+      "resolveColumns",
       "sliceEquals",
     ]);
   });

--- a/packages/runtime/dataviews/src/lib/geometry/createGridInteraction.test.ts
+++ b/packages/runtime/dataviews/src/lib/geometry/createGridInteraction.test.ts
@@ -1,0 +1,210 @@
+import { describe, expect, it } from "vitest";
+import createGridInteraction from "./createGridInteraction.js";
+import createPresentation from "./createPresentation.js";
+import type { ColumnToSize } from "./types.js";
+
+const columns = (): readonly ColumnToSize[] => [
+  { id: "name", sizing: { kind: "flex", weight: 2, minPx: 100, maxPx: 400 } },
+  { id: "status", sizing: { kind: "fixed", px: 120 } },
+];
+
+const harness = (declared: readonly ColumnToSize[] = columns()) => {
+  const presentation = createPresentation(declared);
+  const interaction = createGridInteraction(presentation);
+  return { presentation, interaction };
+};
+
+describe("createGridInteraction", () => {
+  it("starts idle and enters resizing with a captured start width", () => {
+    const { interaction } = harness();
+    expect(interaction.state).toEqual({ status: "idle" });
+    interaction.startResize("name", 500, 100);
+    expect(interaction.state).toEqual({
+      status: "resizing",
+      columnId: "name",
+      originX: 500,
+      startWidth: 100,
+      previewWidth: 100,
+    });
+  });
+
+  it("clamps the preview to the column's declared bounds", () => {
+    const { interaction } = harness();
+    interaction.startResize("name", 500, 100);
+    interaction.preview(900);
+    // start 100 + (900 - 500) = 500, clamped to maxPx 400.
+    const state = interaction.state;
+    if (state.status !== "resizing") {
+      throw new Error("expected resizing");
+    }
+    expect(state.previewWidth).toBe(400);
+    interaction.preview(0);
+    // start 100 + (0 - 500) = -400, clamped to minPx 100.
+    const after = interaction.state;
+    if (after.status !== "resizing") {
+      throw new Error("expected resizing");
+    }
+    expect(after.previewWidth).toBe(100);
+  });
+
+  it("commits a fixed override at the clamped preview width", () => {
+    const { presentation, interaction } = harness();
+    interaction.startResize("name", 500, 100);
+    interaction.preview(650);
+    interaction.commit();
+    expect(interaction.state).toEqual({ status: "idle" });
+    expect(presentation.effective("name")).toEqual({
+      kind: "fixed",
+      px: 250,
+    });
+  });
+
+  it("cancel leaves the authoritative presentation untouched", () => {
+    const { presentation, interaction } = harness();
+    interaction.startResize("name", 500, 100);
+    interaction.preview(650);
+    interaction.cancel();
+    expect(interaction.state).toEqual({ status: "idle" });
+    expect(presentation.effective("name")).toEqual({
+      kind: "flex",
+      weight: 2,
+      minPx: 100,
+      maxPx: 400,
+    });
+  });
+
+  it("ignores previews outside a resize", () => {
+    const { interaction } = harness();
+    interaction.preview(999);
+    expect(interaction.state).toEqual({ status: "idle" });
+  });
+
+  it("ignores commit outside a resize", () => {
+    const { presentation, interaction } = harness();
+    interaction.commit();
+    expect(presentation.state.overrides).toEqual({});
+  });
+
+  it("invalidates the live preview on an external change to the same column", () => {
+    const { presentation, interaction } = harness();
+    interaction.startResize("name", 500, 100);
+    interaction.preview(600);
+    // Another actor fixes the same column mid-resize.
+    presentation.setOverride("name", { kind: "fixed", px: 260 });
+    expect(interaction.state).toEqual({ status: "idle" });
+  });
+
+  it("ignores external changes to unrelated columns", () => {
+    const { presentation, interaction } = harness();
+    interaction.startResize("name", 500, 100);
+    presentation.setOverride("status", { kind: "fixed", px: 140 });
+    // Presentation changes are per-record: a change to status does not
+    // touch the resizing column, so the preview survives.
+    const state = interaction.state;
+    if (state.status !== "resizing") {
+      throw new Error("expected resizing");
+    }
+    expect(state.columnId).toBe("name");
+  });
+
+  it("clamps a fixed column at zero only", () => {
+    const { interaction } = harness();
+    interaction.startResize("status", 500, 120);
+    interaction.preview(900);
+    // A fixed column declares no bounds: 120 + (900 - 500) = 520 stands.
+    const wide = interaction.state;
+    if (wide.status !== "resizing") {
+      throw new Error("expected resizing");
+    }
+    expect(wide.previewWidth).toBe(520);
+    interaction.preview(0);
+    // 120 + (0 - 500) = -380, floored at zero.
+    const narrow = interaction.state;
+    if (narrow.status !== "resizing") {
+      throw new Error("expected resizing");
+    }
+    expect(narrow.previewWidth).toBe(0);
+  });
+
+  it("clamps an unbounded flex column at its minimum only", () => {
+    const { interaction } = harness([
+      { id: "notes", sizing: { kind: "flex", weight: 1, minPx: 80 } },
+    ]);
+    interaction.startResize("notes", 500, 80);
+    interaction.preview(1500);
+    // No maxPx: 80 + (1500 - 500) = 1080 stands.
+    const wide = interaction.state;
+    if (wide.status !== "resizing") {
+      throw new Error("expected resizing");
+    }
+    expect(wide.previewWidth).toBe(1080);
+    interaction.preview(0);
+    // 80 + (0 - 500) = -420, clamped to minPx 80.
+    const narrow = interaction.state;
+    if (narrow.status !== "resizing") {
+      throw new Error("expected resizing");
+    }
+    expect(narrow.previewWidth).toBe(80);
+  });
+
+  it("invalidates the preview when a fixed column's pixels change externally", () => {
+    const { presentation, interaction } = harness();
+    interaction.startResize("status", 500, 120);
+    interaction.preview(600);
+    // Same kind on both sides: the pixel comparison is what invalidates.
+    presentation.setOverride("status", { kind: "fixed", px: 200 });
+    expect(interaction.state).toEqual({ status: "idle" });
+  });
+
+  it("ignores an external write that restates a fixed column's pixels", () => {
+    const { presentation, interaction } = harness();
+    interaction.startResize("status", 500, 120);
+    interaction.preview(600);
+    presentation.setOverride("status", { kind: "fixed", px: 120 });
+    const state = interaction.state;
+    if (state.status !== "resizing") {
+      throw new Error("expected resizing");
+    }
+    expect(state.columnId).toBe("status");
+  });
+
+  it("ignores cancel outside a resize", () => {
+    const { interaction } = harness();
+    interaction.cancel();
+    expect(interaction.state).toEqual({ status: "idle" });
+  });
+
+  it("unsubscribes from previews", () => {
+    const { interaction } = harness();
+    let notifications = 0;
+    const unsubscribe = interaction.subscribe(() => {
+      notifications += 1;
+    });
+    interaction.startResize("name", 500, 100);
+    unsubscribe();
+    interaction.preview(600);
+    expect(notifications).toBe(1);
+  });
+
+  it("stops listening after dispose", () => {
+    const { presentation, interaction } = harness();
+    interaction.dispose();
+    interaction.startResize("name", 500, 100);
+    expect(interaction.state.status).toBe("resizing");
+    presentation.setOverride("name", { kind: "fixed", px: 260 });
+    // No invalidation after dispose: the preview stays.
+    expect(interaction.state.status).toBe("resizing");
+  });
+
+  it("publishes on each preview", () => {
+    const { interaction } = harness();
+    let notifications = 0;
+    interaction.subscribe(() => {
+      notifications += 1;
+    });
+    interaction.startResize("name", 500, 100);
+    interaction.preview(600);
+    interaction.preview(610);
+    expect(notifications).toBe(3);
+  });
+});

--- a/packages/runtime/dataviews/src/lib/geometry/createGridInteraction.ts
+++ b/packages/runtime/dataviews/src/lib/geometry/createGridInteraction.ts
@@ -1,0 +1,145 @@
+import type { Presentation } from "./createPresentation.js";
+import sizingEquals from "./sizingEquals.js";
+import type { ColumnSizing } from "./types.js";
+
+/** The grid interaction state: idle, or one live resize preview. */
+export type GridInteractionState =
+  | { readonly status: "idle" }
+  | {
+      readonly status: "resizing";
+      readonly columnId: string;
+      readonly originX: number;
+      readonly startWidth: number;
+      readonly previewWidth: number;
+    };
+
+/** Handle of one grid interaction record. */
+export type GridInteraction = {
+  readonly state: GridInteractionState;
+  /** Observe interaction changes. */
+  readonly subscribe: (listener: () => void) => () => void;
+  /**
+   * Begin a resize: capture the column, the pointer origin and the current
+   * (resolved) starting width. Previews never mutate the authoritative
+   * presentation.
+   */
+  readonly startResize: (
+    columnId: string,
+    originX: number,
+    startWidth: number,
+  ) => void;
+  /** Preview a pointer position; the width is clamped to the column's bounds. */
+  readonly preview: (pointerX: number) => void;
+  /** Commit the preview: the sizing override is applied to the presentation. */
+  readonly commit: () => void;
+  /** Cancel: the authoritative presentation is untouched, so nothing restores. */
+  readonly cancel: () => void;
+  /** Detach the presentation subscription permanently. */
+  readonly dispose: () => void;
+};
+
+/**
+ * Create the grid interaction record for one table's resize lifecycle,
+ * bound to its presentation record. A conflicting same-column update
+ * invalidates the live preview; unrelated column updates are incorporated.
+ * Preview coalescing to animation frames is the renderer's concern — the
+ * machine clamps and publishes per preview call.
+ */
+export default function createGridInteraction(
+  presentation: Presentation,
+): GridInteraction {
+  let state: GridInteractionState = { status: "idle" };
+  const listeners = new Set<() => void>();
+  // The sizing the live preview was captured against, for conflict checks.
+  let resizingBaseline: ColumnSizing | null = null;
+
+  const publish = (next: GridInteractionState): void => {
+    state = Object.freeze(next);
+    for (const listener of [...listeners]) {
+      listener();
+    }
+  };
+
+  const clamp = (columnId: string, width: number): number => {
+    const sizing = presentation.effective(columnId);
+    let next = Math.max(0, width);
+    if (sizing.kind === "flex") {
+      next = Math.max(sizing.minPx, next);
+      if (sizing.maxPx !== undefined) {
+        next = Math.min(sizing.maxPx, next);
+      }
+    }
+    return next;
+  };
+
+  // A conflicting same-column update invalidates the live preview; an
+  // unrelated column's update does not. Our own commit ends the interaction
+  // before writing, so any change observed while resizing is external.
+  const unsubscribePresentation = presentation.subscribe(() => {
+    if (state.status === "resizing" && resizingBaseline !== null) {
+      const current = presentation.effective(state.columnId);
+      if (!sizingEquals(current, resizingBaseline)) {
+        resizingBaseline = null;
+        publish({ status: "idle" });
+      }
+    }
+  });
+
+  return {
+    get state(): GridInteractionState {
+      return state;
+    },
+    subscribe(listener: () => void): () => void {
+      listeners.add(listener);
+      return () => {
+        listeners.delete(listener);
+      };
+    },
+    startResize(columnId: string, originX: number, startWidth: number): void {
+      resizingBaseline = presentation.effective(columnId);
+      publish({
+        status: "resizing",
+        columnId,
+        originX,
+        startWidth,
+        previewWidth: clamp(columnId, startWidth),
+      });
+    },
+    preview(pointerX: number): void {
+      if (state.status !== "resizing") {
+        return;
+      }
+      publish({
+        ...state,
+        previewWidth: clamp(
+          state.columnId,
+          state.startWidth + (pointerX - state.originX),
+        ),
+      });
+    },
+    commit(): void {
+      if (state.status !== "resizing") {
+        return;
+      }
+      const { columnId, previewWidth } = state;
+      resizingBaseline = null;
+      publish({ status: "idle" });
+      presentation.setOverride(columnId, {
+        kind: "fixed",
+        px: previewWidth,
+      });
+    },
+    cancel(): void {
+      if (state.status !== "resizing") {
+        return;
+      }
+      resizingBaseline = null;
+      publish({ status: "idle" });
+    },
+    dispose(): void {
+      unsubscribePresentation();
+      listeners.clear();
+      resizingBaseline = null;
+    },
+  };
+}

--- a/packages/runtime/dataviews/src/lib/geometry/createPresentation.test.ts
+++ b/packages/runtime/dataviews/src/lib/geometry/createPresentation.test.ts
@@ -1,0 +1,164 @@
+import { describe, expect, it } from "vitest";
+import createPresentation from "./createPresentation.js";
+import type { ColumnToSize } from "./types.js";
+
+const columns = (): readonly ColumnToSize[] => [
+  { id: "name", sizing: { kind: "flex", weight: 2, minPx: 120 } },
+  { id: "status", sizing: { kind: "fixed", px: 120 } },
+  { id: "zone", sizing: { kind: "flex", weight: 1, minPx: 100, maxPx: 300 } },
+];
+
+describe("createPresentation", () => {
+  it("declares sizing per column and rejects empty or duplicate ids", () => {
+    const presentation = createPresentation(columns());
+    expect(presentation.effective("name")).toEqual({
+      kind: "flex",
+      weight: 2,
+      minPx: 120,
+    });
+    expect(presentation.effective("status")).toEqual({
+      kind: "fixed",
+      px: 120,
+    });
+    expect(() =>
+      createPresentation([{ id: "", sizing: { kind: "fixed", px: 1 } }]),
+    ).toThrow("must not be empty");
+    expect(() =>
+      createPresentation([
+        { id: "name", sizing: { kind: "fixed", px: 1 } },
+        { id: "name", sizing: { kind: "fixed", px: 2 } },
+      ]),
+    ).toThrow("duplicate");
+    // The prototype chain is not a member.
+    expect(() => presentation.effective("toString")).toThrow(
+      "unknown column id",
+    );
+  });
+
+  it("applies user-fixed overrides over declared sizing", () => {
+    const presentation = createPresentation(columns());
+    presentation.setOverride("name", { kind: "fixed", px: 340 });
+    expect(presentation.effective("name")).toEqual({ kind: "fixed", px: 340 });
+    expect(presentation.effective("status")).toEqual({
+      kind: "fixed",
+      px: 120,
+    });
+  });
+
+  it("rejects overrides for unknown columns", () => {
+    const presentation = createPresentation(columns());
+    expect(() =>
+      presentation.setOverride("toString", { kind: "fixed", px: 10 }),
+    ).toThrow("unknown column id");
+    expect(() =>
+      presentation.setOverride("zone2", { kind: "fixed", px: 10 }),
+    ).toThrow("unknown column id");
+  });
+
+  it("restores declared sizing on resetOverride and reset", () => {
+    const presentation = createPresentation(columns());
+    presentation.setOverride("name", { kind: "fixed", px: 340 });
+    presentation.setOverride("zone", { kind: "fixed", px: 250 });
+    presentation.resetOverride("name");
+    expect(presentation.effective("name")).toEqual({
+      kind: "flex",
+      weight: 2,
+      minPx: 120,
+    });
+    expect(presentation.effective("zone")).toEqual({ kind: "fixed", px: 250 });
+    presentation.reset();
+    expect(presentation.effective("zone")).toEqual({
+      kind: "flex",
+      weight: 1,
+      minPx: 100,
+      maxPx: 300,
+    });
+  });
+
+  it("publishes a snapshot only on an actual change", () => {
+    const presentation = createPresentation(columns());
+    let notifications = 0;
+    presentation.subscribe(() => {
+      notifications += 1;
+    });
+    presentation.setOverride("name", { kind: "fixed", px: 340 });
+    expect(notifications).toBe(1);
+    // Restating the same override is a no-op, as the reset paths are.
+    presentation.setOverride("name", { kind: "fixed", px: 340 });
+    expect(notifications).toBe(1);
+    expect(presentation.state.revision).toBe(1);
+    // A different sizing of the same kind is an accepted change.
+    presentation.setOverride("name", { kind: "fixed", px: 341 });
+    expect(notifications).toBe(2);
+    presentation.resetOverride("name");
+    expect(notifications).toBe(3);
+    // Resetting a column without an override is a no-op.
+    presentation.resetOverride("zone");
+    expect(notifications).toBe(3);
+    // With no overrides left, reset is a no-op.
+    presentation.reset();
+    expect(notifications).toBe(3);
+  });
+
+  it("serves toColumns with overrides applied, in input order", () => {
+    const presentation = createPresentation(columns());
+    presentation.setOverride("status", { kind: "fixed", px: 200 });
+    const resolved = presentation.toColumns();
+    expect(resolved.map((column) => column.id)).toEqual([
+      "name",
+      "status",
+      "zone",
+    ]);
+    expect(resolved[1]?.sizing).toEqual({ kind: "fixed", px: 200 });
+    expect(resolved[0]?.sizing).toEqual({
+      kind: "flex",
+      weight: 2,
+      minPx: 120,
+    });
+  });
+
+  it("bumps the revision on every accepted change", () => {
+    const presentation = createPresentation(columns());
+    expect(presentation.state.revision).toBe(0);
+    presentation.setOverride("name", { kind: "fixed", px: 340 });
+    expect(presentation.state.revision).toBe(1);
+    presentation.resetOverride("name");
+    expect(presentation.state.revision).toBe(2);
+  });
+
+  it("keeps the declared sizing immune to caller mutations", () => {
+    const input = columns();
+    const presentation = createPresentation(input);
+    (input as { id: string; sizing: unknown }[]).push({
+      id: "sneaky",
+      sizing: { kind: "fixed", px: 1 },
+    });
+    expect(() => presentation.effective("sneaky")).toThrow("unknown column id");
+    // toColumns answers from the construction-time order, not the caller's array.
+    expect(presentation.toColumns().map((column) => column.id)).toEqual([
+      "name",
+      "status",
+      "zone",
+    ]);
+  });
+
+  it("treats a flex override differing in any bound as a change", () => {
+    const presentation = createPresentation(columns());
+    let notifications = 0;
+    presentation.subscribe(() => {
+      notifications += 1;
+    });
+    const base = { kind: "flex", weight: 1, minPx: 100, maxPx: 300 } as const;
+    presentation.setOverride("name", base);
+    expect(notifications).toBe(1);
+    presentation.setOverride("name", { ...base });
+    expect(notifications).toBe(1);
+    presentation.setOverride("name", { ...base, maxPx: undefined });
+    expect(notifications).toBe(2);
+    presentation.setOverride("name", { ...base, weight: 2, maxPx: undefined });
+    expect(notifications).toBe(3);
+    // A kind change is a change.
+    presentation.setOverride("name", { kind: "fixed", px: 100 });
+    expect(notifications).toBe(4);
+  });
+});

--- a/packages/runtime/dataviews/src/lib/geometry/createPresentation.ts
+++ b/packages/runtime/dataviews/src/lib/geometry/createPresentation.ts
@@ -1,0 +1,118 @@
+import createChannel from "../observable/createChannel.js";
+import sizingEquals from "./sizingEquals.js";
+import type { ColumnSizing, ColumnToSize } from "./types.js";
+
+/** Immutable presentation snapshot: declared sizing plus user overrides. */
+export type PresentationState = {
+  /** The declared sizing per column id. */
+  readonly declared: Readonly<Record<string, ColumnSizing>>;
+  /** User-fixed sizing overrides per column id. */
+  readonly overrides: Readonly<Record<string, ColumnSizing>>;
+  /** Bumped on every accepted presentation change. */
+  readonly revision: number;
+};
+
+/** Handle of one presentation record. */
+export type Presentation = {
+  readonly state: PresentationState;
+  /** Observe presentation changes; snapshots are immutable between sets. */
+  readonly subscribe: (listener: () => void) => () => void;
+  /** The effective sizing of one column: its override, else its declared sizing. */
+  readonly effective: (id: string) => ColumnSizing;
+  /** Record a user-fixed sizing override (a resize commit). */
+  readonly setOverride: (id: string, sizing: ColumnSizing) => void;
+  /** Drop one column's override, restoring its declared sizing. */
+  readonly resetOverride: (id: string) => void;
+  /** Drop every override, restoring all declared sizing. */
+  readonly reset: () => void;
+  /** The columns to size: declared sizing with overrides applied. */
+  readonly toColumns: () => readonly ColumnToSize[];
+};
+
+/**
+ * Create the presentation record for one collection's columns: declared
+ * sizing plus user-fixed overrides, with a channel published on change.
+ */
+export default function createPresentation(
+  columns: readonly ColumnToSize[],
+): Presentation {
+  const declared: Record<string, ColumnSizing> = {};
+  for (const column of columns) {
+    if (column.id === "") {
+      throw new Error("column id must not be empty");
+    }
+    if (Object.hasOwn(declared, column.id)) {
+      throw new Error(`duplicate column id "${column.id}"`);
+    }
+    declared[column.id] = column.sizing;
+  }
+  const initialDeclared = Object.freeze({ ...declared });
+  // Copied at construction: toColumns() must not answer from the
+  // caller's array, which it may still mutate.
+  const order: readonly string[] = Object.freeze(
+    columns.map((column) => column.id),
+  );
+
+  let overrides: Readonly<Record<string, ColumnSizing>> = Object.freeze({});
+  const channel = createChannel<PresentationState>(
+    Object.freeze({
+      declared: initialDeclared,
+      overrides,
+      revision: 0,
+    }),
+  );
+
+  const publish = (next: Readonly<Record<string, ColumnSizing>>): void => {
+    overrides = next;
+    channel.set(
+      Object.freeze({
+        declared: initialDeclared,
+        overrides,
+        revision: channel.get().revision + 1,
+      }),
+    );
+  };
+
+  return {
+    get state(): PresentationState {
+      return channel.get();
+    },
+    subscribe: (listener: () => void) => channel.subscribe(listener),
+    effective(id: string): ColumnSizing {
+      if (!Object.hasOwn(initialDeclared, id)) {
+        throw new Error(`unknown column id "${id}"`);
+      }
+      return overrides[id] ?? initialDeclared[id];
+    },
+    setOverride(id: string, sizing: ColumnSizing): void {
+      if (!Object.hasOwn(initialDeclared, id)) {
+        throw new Error(`unknown column id "${id}"`);
+      }
+      const current = overrides[id];
+      if (current !== undefined && sizingEquals(current, sizing)) {
+        return;
+      }
+      publish(Object.freeze({ ...overrides, [id]: sizing }));
+    },
+    resetOverride(id: string): void {
+      if (!Object.hasOwn(overrides, id)) {
+        return;
+      }
+      const next = { ...overrides };
+      delete next[id];
+      publish(Object.freeze(next));
+    },
+    reset(): void {
+      if (Object.keys(overrides).length === 0) {
+        return;
+      }
+      publish(Object.freeze({}));
+    },
+    toColumns(): readonly ColumnToSize[] {
+      return order.map((id) => ({
+        id,
+        sizing: overrides[id] ?? initialDeclared[id],
+      }));
+    },
+  };
+}

--- a/packages/runtime/dataviews/src/lib/geometry/index.ts
+++ b/packages/runtime/dataviews/src/lib/geometry/index.ts
@@ -1,0 +1,12 @@
+export type {
+  GridInteraction,
+  GridInteractionState,
+} from "./createGridInteraction.js";
+export { default as createGridInteraction } from "./createGridInteraction.js";
+export type {
+  Presentation,
+  PresentationState,
+} from "./createPresentation.js";
+export { default as createPresentation } from "./createPresentation.js";
+export { default as resolveColumns } from "./resolveColumns.js";
+export type * from "./types.js";

--- a/packages/runtime/dataviews/src/lib/geometry/resolveColumns.test.ts
+++ b/packages/runtime/dataviews/src/lib/geometry/resolveColumns.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, it } from "vitest";
+import resolveColumns from "./resolveColumns.js";
+import type { ColumnToSize } from "./types.js";
+
+const fixed = (id: string, px: number): ColumnToSize => ({
+  id,
+  sizing: { kind: "fixed", px },
+});
+
+const flex = (
+  id: string,
+  weight: number,
+  minPx: number,
+  maxPx?: number,
+): ColumnToSize => ({
+  id,
+  sizing: {
+    kind: "flex",
+    weight,
+    minPx,
+    ...(maxPx === undefined ? {} : { maxPx }),
+  },
+});
+
+const widths = (resolved: readonly { id: string; width: number }[]) =>
+  Object.fromEntries(resolved.map((column) => [column.id, column.width]));
+
+describe("resolveColumns", () => {
+  it("reserves fixed columns at their declared width", () => {
+    const result = resolveColumns(
+      [fixed("name", 200), fixed("zone", 100)],
+      500,
+    );
+    expect(widths(result)).toEqual({ name: 200, zone: 100 });
+  });
+
+  it("shares remaining width among flex columns by weight", () => {
+    const result = resolveColumns(
+      [fixed("id", 100), flex("name", 2, 100), flex("description", 1, 100)],
+      700,
+    );
+    // Remaining 700 - 100 - 200 = 400; name takes 2/3, description 1/3.
+    expect(widths(result).name).toBeCloseTo(100 + (400 * 2) / 3, 5);
+    expect(widths(result).description).toBeCloseTo(100 + 400 / 3, 5);
+  });
+
+  it("preserves declared widths on overflow so the container scrolls", () => {
+    const result = resolveColumns(
+      [fixed("id", 200), flex("name", 1, 300), flex("zone", 1, 200)],
+      400,
+    );
+    expect(widths(result)).toEqual({ id: 200, name: 300, zone: 200 });
+  });
+
+  it("caps flexible columns at maxPx and redistributes the unused share", () => {
+    const result = resolveColumns(
+      [flex("name", 1, 100, 200), flex("description", 1, 100)],
+      800,
+    );
+    // 800 - 200 minima = 600 shared equally: each asks 300 over its minimum.
+    // Name caps at 200 and description absorbs the rest.
+    expect(widths(result).name).toBe(200);
+    expect(widths(result).description).toBe(600);
+  });
+
+  it("leaves leftover space unassigned when every column is capped or fixed", () => {
+    const result = resolveColumns(
+      [fixed("id", 100), flex("name", 1, 100, 200)],
+      600,
+    );
+    expect(widths(result)).toEqual({ id: 100, name: 200 });
+    const total = result.reduce((sum, column) => sum + column.width, 0);
+    expect(total).toBe(300);
+    expect(total).toBeLessThan(600);
+  });
+
+  it("keeps zero-weight flex columns at their minimum", () => {
+    const result = resolveColumns(
+      [flex("name", 0, 100), flex("description", 1, 100)],
+      500,
+    );
+    // 500 - 200 minima = 300 extra, all to the only positive weight.
+    expect(widths(result).name).toBe(100);
+    expect(widths(result).description).toBe(400);
+  });
+
+  it("keeps all zero-weight flex columns at minima with spare width left", () => {
+    const result = resolveColumns([flex("name", 0, 100)], 500);
+    expect(widths(result).name).toBe(100);
+    const total = result.reduce((sum, column) => sum + column.width, 0);
+    expect(total).toBe(100);
+  });
+
+  it("stops redistributing when nothing can absorb the share", () => {
+    const result = resolveColumns(
+      [flex("stuck", 1, 100, 100), flex("still", 0, 50)],
+      500,
+    );
+    // stuck is already at its cap (minPx === maxPx); still has weight 0.
+    expect(widths(result)).toEqual({ stuck: 100, still: 50 });
+  });
+
+  it("handles a window smaller than a single column", () => {
+    const result = resolveColumns([flex("name", 1, 200)], 100);
+    expect(widths(result).name).toBe(200);
+  });
+
+  it("rejects invalid sizing with reasons", () => {
+    const cases: ColumnToSize[][] = [
+      [{ id: "a", sizing: { kind: "fixed", px: -1 } }],
+      [{ id: "a", sizing: { kind: "fixed", px: Number.NaN } }],
+      [{ id: "a", sizing: { kind: "flex", weight: -1, minPx: 10 } }],
+      [{ id: "a", sizing: { kind: "flex", weight: 1, minPx: Number.NaN } }],
+      [
+        {
+          id: "a",
+          sizing: { kind: "flex", weight: 1, minPx: 200, maxPx: 100 },
+        },
+      ],
+      [
+        {
+          id: "a",
+          sizing: {
+            kind: "flex",
+            weight: 1,
+            minPx: 100,
+            maxPx: Number.POSITIVE_INFINITY,
+          },
+        },
+      ],
+    ];
+    for (const columns of cases) {
+      expect(() => resolveColumns(columns, 500)).toThrow(/needs|≥/);
+    }
+    expect(() => resolveColumns([], Number.NaN)).toThrow("available width");
+    expect(() => resolveColumns([], -5)).toThrow("available width");
+  });
+
+  it("returns widths in the input column order", () => {
+    const result = resolveColumns(
+      [flex("b", 1, 50), fixed("a", 100), flex("c", 1, 50)],
+      400,
+    );
+    expect(result.map((column) => column.id)).toEqual(["b", "a", "c"]);
+  });
+});

--- a/packages/runtime/dataviews/src/lib/geometry/resolveColumns.ts
+++ b/packages/runtime/dataviews/src/lib/geometry/resolveColumns.ts
@@ -1,0 +1,116 @@
+import type { ColumnToSize, FlexSizing, ResolvedColumn } from "./types.js";
+
+/** A column's width while the solver runs. */
+type Slot = { readonly id: string; width: number };
+
+/** A flexible column paired with the slot the water-fill grows. */
+type FlexEntry = { readonly slot: Slot; readonly sizing: FlexSizing };
+
+const sizingRejection = (column: ColumnToSize): string | null => {
+  const { sizing } = column;
+  if (sizing.kind === "fixed") {
+    if (!Number.isFinite(sizing.px) || sizing.px < 0) {
+      return `column "${column.id}" needs a non-negative finite px`;
+    }
+    return null;
+  }
+  if (!Number.isFinite(sizing.weight) || sizing.weight < 0) {
+    return `column "${column.id}" needs a non-negative finite weight`;
+  }
+  if (!Number.isFinite(sizing.minPx) || sizing.minPx < 0) {
+    return `column "${column.id}" needs a non-negative finite minPx`;
+  }
+  if (sizing.maxPx !== undefined) {
+    if (!Number.isFinite(sizing.maxPx) || sizing.maxPx < sizing.minPx) {
+      return `column "${column.id}" needs maxPx ≥ minPx`;
+    }
+  }
+  return null;
+};
+
+/**
+ * Resolve one column-width vector: fixed columns reserve their declared px;
+ * flexible columns reserve their minima, then share the remaining width by
+ * weight until capped at maxPx, with unused shares redistributed among the
+ * remaining flexible columns. When minima plus fixed widths exceed the
+ * available width, declared widths are preserved (the container scrolls).
+ * When every column is capped or fixed, leftover space stays unassigned.
+ */
+export default function resolveColumns(
+  columns: readonly ColumnToSize[],
+  availableWidth: number,
+): readonly ResolvedColumn[] {
+  for (const column of columns) {
+    const rejection = sizingRejection(column);
+    if (rejection !== null) {
+      throw new Error(rejection);
+    }
+  }
+  if (!Number.isFinite(availableWidth) || availableWidth < 0) {
+    throw new Error("available width must be a non-negative finite number");
+  }
+
+  // Seed every column at its reservation, so no later step needs a
+  // missing-width fallback. Flex entries share the slot they grow.
+  const slots: Slot[] = [];
+  const flex: FlexEntry[] = [];
+  let fixedTotal = 0;
+  let minTotal = 0;
+  for (const column of columns) {
+    if (column.sizing.kind === "fixed") {
+      slots.push({ id: column.id, width: column.sizing.px });
+      fixedTotal += column.sizing.px;
+    } else {
+      const slot: Slot = { id: column.id, width: column.sizing.minPx };
+      slots.push(slot);
+      flex.push({ slot, sizing: column.sizing });
+      minTotal += column.sizing.minPx;
+    }
+  }
+
+  if (fixedTotal + minTotal >= availableWidth) {
+    // Overflow: the reservations are the declared widths already.
+    return toVector(slots);
+  }
+
+  let remaining = availableWidth - fixedTotal - minTotal;
+  let active: readonly FlexEntry[] = flex;
+  while (remaining > 0 && active.length > 0) {
+    const totalWeight = active.reduce(
+      (sum, entry) => sum + entry.sizing.weight,
+      0,
+    );
+    if (totalWeight === 0) {
+      break;
+    }
+    let spent = 0;
+    const stillActive: FlexEntry[] = [];
+    for (const entry of active) {
+      const share = (remaining * entry.sizing.weight) / totalWeight;
+      const maxPx = entry.sizing.maxPx;
+      const headroom =
+        maxPx === undefined
+          ? Number.POSITIVE_INFINITY
+          : maxPx - entry.slot.width;
+      if (share <= headroom) {
+        entry.slot.width += share;
+        spent += share;
+        stillActive.push(entry);
+      } else {
+        // Cap at maxPx without a non-null assertion: headroom is finite here.
+        entry.slot.width += headroom;
+        spent += headroom;
+      }
+    }
+    if (spent === 0) {
+      break;
+    }
+    remaining -= spent;
+    active = stillActive;
+  }
+
+  return toVector(slots);
+}
+
+const toVector = (slots: readonly Slot[]): readonly ResolvedColumn[] =>
+  slots.map(({ id, width }) => ({ id, width }));

--- a/packages/runtime/dataviews/src/lib/geometry/sizingEquals.ts
+++ b/packages/runtime/dataviews/src/lib/geometry/sizingEquals.ts
@@ -1,0 +1,14 @@
+import type { ColumnSizing } from "./types.js";
+
+/** Structural equality of two column sizings. */
+export default function sizingEquals(
+  a: ColumnSizing,
+  b: ColumnSizing,
+): boolean {
+  return a.kind === "fixed"
+    ? b.kind === "fixed" && a.px === b.px
+    : b.kind === "flex" &&
+        a.weight === b.weight &&
+        a.minPx === b.minPx &&
+        a.maxPx === b.maxPx;
+}

--- a/packages/runtime/dataviews/src/lib/geometry/types.ts
+++ b/packages/runtime/dataviews/src/lib/geometry/types.ts
@@ -1,0 +1,34 @@
+/**
+ * Column sizing intent and resolved geometry. Declared sizing is a fixed
+ * pixel reservation or a flex weight with bounds; user resizing creates a
+ * fixed override.
+ */
+
+/** Fixed sizing: reserve exactly these pixels. */
+export type FixedSizing = {
+  readonly kind: "fixed";
+  readonly px: number;
+};
+
+/** Flex sizing: reserve `minPx`, then share remaining width by `weight` until `maxPx`. */
+export type FlexSizing = {
+  readonly kind: "flex";
+  readonly weight: number;
+  readonly minPx: number;
+  readonly maxPx?: number;
+};
+
+/** One column's sizing intent. */
+export type ColumnSizing = FixedSizing | FlexSizing;
+
+/** A column the solver sizes: identity plus sizing intent. */
+export type ColumnToSize = {
+  readonly id: string;
+  readonly sizing: ColumnSizing;
+};
+
+/** One resolved column width. */
+export type ResolvedColumn = {
+  readonly id: string;
+  readonly width: number;
+};

--- a/packages/runtime/dataviews/src/lib/index.ts
+++ b/packages/runtime/dataviews/src/lib/index.ts
@@ -2,6 +2,7 @@ export * from "./collection/index.js";
 export type { Identity } from "./createIdentity.js";
 export { default as createIdentity } from "./createIdentity.js";
 export * from "./field/index.js";
+export * from "./geometry/index.js";
 export { default as isIdentity } from "./isIdentity.js";
 export * from "./location/index.js";
 export * from "./observable/index.js";


### PR DESCRIPTION
## Done

Adds the shared column geometry to `@canonical/dataviews-core`. Framework-neutral: no renderer, no DOM.

- `resolveColumns(columns, availableWidth)` — fixed columns reserve their declared px; flexible columns reserve their minima, then share the remainder by weight, capping at `maxPx` and redistributing the unused share among the still-active columns. If fixed widths plus minima meet or exceed the available width, the declared widths stand and the container scrolls. When every column is fixed or capped, leftover space stays unassigned rather than being forced onto a column.
- `createPresentation(columns)` — declared sizing plus user overrides behind a channel: `effective`, `setOverride`, `resetOverride`, `reset`, `toColumns`. Empty and duplicate ids are rejected at construction. All three write paths are equality-guarded, so a write restating the sizing already recorded notifies nobody and does not bump the revision.
- `createGridInteraction(presentation)` — one live resize preview per table. Previews clamp to the column's bounds and never touch the authoritative presentation, so cancel has nothing to restore; commit ends the interaction before writing its fixed override. An external change to the resizing column invalidates the preview; an unrelated column's does not. Coalescing previews to animation frames stays the renderer's concern.
- Internal `sizingEquals` is the one structural comparison used by both the presentation guard and the interaction's conflict check.

Merge order: #1199 must land first — this branch is based on it, and the four below it, so that the diff here is only the geometry.

## QA

- `bun run check` green at the root (68 projects).
- Package: 272/272 tests, 100% branch/function/line/statement coverage through the standard `test` target; `tsc -p tsconfig.build.json` emits cleanly.
- `nx run-many -t test` green for both dataviews packages (core 272/272, react 23/23). The three svelte browser-mode packages fail on this host only (missing Playwright OS dependencies) and `pragma-cli` is flaky under full parallel load; neither is touched by this diff.

### Drive-by not taken

`lib/selection/createSelection.ts` has an unused `Channel` type import (one biome warning). It came in with #1196 and is left there rather than fixed across a branch boundary.

### PR readiness check

- [x] PR title follows the Conventional Commits format.
- [x] The code follows the appropriate code standards.
- [x] The package defines `check`, `check:fix`, `test`, `build`, `build:all`.
- [x] No visual surface — Chromatic: skip label applied.

Chromatic: skip

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)