### PR TITLE
feat(ds-global): add interactive panels to ContextualMenu

### DIFF
--- a/packages/react/ds-global/src/lib/component/Button/Button.tests.tsx
+++ b/packages/react/ds-global/src/lib/component/Button/Button.tests.tsx
@@ -1,4 +1,5 @@
 import { render, screen } from "@testing-library/react";
+import { createRef } from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import Component from "./Button.js";
 
@@ -237,6 +238,14 @@ describe("Button component", () => {
   });
 
   describe("HTML attributes", () => {
+    it("forwards a ref to the native button", () => {
+      const ref = createRef<HTMLButtonElement>();
+      render(<Component ref={ref}>Test</Component>);
+
+      expect(ref.current).toBe(screen.getByRole("button"));
+      expect(ref.current).toBeInstanceOf(HTMLButtonElement);
+    });
+
     it("passes through HTML button attributes", () => {
       render(
         <Component type="submit" name="submitBtn" value="submit">

--- a/packages/react/ds-global/src/lib/component/Button/Button.tsx
+++ b/packages/react/ds-global/src/lib/component/Button/Button.tsx
@@ -1,4 +1,5 @@
 import type React from "react";
+import { forwardRef } from "react";
 import { Spinner } from "../../subcomponent/Spinner/index.js";
 import { Icon } from "../Icon/index.js";
 import type Props from "./types.js";
@@ -15,19 +16,22 @@ const componentCssClassName = "ds button";
  *
  * @implements ds:global.component.button
  */
-const Button = ({
-  id,
-  className,
-  children,
-  style,
-  importance = "primary",
-  anticipation,
-  variant,
-  icon,
-  loading = false,
-  disabled,
-  ...props
-}: Props): React.ReactElement => {
+const Button = forwardRef<HTMLButtonElement, Props>(function Button(
+  {
+    id,
+    className,
+    children,
+    style,
+    importance = "primary",
+    anticipation,
+    variant,
+    icon,
+    loading = false,
+    disabled,
+    ...props
+  },
+  ref,
+): React.ReactElement {
   // Booleans and nullish children render nothing; everything else (including
   // the number 0) produces visible text that names the button.
   const hasVisibleChildren =
@@ -56,6 +60,7 @@ const Button = ({
 
   return (
     <button
+      ref={ref}
       id={id}
       className={[
         componentCssClassName,
@@ -68,10 +73,10 @@ const Button = ({
         .filter(Boolean)
         .join(" ")}
       style={style}
+      {...props}
       // A loading button is busy and must not be re-triggered mid-action.
       aria-busy={loading || undefined}
       disabled={disabled || loading}
-      {...props}
     >
       {/* The icon and label stay in the DOM while loading so the button keeps
           its width; CSS hides them (visibility:hidden) and the Spinner is
@@ -86,6 +91,8 @@ const Button = ({
       )}
     </button>
   );
-};
+});
+
+Button.displayName = "Button";
 
 export default Button;

--- a/packages/react/ds-global/src/lib/component/ContextualMenu/ContextualMenu.hydration.tests.tsx
+++ b/packages/react/ds-global/src/lib/component/ContextualMenu/ContextualMenu.hydration.tests.tsx
@@ -40,4 +40,28 @@ describe("ContextualMenu (hydration)", () => {
     // replaced by a mismatch recovery.
     expect(container.querySelector(".trigger")?.textContent).toBe("Actions");
   });
+
+  it("hydrates a Button trigger from triggerProps with no recoverable error", () => {
+    const ui = (
+      <ContextualMenu
+        trigger="Filters"
+        triggerProps={{ importance: "secondary", className: "ssr-trigger" }}
+        items={items}
+      />
+    );
+
+    const container = document.createElement("div");
+    container.innerHTML = renderToString(ui);
+    document.body.appendChild(container);
+
+    const onRecoverableError = vi.fn();
+    act(() => {
+      hydrateRoot(container, ui, { onRecoverableError });
+    });
+
+    expect(onRecoverableError).not.toHaveBeenCalled();
+    expect(container.querySelector(".ssr-trigger")?.textContent).toBe(
+      "Filters",
+    );
+  });
 });

--- a/packages/react/ds-global/src/lib/component/ContextualMenu/ContextualMenu.ssr.tests.tsx
+++ b/packages/react/ds-global/src/lib/component/ContextualMenu/ContextualMenu.ssr.tests.tsx
@@ -32,4 +32,20 @@ describe("ContextualMenu SSR", () => {
     expect(html).toContain('aria-expanded="false"');
     expect(html).toContain('aria-hidden="true"');
   });
+
+  it("renders a Pragma Button trigger from triggerProps on the server", () => {
+    const html = renderToString(
+      <ContextualMenu
+        trigger="Filters"
+        triggerProps={{ importance: "secondary", className: "ssr-trigger" }}
+        items={items}
+      />,
+    );
+
+    expect(html).toContain("ds button");
+    expect(html).toContain("secondary");
+    expect(html).toContain("ssr-trigger");
+    expect(html).toContain('aria-expanded="false"');
+    expect(html).toContain('aria-hidden="true"');
+  });
 });

--- a/packages/react/ds-global/src/lib/component/ContextualMenu/ContextualMenu.stories.tsx
+++ b/packages/react/ds-global/src/lib/component/ContextualMenu/ContextualMenu.stories.tsx
@@ -1,5 +1,6 @@
 import type { Decorator, Meta, StoryObj } from "@storybook/react-vite";
-import { useEffect } from "react";
+import { type CSSProperties, useEffect, useState } from "react";
+import { Badge } from "../Badge/index.js";
 import Component from "./ContextualMenu.js";
 import type { MenuEntry } from "./types.js";
 
@@ -164,6 +165,167 @@ export const CustomItems_NotCoreApi: Story = {
         ),
       },
     ],
+  },
+};
+
+const TAG_OPTIONS = [
+  "web",
+  "database",
+  "cache",
+  "production",
+  "staging",
+  "gpu",
+] as const;
+
+const filterSearchStyle: CSSProperties = {
+  inlineSize: "100%",
+  boxSizing: "border-box",
+  paddingBlock: "var(--dimension-100, 8px)",
+  paddingInline: "var(--dimension-150, 12px)",
+  border:
+    "var(--dimension-stroke-thickness-medium, 1px) solid var(--color-border, currentColor)",
+  borderRadius: "var(--border-radius, 4px)",
+  background: "var(--color-background, transparent)",
+  color: "inherit",
+  font: "inherit",
+};
+
+const filterPanelStyle: CSSProperties = {
+  display: "grid",
+  gap: "var(--dimension-100, 8px)",
+};
+
+const filterListStyle: CSSProperties = {
+  listStyle: "none",
+  margin: 0,
+  padding: 0,
+};
+
+const filterRowStyle: CSSProperties = {
+  display: "flex",
+  alignItems: "center",
+  gap: "var(--dimension-100, 8px)",
+  paddingBlock: "var(--dimension-50, 4px)",
+};
+
+const filterFooterStyle: CSSProperties = {
+  display: "flex",
+  justifyContent: "space-between",
+  gap: "var(--dimension-100, 8px)",
+  borderBlockStart:
+    "var(--dimension-stroke-thickness-medium, 1px) solid var(--color-border-muted, currentColor)",
+  paddingBlockStart: "var(--dimension-100, 8px)",
+};
+
+const filterTextActionStyle: CSSProperties = {
+  appearance: "none",
+  margin: 0,
+  padding: 0,
+  border: 0,
+  background: "none",
+  color: "inherit",
+  font: "inherit",
+  textDecoration: "underline",
+  cursor: "pointer",
+};
+
+/**
+ * A table column filter: search plus a checkbox list. Those controls need
+ * native Tab and text selection, which a selectable `menuitem` cannot host.
+ * `displayItemsType: "panel"` keeps that surface inside the menu; Escape still
+ * closes.
+ */
+export const StyledTriggerWithInteractivePanel: Story = {
+  args: {
+    trigger: "Tags",
+    items: [],
+  },
+  render: () => {
+    const [search, setSearch] = useState("");
+    const [selected, setSelected] = useState<string[]>(["web", "production"]);
+    const visibleTags = TAG_OPTIONS.filter((tag) =>
+      tag.includes(search.trim()),
+    );
+
+    const toggleTag = (tag: string) => {
+      setSelected((current) =>
+        current.includes(tag)
+          ? current.filter((value) => value !== tag)
+          : [...current, tag],
+      );
+    };
+
+    return (
+      <Component
+        trigger={
+          <>
+            Tags
+            {selected.length > 0 ? (
+              <Badge
+                value={selected.length}
+                style={{ marginInlineStart: "var(--dimension-50, 4px)" }}
+              />
+            ) : null}
+          </>
+        }
+        triggerProps={{
+          icon: "filter",
+          importance: "secondary",
+        }}
+        label="Tags"
+        highlightFirstItem={false}
+        maxWidth="18rem"
+        items={[
+          {
+            key: "tags",
+            label: "Tags",
+            displayItemsType: "panel",
+            Component: () => (
+              <div style={filterPanelStyle}>
+                <input
+                  type="search"
+                  aria-label="Search tags"
+                  placeholder="Search"
+                  value={search}
+                  style={filterSearchStyle}
+                  onChange={(event) => setSearch(event.target.value)}
+                />
+                <ul style={filterListStyle}>
+                  {visibleTags.map((tag) => (
+                    <li key={tag}>
+                      <label style={filterRowStyle}>
+                        <input
+                          type="checkbox"
+                          checked={selected.includes(tag)}
+                          onChange={() => toggleTag(tag)}
+                        />
+                        {tag}
+                      </label>
+                    </li>
+                  ))}
+                </ul>
+                <div style={filterFooterStyle}>
+                  <button
+                    type="button"
+                    style={filterTextActionStyle}
+                    onClick={() => setSelected([...visibleTags])}
+                  >
+                    Select all
+                  </button>
+                  <button
+                    type="button"
+                    style={filterTextActionStyle}
+                    onClick={() => setSelected([])}
+                  >
+                    Clear
+                  </button>
+                </div>
+              </div>
+            ),
+          },
+        ]}
+      />
+    );
   },
 };
 

--- a/packages/react/ds-global/src/lib/component/ContextualMenu/ContextualMenu.tests.tsx
+++ b/packages/react/ds-global/src/lib/component/ContextualMenu/ContextualMenu.tests.tsx
@@ -1,4 +1,12 @@
-import { fireEvent, render, screen, within } from "@testing-library/react";
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+  within,
+} from "@testing-library/react";
+import { createRef, type MouseEvent } from "react";
 import { describe, expect, it, vi } from "vitest";
 import ContextualMenu from "./ContextualMenu.js";
 import type { MenuEntry, MenuItem } from "./types.js";
@@ -39,6 +47,125 @@ describe("ContextualMenu", () => {
     );
   });
 
+  it("renders a Pragma Button trigger and composes its custom class", () => {
+    const onClick = vi.fn();
+    renderMenu({
+      triggerProps: {
+        className: "custom-trigger",
+        importance: "secondary",
+        onClick,
+      },
+    });
+    const trigger = screen.getByRole("button", { name: "Actions" });
+
+    expect(trigger).toHaveClass(
+      "ds",
+      "button",
+      "trigger",
+      "custom-trigger",
+      "secondary",
+    );
+    fireEvent.click(trigger);
+    expect(onClick).toHaveBeenCalledOnce();
+    expect(trigger).toHaveAttribute("aria-expanded", "true");
+  });
+
+  it("composes triggerProps.ref onto the native button", () => {
+    const triggerRef = createRef<HTMLButtonElement>();
+    renderMenu({ triggerProps: { ref: triggerRef } });
+    const trigger = screen.getByRole("button", { name: "Actions" });
+
+    expect(triggerRef.current).toBe(trigger);
+    fireEvent.click(trigger);
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(trigger).toHaveFocus();
+  });
+
+  it("does not open when the consumer click handler prevents default", () => {
+    renderMenu({
+      triggerProps: {
+        onClick: (event: MouseEvent<HTMLButtonElement>) =>
+          event.preventDefault(),
+      },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Actions" }));
+    expect(screen.getByRole("menu", { hidden: true })).toHaveAttribute(
+      "aria-hidden",
+      "true",
+    );
+  });
+
+  it("keeps the native trigger when triggerProps is absent", () => {
+    renderMenu();
+    expect(screen.getByRole("button", { name: "Actions" })).toHaveClass(
+      "trigger",
+    );
+    expect(screen.getByRole("button", { name: "Actions" })).not.toHaveClass(
+      "ds",
+      "button",
+    );
+  });
+
+  it("reports uncontrolled open changes", () => {
+    const onOpenChange = vi.fn();
+    renderMenu({ onOpenChange });
+    fireEvent.click(screen.getByRole("button", { name: "Actions" }));
+    fireEvent.click(screen.getByRole("menuitem", { name: "Copy" }));
+    expect(onOpenChange.mock.calls).toEqual([[true], [false]]);
+  });
+
+  it("supports controlled open state", () => {
+    const onOpenChange = vi.fn();
+    const { rerender } = render(
+      <ContextualMenu
+        trigger="Actions"
+        items={items}
+        open={false}
+        onOpenChange={onOpenChange}
+      />,
+    );
+    const trigger = screen.getByRole("button", { name: "Actions" });
+    fireEvent.click(trigger);
+    expect(onOpenChange).toHaveBeenLastCalledWith(true);
+    expect(screen.getByRole("menu", { hidden: true })).toHaveAttribute(
+      "aria-hidden",
+      "true",
+    );
+
+    rerender(
+      <ContextualMenu
+        trigger="Actions"
+        items={items}
+        open
+        onOpenChange={onOpenChange}
+      />,
+    );
+    expect(screen.getByRole("menu")).toHaveAttribute("aria-hidden", "false");
+    fireEvent.click(trigger);
+    expect(onOpenChange).toHaveBeenLastCalledWith(false);
+  });
+
+  describe("accessible menu labels", () => {
+    it("uses a string label directly", () => {
+      renderMenu({ label: "Action menu" });
+      fireEvent.click(screen.getByRole("button", { name: "Actions" }));
+      expect(screen.getByRole("menu", { name: "Action menu" })).toHaveAttribute(
+        "aria-label",
+        "Action menu",
+      );
+    });
+
+    it("falls back to the trigger when no label is supplied", () => {
+      renderMenu();
+      const trigger = screen.getByRole("button", { name: "Actions" });
+      fireEvent.click(trigger);
+      expect(screen.getByRole("menu", { name: "Actions" })).toHaveAttribute(
+        "aria-labelledby",
+        trigger.id,
+      );
+    });
+  });
+
   it("renders items and separators", () => {
     renderMenu();
     expect(screen.getByText("Cut")).toBeInTheDocument();
@@ -72,7 +199,8 @@ describe("ContextualMenu", () => {
     expect(screen.getByText("⌘S")).toHaveClass("slot");
   });
 
-  it("renders a custom item component", () => {
+  it("renders a custom item as a selectable menuitem", () => {
+    const onSelect = vi.fn();
     const custom: MenuEntry[] = [
       {
         key: "custom",
@@ -81,8 +209,24 @@ describe("ContextualMenu", () => {
         Component: () => <span data-testid="custom-render">Custom!</span>,
       },
     ];
-    render(<ContextualMenu trigger="More" items={custom} />);
+    render(
+      <ContextualMenu trigger="More" items={custom} onSelect={onSelect} />,
+    );
+    const item = screen.getByRole("menuitem", {
+      hidden: true,
+      name: "Custom!",
+    });
     expect(screen.getByTestId("custom-render")).toBeInTheDocument();
+    expect(item).toHaveClass("contextual-menu-item");
+    fireEvent.click(screen.getByRole("button", { name: "More" }));
+    fireEvent.click(item);
+    expect(onSelect).toHaveBeenCalledWith(
+      expect.objectContaining({ key: "custom" }),
+    );
+    expect(screen.getByRole("menu", { hidden: true })).toHaveAttribute(
+      "aria-hidden",
+      "true",
+    );
   });
 
   it("closes on Escape", () => {
@@ -94,6 +238,24 @@ describe("ContextualMenu", () => {
       "aria-hidden",
       "true",
     );
+  });
+
+  it("stays open on Escape when closeOnEscape is false", () => {
+    renderMenu({ closeOnEscape: false });
+    fireEvent.click(screen.getByRole("button", { name: "Actions" }));
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(screen.getByRole("menu")).toHaveAttribute("aria-hidden", "false");
+  });
+
+  it("keeps menuitem focus on Escape when closeOnEscape is false", async () => {
+    renderMenu({ closeOnEscape: false });
+    fireEvent.click(screen.getByRole("button", { name: "Actions" }));
+    const cut = screen.getByRole("menuitem", { name: "Cut" });
+    await waitFor(() => expect(cut).toHaveFocus());
+    fireEvent.keyDown(cut, { key: "Escape" });
+    expect(screen.getByRole("menu")).toHaveAttribute("aria-hidden", "false");
+    expect(cut).toHaveFocus();
+    expect(cut).toHaveAttribute("data-highlighted", "true");
   });
 
   it("returns focus to the trigger on Escape", () => {
@@ -171,11 +333,118 @@ describe("ContextualMenu", () => {
       expect(screen.getByText("Sub one")).toBeInTheDocument();
       expect(parent).toHaveAttribute("aria-expanded", "true");
 
-      fireEvent.pointerLeave(anchor as HTMLElement);
-      expect(screen.queryByText("Sub one")).not.toBeInTheDocument();
-      expect(parent).toHaveAttribute("aria-expanded", "false");
-      // Closed popup: no dangling aria-controls IDREF.
-      expect(parent).not.toHaveAttribute("aria-controls");
+      vi.useFakeTimers();
+      try {
+        fireEvent.pointerLeave(anchor as HTMLElement);
+        expect(screen.getByText("Sub one")).toBeInTheDocument();
+        act(() => vi.advanceTimersByTime(120));
+        expect(screen.queryByText("Sub one")).not.toBeInTheDocument();
+        expect(parent).toHaveAttribute("aria-expanded", "false");
+        // Closed popup: no dangling aria-controls IDREF.
+        expect(parent).not.toHaveAttribute("aria-controls");
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("positions a keyboard-opened submenu and restores focus on ArrowLeft", async () => {
+      const rect = {
+        x: 100,
+        y: 100,
+        top: 100,
+        right: 200,
+        bottom: 132,
+        left: 100,
+        width: 100,
+        height: 32,
+        toJSON: () => ({}),
+      } as DOMRect;
+      const rectSpy = vi
+        .spyOn(HTMLElement.prototype, "getBoundingClientRect")
+        .mockReturnValue(rect);
+
+      try {
+        const { menu, parent } = openSubmenuMenu();
+        fireEvent.keyDown(menu, { key: "ArrowDown" });
+        fireEvent.keyDown(menu, { key: "ArrowRight" });
+
+        const submenu = screen.getByRole("menu", { name: "Parent" });
+        const firstChild = within(submenu).getByRole("menuitem", {
+          name: "Sub one",
+        });
+        await waitFor(() =>
+          expect(submenu).toHaveAttribute("data-positioned", "true"),
+        );
+        await waitFor(() => expect(firstChild).toHaveFocus());
+
+        fireEvent.keyDown(firstChild, { key: "ArrowLeft" });
+        await waitFor(() => expect(parent).toHaveFocus());
+        expect(screen.queryByRole("menu", { name: "Parent" })).toBeNull();
+      } finally {
+        rectSpy.mockRestore();
+      }
+    });
+
+    it("places a keyboard-opened submenu toward inline-end, mirrored in RTL", async () => {
+      const originalDir = document.documentElement.dir;
+      const parentRect = {
+        x: 200,
+        y: 80,
+        top: 80,
+        right: 320,
+        bottom: 112,
+        left: 200,
+        width: 120,
+        height: 32,
+        toJSON: () => ({}),
+      } as DOMRect;
+      const submenuRect = {
+        x: 0,
+        y: 0,
+        top: 0,
+        right: 160,
+        bottom: 80,
+        left: 0,
+        width: 160,
+        height: 80,
+        toJSON: () => ({}),
+      } as DOMRect;
+      const rectSpy = vi
+        .spyOn(HTMLElement.prototype, "getBoundingClientRect")
+        .mockImplementation(function (this: HTMLElement) {
+          return this.getAttribute("role") === "menu" &&
+            this.classList.contains("submenu")
+            ? submenuRect
+            : parentRect;
+        });
+
+      try {
+        const { menu } = openSubmenuMenu();
+        fireEvent.keyDown(menu, { key: "ArrowDown" });
+        fireEvent.keyDown(menu, { key: "ArrowRight" });
+        const ltrSubmenu = await screen.findByRole("menu", { name: "Parent" });
+        await waitFor(() =>
+          expect(ltrSubmenu).toHaveAttribute("data-positioned", "true"),
+        );
+        expect(ltrSubmenu).toHaveClass("right");
+
+        act(() => {
+          document.documentElement.dir = "rtl";
+        });
+        fireEvent.keyDown(
+          within(ltrSubmenu).getByRole("menuitem", { name: "Sub one" }),
+          { key: "ArrowLeft" },
+        );
+        fireEvent.keyDown(menu, { key: "ArrowRight" });
+        const rtlSubmenu = await screen.findByRole("menu", { name: "Parent" });
+        await waitFor(() =>
+          expect(rtlSubmenu).toHaveAttribute("data-positioned", "true"),
+        );
+        expect(rtlSubmenu).toHaveClass("left");
+      } finally {
+        document.documentElement.dir = originalDir;
+        rectSpy.mockRestore();
+      }
     });
   });
 
@@ -225,15 +494,21 @@ describe("ContextualMenu", () => {
       expect(screen.queryByText("Sub")).not.toBeInTheDocument();
     });
 
-    it("does not fire onSelect for a submenu parent (opens its submenu instead)", () => {
+    it("opens the first submenu child without selecting the parent", () => {
       // A parent is a submenu trigger, not a choosable leaf: activating it must
       // open the submenu and never call onSelect (WAI-ARIA menu pattern).
       const onSelect = vi.fn();
       openMenu(onSelect);
       fireEvent.click(screen.getByRole("menuitem", { name: "Parent" }));
       expect(onSelect).not.toHaveBeenCalled();
-      // The menu stays open (a parent click does not dismiss like a leaf).
-      expect(screen.getByRole("menu")).toHaveAttribute("aria-hidden", "false");
+      expect(screen.getAllByRole("menu")[0]).toHaveAttribute(
+        "aria-hidden",
+        "false",
+      );
+      expect(screen.getByRole("menuitem", { name: "Sub" })).toHaveAttribute(
+        "tabindex",
+        "0",
+      );
     });
 
     it("does not fire onSelect for a disabled item", () => {
@@ -241,6 +516,55 @@ describe("ContextualMenu", () => {
       openMenu(onSelect);
       fireEvent.click(screen.getByRole("menuitem", { name: "Disabled" }));
       expect(onSelect).not.toHaveBeenCalled();
+    });
+
+    it("runs item onSelect before menu onSelect and closes once", () => {
+      const calls: string[] = [];
+      const onOpenChange = vi.fn();
+      const selectable: MenuEntry[] = [
+        {
+          key: "leaf",
+          label: "Leaf",
+          "aria-label": "Select leaf",
+          onSelect: () => calls.push("item"),
+        },
+      ];
+      render(
+        <ContextualMenu
+          trigger="Actions"
+          items={selectable}
+          onSelect={() => calls.push("menu")}
+          onOpenChange={onOpenChange}
+        />,
+      );
+      fireEvent.click(screen.getByRole("button", { name: "Actions" }));
+      fireEvent.click(screen.getByRole("menuitem", { name: "Select leaf" }));
+
+      expect(calls).toEqual(["item", "menu"]);
+      expect(onOpenChange.mock.calls).toEqual([[true], [false]]);
+    });
+
+    it("does not invoke item callbacks for disabled items", () => {
+      const itemOnSelect = vi.fn();
+      const menuOnSelect = vi.fn();
+      render(
+        <ContextualMenu
+          trigger="Actions"
+          items={[
+            {
+              key: "disabled",
+              label: "Disabled",
+              disabled: true,
+              onSelect: itemOnSelect,
+            },
+          ]}
+          onSelect={menuOnSelect}
+        />,
+      );
+      fireEvent.click(screen.getByRole("button", { name: "Actions" }));
+      fireEvent.click(screen.getByRole("menuitem", { name: "Disabled" }));
+      expect(itemOnSelect).not.toHaveBeenCalled();
+      expect(menuOnSelect).not.toHaveBeenCalled();
     });
 
     it("marks a disabled item aria-disabled", () => {
@@ -294,6 +618,270 @@ describe("ContextualMenu", () => {
       // The leaf last: Space activates it, which closes the menu.
       const leaf = screen.getByRole("menuitem", { name: "Leaf" });
       expect(fireEvent.keyDown(leaf, { key: " " })).toBe(false);
+    });
+  });
+
+  describe("interactive panels", () => {
+    const FilterPanel = () => (
+      <form onSubmit={(event) => event.preventDefault()}>
+        <input aria-label="Filter instances" />
+        <input type="checkbox" aria-label="Running" />
+        <button type="submit">Apply</button>
+      </form>
+    );
+    const panelItems: MenuEntry[] = [
+      {
+        key: "filter",
+        label: "Filter",
+        displayItemsType: "panel",
+        Component: FilterPanel,
+      },
+    ];
+
+    it("renders a non-selectable group, not a menuitem", () => {
+      render(<ContextualMenu trigger="Actions" items={panelItems} />);
+      fireEvent.click(screen.getByRole("button", { name: "Actions" }));
+      const panel = screen.getByRole("group", { name: "Filter" });
+      expect(panel).toHaveClass("contextual-menu-panel");
+      expect(panel).toHaveAttribute("data-contextual-menu-panel");
+      expect(panel).not.toHaveClass("contextual-menu-item");
+      expect(
+        screen.queryByRole("menuitem", { name: "Filter" }),
+      ).not.toBeInTheDocument();
+    });
+
+    it("focuses the first panel control by default", async () => {
+      render(<ContextualMenu trigger="Actions" items={panelItems} />);
+      fireEvent.click(screen.getByRole("button", { name: "Actions" }));
+      await waitFor(() =>
+        expect(
+          screen.getByRole("textbox", { name: "Filter instances" }),
+        ).toHaveFocus(),
+      );
+    });
+
+    it("focuses the menu container when highlightFirstItem is false", async () => {
+      render(
+        <ContextualMenu
+          trigger="Actions"
+          items={panelItems}
+          highlightFirstItem={false}
+        />,
+      );
+      fireEvent.click(screen.getByRole("button", { name: "Actions" }));
+      await waitFor(() => expect(screen.getByRole("menu")).toHaveFocus());
+      expect(
+        screen.getByRole("textbox", { name: "Filter instances" }),
+      ).not.toHaveFocus();
+    });
+
+    it("lets controls handle clicks and keys without selecting or closing", () => {
+      const onSelect = vi.fn();
+      render(
+        <ContextualMenu
+          trigger="Actions"
+          items={panelItems}
+          onSelect={onSelect}
+        />,
+      );
+      fireEvent.click(screen.getByRole("button", { name: "Actions" }));
+      const input = screen.getByRole("textbox", { name: "Filter instances" });
+      fireEvent.click(input);
+      fireEvent.keyDown(input, { key: "a" });
+      fireEvent.keyDown(input, { key: "ArrowDown" });
+
+      expect(onSelect).not.toHaveBeenCalled();
+      expect(screen.getByRole("menu")).toHaveAttribute("aria-hidden", "false");
+      expect(input.closest(".contextual-menu-panel")).not.toHaveClass(
+        "contextual-menu-item",
+      );
+      expect(input.closest("[role='group']")).toHaveAttribute(
+        "aria-label",
+        "Filter",
+      );
+    });
+
+    it("keeps Tab inside the panel as native form navigation", () => {
+      render(
+        <ContextualMenu
+          trigger="Actions"
+          items={panelItems}
+          highlightFirstItem={false}
+        />,
+      );
+      fireEvent.click(screen.getByRole("button", { name: "Actions" }));
+      const search = screen.getByRole("textbox", { name: "Filter instances" });
+      const running = screen.getByRole("checkbox", { name: "Running" });
+      const apply = screen.getByRole("button", { name: "Apply" });
+
+      search.focus();
+      expect(fireEvent.keyDown(search, { key: "Tab", bubbles: true })).toBe(
+        true,
+      );
+      running.focus();
+      expect(fireEvent.keyDown(running, { key: "Tab", bubbles: true })).toBe(
+        true,
+      );
+      apply.focus();
+
+      expect(screen.getByRole("menu")).toHaveAttribute("aria-hidden", "false");
+      expect(apply).toHaveFocus();
+    });
+
+    it("closes on Escape and returns focus to the trigger", () => {
+      const onOpenChange = vi.fn();
+      render(
+        <ContextualMenu
+          trigger="Actions"
+          items={panelItems}
+          onOpenChange={onOpenChange}
+        />,
+      );
+      const trigger = screen.getByRole("button", { name: "Actions" });
+      fireEvent.click(trigger);
+      const input = screen.getByRole("textbox", { name: "Filter instances" });
+      input.focus();
+      fireEvent.keyDown(input, { key: "Escape" });
+
+      expect(screen.getByRole("menu", { hidden: true })).toHaveAttribute(
+        "aria-hidden",
+        "true",
+      );
+      expect(trigger).toHaveFocus();
+      expect(onOpenChange.mock.calls).toEqual([[true], [false]]);
+    });
+
+    it("keeps a panel open on Escape when closeOnEscape is false", () => {
+      render(
+        <ContextualMenu
+          trigger="Actions"
+          items={panelItems}
+          closeOnEscape={false}
+        />,
+      );
+      fireEvent.click(screen.getByRole("button", { name: "Actions" }));
+      const input = screen.getByRole("textbox", { name: "Filter instances" });
+      input.focus();
+      fireEvent.keyDown(input, { key: "Escape" });
+      fireEvent.keyDown(document, { key: "Escape" });
+
+      expect(screen.getByRole("menu")).toHaveAttribute("aria-hidden", "false");
+      expect(input).toHaveFocus();
+    });
+  });
+
+  describe("portalled submenu ownership", () => {
+    const nestedItems: MenuEntry[] = [
+      {
+        key: "parent",
+        label: "Parent",
+        items: [{ key: "child", label: "Child" }],
+      },
+    ];
+
+    it("opens the first enabled child when the parent is keyboard-activated", () => {
+      render(<ContextualMenu trigger="Actions" items={nestedItems} />);
+      fireEvent.click(screen.getByRole("button", { name: "Actions" }));
+      const parent = screen.getByRole("menuitem", { name: "Parent" });
+      fireEvent.keyDown(parent, { key: "Enter" });
+      expect(screen.getByRole("menuitem", { name: "Child" })).toHaveAttribute(
+        "tabindex",
+        "0",
+      );
+    });
+
+    it("closes a nested panel from its input on ArrowLeft", async () => {
+      const interactiveNestedItems: MenuEntry[] = [
+        {
+          key: "parent",
+          label: "Parent",
+          items: [
+            {
+              key: "filter",
+              label: "Filter",
+              displayItemsType: "panel",
+              Component: () => <input aria-label="Nested filter" />,
+            },
+          ],
+        },
+      ];
+      render(
+        <ContextualMenu trigger="Actions" items={interactiveNestedItems} />,
+      );
+      fireEvent.click(screen.getByRole("button", { name: "Actions" }));
+      const parent = screen.getByRole("menuitem", { name: "Parent" });
+      fireEvent.keyDown(parent, { key: "Enter" });
+      const input = screen.getByRole("textbox", { name: "Nested filter" });
+      input.focus();
+
+      fireEvent.keyDown(input, { key: "ArrowLeft" });
+      await waitFor(() => expect(parent).toHaveFocus());
+      expect(screen.queryByRole("menu", { name: "Parent" })).toBeNull();
+    });
+
+    it("keeps the submenu open while the pointer crosses into its portal", () => {
+      render(<ContextualMenu trigger="Actions" items={nestedItems} />);
+      fireEvent.click(screen.getByRole("button", { name: "Actions" }));
+      const anchor = screen
+        .getByRole("menuitem", { name: "Parent" })
+        .closest(".submenu-anchor") as HTMLElement;
+      fireEvent.pointerEnter(anchor);
+      const submenu = screen.getByRole("menu", { name: "Parent" });
+
+      vi.useFakeTimers();
+      try {
+        fireEvent.pointerLeave(anchor);
+        fireEvent.pointerEnter(submenu);
+        act(() => vi.advanceTimersByTime(120));
+        expect(submenu).toBeInTheDocument();
+
+        fireEvent.pointerLeave(submenu);
+        act(() => vi.advanceTimersByTime(120));
+        expect(screen.queryByRole("menu", { name: "Parent" })).toBeNull();
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("treats nested surfaces as inside and closes once on a genuine outside pointer", () => {
+      const onOpenChange = vi.fn();
+      render(
+        <ContextualMenu
+          trigger="Actions"
+          items={nestedItems}
+          onOpenChange={onOpenChange}
+        />,
+      );
+      fireEvent.click(screen.getByRole("button", { name: "Actions" }));
+      const anchor = screen
+        .getByRole("menuitem", { name: "Parent" })
+        .closest(".submenu-anchor") as HTMLElement;
+      fireEvent.pointerEnter(anchor);
+      const child = screen.getByRole("menuitem", { name: "Child" });
+
+      fireEvent.pointerDown(child);
+      expect(screen.getByRole("button", { name: "Actions" })).toHaveAttribute(
+        "aria-expanded",
+        "true",
+      );
+      fireEvent.pointerDown(document.body);
+      expect(onOpenChange.mock.calls).toEqual([[true], [false]]);
+    });
+
+    it("keeps the menu open on outside pointer-down when opted out", () => {
+      render(
+        <ContextualMenu
+          trigger="Actions"
+          items={nestedItems}
+          closeOnOutsideClick={false}
+        />,
+      );
+      const trigger = screen.getByRole("button", { name: "Actions" });
+      fireEvent.click(trigger);
+      fireEvent.pointerDown(document.body);
+
+      expect(trigger).toHaveAttribute("aria-expanded", "true");
+      expect(screen.getByRole("menu")).toHaveAttribute("aria-hidden", "false");
     });
   });
 

--- a/packages/react/ds-global/src/lib/component/ContextualMenu/ContextualMenu.tsx
+++ b/packages/react/ds-global/src/lib/component/ContextualMenu/ContextualMenu.tsx
@@ -1,19 +1,35 @@
 import type { _Item } from "@canonical/ds-types";
 import { getItemId } from "@canonical/ds-utils";
 import type React from "react";
-import { useMemo } from "react";
+import { useCallback, useMemo } from "react";
 import { createPortal } from "react-dom";
 import {
   MENU_ROOT_PLACEMENT,
   useContextualMenu,
   useIsMounted,
 } from "../../hooks/index.js";
+import { Button } from "../Button/index.js";
 import MenuContext from "./common/MenuContext.js";
 import SubMenu from "./common/SubMenu/index.js";
 import type { ContextualMenuProps, MenuItem } from "./types.js";
 import "./styles.css";
 
 const componentCssClassName = "ds contextual-menu";
+
+const setRef = <T,>(ref: React.Ref<T> | undefined, value: T | null) => {
+  if (typeof ref === "function") ref(value);
+  else if (ref) ref.current = value;
+};
+
+const composeHandlers =
+  <TEvent extends React.SyntheticEvent>(
+    consumerHandler: ((event: TEvent) => void) | undefined,
+    internalHandler: ((event: TEvent) => void) | undefined,
+  ) =>
+  (event: TEvent) => {
+    consumerHandler?.(event);
+    if (!event.defaultPrevented) internalHandler?.(event);
+  };
 
 /**
  * A contextual menu presents a flat list of actions — optionally partitioned
@@ -26,6 +42,7 @@ const componentCssClassName = "ds contextual-menu";
  */
 const ContextualMenu = ({
   trigger,
+  triggerProps: buttonTriggerProps,
   items,
   label,
   className,
@@ -35,6 +52,9 @@ const ContextualMenu = ({
   maxWidth,
   autoFit,
   wrap,
+  highlightFirstItem,
+  closeOnEscape,
+  closeOnOutsideClick,
   onSelect,
   open,
   onOpenChange,
@@ -63,6 +83,9 @@ const ContextualMenu = ({
     // Menus conventionally wrap: ArrowDown on the last item loops to the
     // first (APG menu pattern). Opt out with `wrap={false}`.
     wrap: wrap ?? true,
+    highlightFirstItem,
+    closeOnEscape,
+    closeOnOutsideClick,
     onShow: () => onOpenChange?.(true),
     onHide: () => onOpenChange?.(false),
   });
@@ -83,8 +106,7 @@ const ContextualMenu = ({
     getItemProps,
   } = menu;
 
-  const triggerProps = getTriggerProps();
-  const annotatedEntries = annotatedRoot.items ?? [];
+  const menuEntries = annotatedRoot.items ?? [];
 
   // The shared menu API threaded to every (nested) level. One state, one
   // highlight path, one keyboard handler — submenus are render-only. Memoised so
@@ -102,9 +124,11 @@ const ContextualMenu = ({
       // would close the root surface while the hovered submenu stayed up.
       isOpen,
       onSelectItem: (item: _Item<MenuItem>) => {
+        item.onSelect?.(item);
         onSelect?.(item);
         close();
       },
+      ownerId: popupId,
     }),
     [
       getItemProps,
@@ -114,6 +138,7 @@ const ContextualMenu = ({
       close,
       isOpen,
       onSelect,
+      popupId,
     ],
   );
 
@@ -125,13 +150,22 @@ const ContextualMenu = ({
   // getMenuProps returns a generic prop bag from the headless navigation hook
   // (loose event-handler and ref types); it is spread onto the menu container.
   const menuProps = getMenuProps({
-    label,
+    label: label || undefined,
     labelledBy: label ? undefined : triggerId,
     // Compose the positioning ref with the menu's keyboard ref.
     ref: popupRef,
   }) as React.HTMLAttributes<HTMLDivElement> & {
     ref?: React.Ref<HTMLDivElement>;
   };
+
+  const { ref: menuPropsRef, ...restMenuProps } = menuProps;
+  const composedMenuRef = useCallback(
+    (node: HTMLDivElement | null) => {
+      popupRef.current = node;
+      setRef(menuPropsRef, node);
+    },
+    [popupRef, menuPropsRef],
+  );
 
   const menuElement = (
     <div
@@ -147,17 +181,84 @@ const ContextualMenu = ({
       ]
         .filter(Boolean)
         .join(" ")}
+      {...restMenuProps}
       id={popupId}
+      data-contextual-menu-owner={popupId}
       aria-hidden={!isOpen}
       style={popupPositionStyle}
-      {...menuProps}
+      ref={composedMenuRef}
     >
-      {annotatedEntries.map((entry) => (
+      {menuEntries.map((entry) => (
         // SubMenu renders a separator as a divider, a submenu parent as the
         // item plus its nested popup (recursively), and a leaf as a plain item.
         <SubMenu key={getItemId(entry)} item={entry} />
       ))}
     </div>
+  );
+
+  const disclosureTriggerProps =
+    getTriggerProps() as React.ComponentProps<"button">;
+  const {
+    className: buttonTriggerClassName,
+    ref: buttonTriggerRef,
+    onClick: buttonTriggerOnClick,
+    onKeyDown: buttonTriggerOnKeyDown,
+    onFocus: buttonTriggerOnFocus,
+    onBlur: buttonTriggerOnBlur,
+    ...restButtonTriggerProps
+  } = buttonTriggerProps ?? {};
+  const {
+    ref: disclosureTriggerRef,
+    onClick: disclosureTriggerOnClick,
+    onKeyDown: disclosureTriggerOnKeyDown,
+    onFocus: disclosureTriggerOnFocus,
+    onBlur: disclosureTriggerOnBlur,
+    ...restDisclosureTriggerProps
+  } = disclosureTriggerProps;
+  const composedTriggerRef = useCallback(
+    (node: HTMLButtonElement | null) => {
+      targetRef.current = node;
+      setRef(
+        disclosureTriggerRef as React.Ref<HTMLButtonElement> | undefined,
+        node,
+      );
+      setRef(buttonTriggerRef, node);
+    },
+    [targetRef, disclosureTriggerRef, buttonTriggerRef],
+  );
+
+  const triggerElement = buttonTriggerProps ? (
+    <Button
+      {...restButtonTriggerProps}
+      {...restDisclosureTriggerProps}
+      type={restButtonTriggerProps.type ?? "button"}
+      id={triggerId}
+      className={["trigger", buttonTriggerClassName].filter(Boolean).join(" ")}
+      ref={composedTriggerRef}
+      onClick={composeHandlers(buttonTriggerOnClick, disclosureTriggerOnClick)}
+      onKeyDown={composeHandlers(
+        buttonTriggerOnKeyDown,
+        disclosureTriggerOnKeyDown,
+      )}
+      onFocus={composeHandlers(buttonTriggerOnFocus, disclosureTriggerOnFocus)}
+      onBlur={composeHandlers(buttonTriggerOnBlur, disclosureTriggerOnBlur)}
+    >
+      {trigger}
+    </Button>
+  ) : (
+    <button
+      type="button"
+      id={triggerId}
+      className="trigger"
+      {...restDisclosureTriggerProps}
+      ref={composedTriggerRef}
+      onClick={disclosureTriggerOnClick}
+      onKeyDown={disclosureTriggerOnKeyDown}
+      onFocus={disclosureTriggerOnFocus}
+      onBlur={disclosureTriggerOnBlur}
+    >
+      {trigger}
+    </button>
   );
 
   return (
@@ -173,15 +274,7 @@ const ContextualMenu = ({
             a no-op — focus would silently fall to <body> (WCAG 2.4.3). The
             fitment hook types its anchor as a div; the button anchors the same
             rect, so cast (Popover precedent). */}
-        <button
-          type="button"
-          id={triggerId}
-          className="trigger"
-          ref={targetRef as React.Ref<HTMLButtonElement>}
-          {...triggerProps}
-        >
-          {trigger}
-        </button>
+        {triggerElement}
         {mounted ? createPortal(menuElement, document.body) : menuElement}
       </div>
     </MenuContext.Provider>

--- a/packages/react/ds-global/src/lib/component/ContextualMenu/common/Item/Item.tsx
+++ b/packages/react/ds-global/src/lib/component/ContextualMenu/common/Item/Item.tsx
@@ -7,13 +7,19 @@ const componentCssClassName = "ds contextual-menu-item";
 
 /**
  * A single contextual-menu entry. By default it renders an optional leading
- * icon, the label, and an optional right-aligned slot (badge or shortcut). When
- * the item opts into a custom renderer (`displayItemsType: "custom"` with a
- * `Component`), that component owns the item's content instead.
+ * icon, the label, and an optional right-aligned slot (badge or shortcut).
+ * `displayItemsType: "custom"` keeps that selectable `menuitem` and replaces
+ * only the inner markup. `displayItemsType: "panel"` is a non-selectable
+ * interactive surface for embedded controls — not a command row.
  *
  * @implements ds:global.subcomponent.contextual-menu-item
  */
-const Item = ({ item, itemProps, onSelect }: ItemProps): React.ReactElement => {
+const Item = ({
+  item,
+  itemProps,
+  onSelect,
+  onOpenSubmenu,
+}: ItemProps): React.ReactElement => {
   const {
     label,
     disabled,
@@ -23,6 +29,7 @@ const Item = ({ item, itemProps, onSelect }: ItemProps): React.ReactElement => {
     displayItemsType,
     Component,
     items,
+    "aria-label": ariaLabel,
   } = item;
 
   // An item with children is a submenu trigger; it shows a trailing caret.
@@ -32,6 +39,30 @@ const Item = ({ item, itemProps, onSelect }: ItemProps): React.ReactElement => {
   // (handled by the navigation hook's ArrowRight/click), it does not fire
   // `onSelect` like a leaf. Only enabled leaves select.
   const isSelectable = !disabled && !hasSubmenu;
+  const isPanel = displayItemsType === "panel" && Component;
+  const isCustomRow = displayItemsType === "custom" && Component;
+
+  if (isPanel) {
+    const panelRef = itemProps.ref as React.Ref<HTMLDivElement> | undefined;
+    const panelLabel =
+      ariaLabel ?? (typeof label === "string" ? label : undefined);
+    return (
+      // biome-ignore lint/a11y/useSemanticElements: a panel groups arbitrary interactive content inside a menu, not form fields.
+      <div
+        className={["ds contextual-menu-panel", className]
+          .filter(Boolean)
+          .join(" ")}
+        role="group"
+        aria-label={panelLabel}
+        data-contextual-menu-entry
+        data-contextual-menu-panel
+        data-highlighted={itemProps.tabIndex === 0 ? "true" : undefined}
+        ref={panelRef}
+      >
+        <Component item={item} />
+      </div>
+    );
+  }
 
   const handleKeyDown = (event: React.KeyboardEvent) => {
     if (event.key === "Enter" || event.key === " ") {
@@ -42,9 +73,8 @@ const Item = ({ item, itemProps, onSelect }: ItemProps): React.ReactElement => {
       // scrolls the page, so a "no-op" on a disabled item or submenu parent
       // would not actually be a no-op. Only a selectable leaf activates.
       event.preventDefault();
-      if (isSelectable) {
-        onSelect();
-      }
+      if (hasSubmenu && !disabled) onOpenSubmenu?.();
+      else if (isSelectable) onSelect();
     }
   };
 
@@ -58,37 +88,45 @@ const Item = ({ item, itemProps, onSelect }: ItemProps): React.ReactElement => {
     | ((event: React.MouseEvent) => void)
     | undefined;
   const handleClick = (event: React.MouseEvent) => {
-    navOnClick?.(event);
-    if (isSelectable) onSelect();
+    if (hasSubmenu && !disabled) {
+      event.stopPropagation();
+      onOpenSubmenu?.();
+    } else {
+      navOnClick?.(event);
+      if (isSelectable) onSelect();
+    }
   };
 
-  const content =
-    displayItemsType === "custom" && Component ? (
-      <Component item={item} />
-    ) : (
-      <>
-        {/* Icon always precedes the text (Figma). */}
-        {icon ? <span className="icon">{icon}</span> : null}
-        <span className="label">{label}</span>
-        {slot ? <span className="slot">{slot}</span> : null}
-        {/* Submenu items show a trailing caret (Canonical chevron-right icon; a
+  const content = isCustomRow ? (
+    <Component item={item} />
+  ) : (
+    <>
+      {/* Icon always precedes the text (Figma). */}
+      {icon ? <span className="icon">{icon}</span> : null}
+      <span className="label">{label}</span>
+      {slot ? <span className="slot">{slot}</span> : null}
+      {/* Submenu items show a trailing caret (Canonical chevron-right icon; a
             plain slot and a submenu caret are mutually exclusive in the Figma
             spec). It is mirrored to point left in RTL via CSS. */}
-        {hasSubmenu ? (
-          <span className="caret" aria-hidden="true">
-            <Icon icon="chevron-right" />
-          </span>
-        ) : null}
-      </>
-    );
+      {hasSubmenu ? (
+        <span className="caret" aria-hidden="true">
+          <Icon icon="chevron-right" />
+        </span>
+      ) : null}
+    </>
+  );
 
   return (
-    // biome-ignore lint/a11y/noStaticElementInteractions: the div carries role="menuitem" (from itemProps) with roving tabindex, the correct WAI-ARIA menu pattern (a <button> cannot be a menuitem)
     <div
       className={[componentCssClassName, disabled && "disabled", className]
         .filter(Boolean)
         .join(" ")}
       {...itemProps}
+      role="menuitem"
+      tabIndex={itemProps.tabIndex as number}
+      aria-label={ariaLabel}
+      data-contextual-menu-entry
+      data-highlighted={itemProps.tabIndex === 0 ? "true" : undefined}
       onClick={handleClick}
       onKeyDown={handleKeyDown}
     >

--- a/packages/react/ds-global/src/lib/component/ContextualMenu/common/Item/styles.css
+++ b/packages/react/ds-global/src/lib/component/ContextualMenu/common/Item/styles.css
@@ -81,6 +81,20 @@
       flex: 1 1 auto;
     }
 
+    > .icon {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      flex: 0 0 auto;
+      inline-size: var(--dimension-200, 16px);
+      block-size: var(--dimension-300, 24px);
+
+      > svg {
+        inline-size: var(--dimension-200, 16px);
+        block-size: var(--dimension-200, 16px);
+      }
+    }
+
     /* The slot (badge / keyboard shortcut) sits right-aligned. */
     > .slot {
       flex: 0 0 auto;
@@ -119,6 +133,15 @@
         color: inherit;
       }
     }
+  }
+
+  .ds.contextual-menu-panel {
+    padding-block: var(--contextual-menu-item-padding-block);
+    padding-inline: var(--contextual-menu-item-padding-inline);
+    color: var(--contextual-menu-item-color-text);
+    background-color: transparent;
+    cursor: default;
+    user-select: text;
   }
 
   /* Mirror the `›` caret glyph to `‹` for right-to-left reading. Keyed on any

--- a/packages/react/ds-global/src/lib/component/ContextualMenu/common/Item/types.ts
+++ b/packages/react/ds-global/src/lib/component/ContextualMenu/common/Item/types.ts
@@ -15,4 +15,6 @@ export interface ItemProps {
   itemProps: Record<string, unknown>;
   /** Called when the item is activated (click or Enter/Space). */
   onSelect: () => void;
+  /** Opens this item's submenu when it has child entries. */
+  onOpenSubmenu?: () => void;
 }

--- a/packages/react/ds-global/src/lib/component/ContextualMenu/common/MenuContext.tsx
+++ b/packages/react/ds-global/src/lib/component/ContextualMenu/common/MenuContext.tsx
@@ -22,6 +22,8 @@ export interface MenuContextValue
   > {
   /** Activate an item (run the consumer's onSelect and close the menu). */
   onSelectItem: (item: _Item<MenuItem>) => void;
+  /** Stable owner id shared by every portalled menu surface. */
+  ownerId: string;
 }
 
 const MenuContext = createContext<MenuContextValue | null>(null);

--- a/packages/react/ds-global/src/lib/component/ContextualMenu/common/SubMenu/SubMenu.tsx
+++ b/packages/react/ds-global/src/lib/component/ContextualMenu/common/SubMenu/SubMenu.tsx
@@ -4,6 +4,8 @@ import type React from "react";
 import { type ReactElement, useEffect, useId, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 import {
+  getHighlightedMenuEntry,
+  getMenuEntryFocusTarget,
   isMenuSeparator,
   MENU_PLACEMENT,
   useIsMounted,
@@ -54,8 +56,15 @@ const SubMenu = ({ item }: { item: _Item<MenuEntry> }): ReactElement => {
  * alignment as space runs out.
  */
 const SubMenuParent = ({ item }: { item: _Item<MenuItem> }): ReactElement => {
-  const { getItemProps, getMenuProps, getNodeStatus, onSelectItem, isOpen } =
-    useMenuContext();
+  const {
+    getItemProps,
+    getMenuProps,
+    getNodeStatus,
+    highlightItem,
+    onSelectItem,
+    isOpen,
+    ownerId,
+  } = useMenuContext();
 
   // `_Item<MenuItem>` re-types annotated children with the single member, but
   // a submenu's children genuinely include separators at runtime (the hook's
@@ -69,6 +78,8 @@ const SubMenuParent = ({ item }: { item: _Item<MenuItem> }): ReactElement => {
   // (which moves the highlight back onto the parent) would leave the submenu open.
   const keyboardOpen = status.inHighlightedBranch && !status.highlighted;
   const [hovered, setHovered] = useState(false);
+  const closeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const [, refreshFitmentRefs] = useState(0);
   // Gate on the ROOT open state: `hovered` is local, so a mouse-selected
   // nested leaf (which closes the root disclosure) would otherwise leave the
   // still-hovered submenu surface mounted and visible on its own.
@@ -77,17 +88,70 @@ const SubMenuParent = ({ item }: { item: _Item<MenuItem> }): ReactElement => {
   // `typeof window` is already truthy on the first client render.
   const mounted = useIsMounted();
 
+  // The popup mounts conditionally when `open` becomes true. Refresh once after
+  // that commit so useWindowFitment sees popupRef.current and starts observing
+  // the surface; otherwise no state change follows the ref assignment and the
+  // submenu remains hidden at its fallback position.
+  useEffect(() => {
+    if (open) refreshFitmentRefs((version) => version + 1);
+  }, [open]);
+
   // The pointer never "leaves" a surface that is hidden under it, so clear
   // the hover state when the menu closes — otherwise the submenu would pop
   // straight open the next time the menu opens.
   useEffect(() => {
-    if (!isOpen) setHovered(false);
+    if (!isOpen) {
+      if (closeTimerRef.current) clearTimeout(closeTimerRef.current);
+      closeTimerRef.current = null;
+      setHovered(false);
+    }
   }, [isOpen]);
+
+  useEffect(
+    () => () => {
+      if (closeTimerRef.current) clearTimeout(closeTimerRef.current);
+    },
+    [],
+  );
+
+  const keepOpen = () => {
+    if (closeTimerRef.current) clearTimeout(closeTimerRef.current);
+    closeTimerRef.current = null;
+    setHovered(true);
+  };
+
+  const scheduleClose = () => {
+    if (closeTimerRef.current) clearTimeout(closeTimerRef.current);
+    closeTimerRef.current = setTimeout(() => {
+      setHovered(false);
+      closeTimerRef.current = null;
+    }, 120);
+  };
+
+  const openFirstChild = () => {
+    const firstChild = children.find(
+      (child) => !isMenuSeparator(child) && !child.disabled,
+    );
+    if (firstChild && !isMenuSeparator(firstChild)) highlightItem(firstChild);
+  };
 
   // MENU_PLACEMENT is a stable module constant and logical, so the hook mirrors
   // it in RTL from this item's own writing direction — no per-submenu dir read.
   const { targetRef, popupRef, popupPositionStyle, bestPosition } =
-    useWindowFitment({ preferredDirections: MENU_PLACEMENT, autoFit: true });
+    useWindowFitment({
+      preferredDirections: MENU_PLACEMENT,
+      autoFit: true,
+      isOpen: open,
+    });
+  const positioned = !!bestPosition;
+  const keyboardWasOpenRef = useRef(false);
+
+  useEffect(() => {
+    if (keyboardWasOpenRef.current && !keyboardOpen && isOpen) {
+      targetRef.current?.focus();
+    }
+    keyboardWasOpenRef.current = keyboardOpen;
+  }, [isOpen, keyboardOpen, targetRef]);
 
   // A stable, instance-unique id for the submenu surface so the parent item
   // can reference the popup it controls (item keys are only unique within one
@@ -123,18 +187,17 @@ const SubMenuParent = ({ item }: { item: _Item<MenuItem> }): ReactElement => {
   // @note Impure — moves DOM focus.
   const surfaceRef = useRef<HTMLDivElement | null>(null);
   useEffect(() => {
-    if (!open || !keyboardOpen || typeof window === "undefined") return;
+    if (!open || !keyboardOpen || !positioned || typeof window === "undefined")
+      return;
     const surface = surfaceRef.current;
     if (!surface) return;
     const id = requestAnimationFrame(() =>
       requestAnimationFrame(() => {
-        surface
-          .querySelector<HTMLElement>('[role="menuitem"][tabindex="0"]')
-          ?.focus();
+        getMenuEntryFocusTarget(getHighlightedMenuEntry(surface))?.focus();
       }),
     );
     return () => cancelAnimationFrame(id);
-  }, [open, keyboardOpen]);
+  }, [open, keyboardOpen, positioned]);
 
   const menuProps = getMenuProps({
     label: item.label,
@@ -147,6 +210,7 @@ const SubMenuParent = ({ item }: { item: _Item<MenuItem> }): ReactElement => {
   // `popupRef` stays null and `useWindowFitment` measures nothing — no
   // ResizeObserver, no reposition, and crucially no measure→reposition→measure
   // feedback across a tree of always-mounted hidden popups (which froze the UI).
+  const { ref: menuPropsRef, ...restMenuProps } = menuProps;
   const submenuSurface = open ? (
     <div
       className={[
@@ -158,22 +222,25 @@ const SubMenuParent = ({ item }: { item: _Item<MenuItem> }): ReactElement => {
       ]
         .filter(Boolean)
         .join(" ")}
+      {...restMenuProps}
       id={submenuId}
-      aria-hidden={false}
+      data-contextual-menu-owner={ownerId}
       // Reveal visually only once positioned. The submenu mounts on open but
       // `bestPosition` resolves a frame later; without this gate it paints for a
       // frame at the fallback top:0/left:0 before snapping to the anchor.
-      data-positioned={bestPosition ? "true" : undefined}
+      data-positioned={positioned ? "true" : undefined}
       style={popupPositionStyle}
-      {...menuProps}
-      // After the spread so this composing callback wins over menuProps.ref
-      // (later JSX props override earlier ones): it captures the surface for
-      // the keyboard-open focus effect AND forwards to the tree's ref.
+      aria-hidden={false}
+      onPointerEnter={keepOpen}
+      onPointerLeave={scheduleClose}
+      // After the spread so this composing callback wins over menuProps.ref:
+      // it captures the surface for the keyboard-open focus effect AND
+      // forwards to the tree's ref.
       ref={(el) => {
         surfaceRef.current = el;
-        if (typeof menuProps.ref === "function") menuProps.ref(el);
-        else if (menuProps.ref)
-          (menuProps.ref as React.RefObject<HTMLElement | null>).current = el;
+        if (typeof menuPropsRef === "function") menuPropsRef(el);
+        else if (menuPropsRef)
+          (menuPropsRef as React.RefObject<HTMLElement | null>).current = el;
       }}
     >
       {children.map((child) => (
@@ -186,13 +253,14 @@ const SubMenuParent = ({ item }: { item: _Item<MenuItem> }): ReactElement => {
   return (
     <div
       className="submenu-anchor"
-      onPointerEnter={() => setHovered(true)}
-      onPointerLeave={() => setHovered(false)}
+      onPointerEnter={keepOpen}
+      onPointerLeave={scheduleClose}
     >
       <Item
         item={item}
         itemProps={itemProps}
         onSelect={() => onSelectItem(item)}
+        onOpenSubmenu={openFirstChild}
       />
       {submenuSurface && mounted
         ? createPortal(submenuSurface, document.body)

--- a/packages/react/ds-global/src/lib/component/ContextualMenu/styles.css
+++ b/packages/react/ds-global/src/lib/component/ContextualMenu/styles.css
@@ -22,6 +22,15 @@
 
     > .trigger {
       cursor: pointer;
+
+      /* Native trigger only. A Pragma Button already owns its expanded/active
+         surface; painting over `.button` fights primary/secondary tokens. */
+      &:not(.button)[aria-expanded="true"] {
+        background-color: var(
+          --modifier-surface-active,
+          var(--color-foreground-ghost-active, transparent)
+        );
+      }
     }
   }
 

--- a/packages/react/ds-global/src/lib/component/ContextualMenu/types.ts
+++ b/packages/react/ds-global/src/lib/component/ContextualMenu/types.ts
@@ -6,12 +6,19 @@ import type {
   WindowFitmentPlacement,
   WindowFitmentSide,
 } from "../../hooks/index.js";
+import type ButtonProps from "../Button/types.js";
 
 export type { MenuEntry, MenuItem, MenuSeparator } from "../../hooks/index.js";
 
 type OwnProps = Pick<
   UseContextualMenuProps,
-  "distance" | "gutter" | "maxWidth" | "autoFit"
+  | "distance"
+  | "gutter"
+  | "maxWidth"
+  | "autoFit"
+  | "closeOnEscape"
+  | "closeOnOutsideClick"
+  | "highlightFirstItem"
 > & {
   /**
    * Whether arrow keys wrap at the first/last item. Defaults to true (the
@@ -25,6 +32,11 @@ type OwnProps = Pick<
    * the menu.
    */
   trigger: ReactNode;
+  /**
+   * Design-system Button props for a styled trigger. Children are supplied by
+   * `trigger`; omit this prop to preserve the native button trigger.
+   */
+  triggerProps?: Omit<ButtonProps, "children">;
   /**
    * The menu entries: one flat list of items and separators
    * (`{ type: "separator", key: "…" }`). An item's own `items` form its submenu, which

--- a/packages/react/ds-global/src/lib/hooks/useContextualMenu/getMenuEntryFocusTarget.ts
+++ b/packages/react/ds-global/src/lib/hooks/useContextualMenu/getMenuEntryFocusTarget.ts
@@ -1,0 +1,23 @@
+const HIGHLIGHTED_ENTRY_SELECTOR =
+  '[data-contextual-menu-entry][data-highlighted="true"]';
+const PANEL_FOCUSABLE_SELECTOR =
+  'input, select, textarea, button, a[href], [contenteditable="true"], [tabindex]:not([tabindex="-1"])';
+
+/**
+ * The currently highlighted menu entry under `root`, if any.
+ */
+export const getHighlightedMenuEntry = (root: ParentNode): HTMLElement | null =>
+  root.querySelector<HTMLElement>(HIGHLIGHTED_ENTRY_SELECTOR);
+
+/**
+ * Where DOM focus should land for a highlighted entry. A panel is not a
+ * command row: focus the first native control inside it, otherwise the entry
+ * itself.
+ */
+export const getMenuEntryFocusTarget = (
+  item: HTMLElement | null,
+): HTMLElement | null => {
+  if (!item) return null;
+  if (!item.matches("[data-contextual-menu-panel]")) return item;
+  return item.querySelector<HTMLElement>(PANEL_FOCUSABLE_SELECTOR) ?? item;
+};

--- a/packages/react/ds-global/src/lib/hooks/useContextualMenu/index.ts
+++ b/packages/react/ds-global/src/lib/hooks/useContextualMenu/index.ts
@@ -1,3 +1,7 @@
+export {
+  getHighlightedMenuEntry,
+  getMenuEntryFocusTarget,
+} from "./getMenuEntryFocusTarget.js";
 export { default as isMenuSeparator } from "./isMenuSeparator.js";
 export * from "./types.js";
 export { default as useContextualMenu } from "./useContextualMenu.js";

--- a/packages/react/ds-global/src/lib/hooks/useContextualMenu/types.ts
+++ b/packages/react/ds-global/src/lib/hooks/useContextualMenu/types.ts
@@ -25,12 +25,23 @@ export type MenuItem = _DistributiveOmit<Item, "items"> & {
   items?: MenuEntry[];
   /** CSS class name applied to this item, in addition to the base classes. */
   className?: string;
+  /** Accessible label overriding the item's visible label. */
+  "aria-label"?: string;
+  /** Called before the menu-level callback when this item is selected. */
+  onSelect?: (item: MenuItem) => void;
   /**
-   * Opts this item into rendering via `Component` instead of the default
-   * layout. `"custom"` without a `Component` falls back to the default.
+   * How this item is rendered. `"custom"` without a `Component` falls back to
+   * the default layout; `"panel"` without a `Component` does the same.
+   * - `default`: ordinary selectable command row.
+   * - `custom`: selectable command row whose contents come from `Component`.
+   * - `panel`: non-selectable interactive surface (inputs, checkboxes,
+   *   Apply/Reset). It is not a `menuitem` and does not intercept form keys.
    */
-  displayItemsType?: "default" | "custom";
-  /** Custom component for rendering this item itself, when `displayItemsType` is `"custom"`. */
+  displayItemsType?: "default" | "custom" | "panel";
+  /**
+   * Custom renderer for this item. Used by `"custom"` (selectable row) and
+   * `"panel"` (non-selectable interactive surface).
+   */
   Component?: React.ComponentType<{ item: MenuItem }>;
 };
 
@@ -77,6 +88,8 @@ export interface UseContextualMenuProps
   wrap?: boolean;
   /** Type-ahead reset timeout in milliseconds. */
   typeAheadTimeout?: number;
+  /** Whether opening highlights and focuses the first enabled item. Defaults to true. */
+  highlightFirstItem?: boolean;
 }
 
 /** Options for the menu ARIA prop-getter. */

--- a/packages/react/ds-global/src/lib/hooks/useContextualMenu/useContextualMenu.ts
+++ b/packages/react/ds-global/src/lib/hooks/useContextualMenu/useContextualMenu.ts
@@ -1,11 +1,17 @@
 import type { _Item } from "@canonical/ds-types";
+import type { NavigationAction, NavigationState } from "@canonical/react-hooks";
 import {
   getMenuProps as getMenuAriaProps,
   getMenuItemProps,
+  NavigationActionType,
   useNavigationTree,
 } from "@canonical/react-hooks";
 import { useCallback, useEffect, useMemo } from "react";
 import { useDisclosure } from "../useDisclosure/index.js";
+import {
+  getHighlightedMenuEntry,
+  getMenuEntryFocusTarget,
+} from "./getMenuEntryFocusTarget.js";
 import isMenuSeparator from "./isMenuSeparator.js";
 import type {
   MenuEntry,
@@ -60,6 +66,9 @@ const useContextualMenu = ({
   root,
   wrap = false,
   typeAheadTimeout,
+  highlightFirstItem = true,
+  closeOnEscape = true,
+  closeOnOutsideClick = true,
   ...props
 }: UseContextualMenuProps): UseContextualMenuResult => {
   const {
@@ -74,17 +83,38 @@ const useContextualMenu = ({
     bestPosition,
     arrowOffset,
     getToggleProps: getDisclosureToggleProps,
-  } = useDisclosure({ ...props, mode: "click" });
+  } = useDisclosure({
+    ...props,
+    mode: "click",
+    // ContextualMenu owns Escape so a key event handled by a menu surface
+    // cannot race the disclosure's document listener and close twice.
+    closeOnEscape: false,
+    // ContextualMenu owns outside dismissal because nested surfaces are
+    // portalled outside the root popup ref.
+    closeOnOutsideClick: false,
+  });
 
   // Separators become presentational nodes BEFORE the tree annotates the root,
   // so useNavigationTree runs unmodified.
   const preparedRoot = useMemo(() => prepareEntry(root) as MenuItem, [root]);
+
+  const stateReducer = useCallback(
+    (
+      state: NavigationState<MenuEntry>,
+      action: NavigationAction<MenuEntry>,
+    ): NavigationState<MenuEntry> =>
+      !highlightFirstItem && action.type === NavigationActionType.OPEN
+        ? { ...state, highlightedItems: [] }
+        : state,
+    [highlightFirstItem],
+  );
 
   const nav = useNavigationTree<MenuEntry>({
     root: preparedRoot,
     focus: "roving",
     wrap,
     typeAheadTimeout,
+    stateReducer,
   });
 
   // The disclosure owns the open state (it drives positioning and dismissal);
@@ -110,16 +140,18 @@ const useContextualMenu = ({
     const menu = popupRef.current;
     if (!menu) return;
     const focusMenu = () => {
-      const firstItem = menu.querySelector<HTMLElement>(
-        '[role="menuitem"]:not([aria-disabled="true"])',
+      if (!highlightFirstItem) {
+        menu.focus();
+        return;
+      }
+      const focusTarget = getMenuEntryFocusTarget(
+        getHighlightedMenuEntry(menu),
       );
-      // Prefer the first enabled menuitem; fall back to the menu container,
-      // which carries the keyboard handler.
-      (firstItem ?? menu).focus();
+      (focusTarget ?? menu).focus();
     };
     const id = requestAnimationFrame(() => requestAnimationFrame(focusMenu));
     return () => cancelAnimationFrame(id);
-  }, [isOpen, popupRef]);
+  }, [isOpen, popupRef, highlightFirstItem]);
 
   // Keep DOM focus on the currently-highlighted item as the keyboard highlight
   // moves. The tree only updates the roving `tabindex`; without moving focus too
@@ -137,12 +169,13 @@ const useContextualMenu = ({
       active instanceof HTMLElement && active.closest('[role="menu"]') !== null;
     if (!focusWithinMenu) return;
     const id = requestAnimationFrame(() => {
-      const item = document.querySelector<HTMLElement>(
-        '[role="menuitem"][tabindex="0"]',
-      );
-      if (item && item !== document.activeElement) {
-        item.focus();
-        item.scrollIntoView({ block: "nearest" });
+      const item = getHighlightedMenuEntry(document);
+      const focusTarget = getMenuEntryFocusTarget(item);
+      if (focusTarget && focusTarget !== document.activeElement) {
+        focusTarget.focus();
+        if (typeof item?.scrollIntoView === "function") {
+          item.scrollIntoView({ block: "nearest" });
+        }
       }
     });
     return () => cancelAnimationFrame(id);
@@ -151,27 +184,50 @@ const useContextualMenu = ({
   // The trigger must drive the DISCLOSURE (the source of truth for open) while
   // keeping the disclosure's click/keyboard handlers. The tree's toggle is not
   // used for open/close here.
-  const getTriggerProps = useCallback(
-    () => ({
+  const getTriggerProps = useCallback(() => {
+    const disclosureToggleProps = getDisclosureToggleProps();
+    return {
+      ...disclosureToggleProps,
       "aria-haspopup": "menu" as const,
       "aria-expanded": isOpen,
       "aria-controls": popupId,
-      ...getDisclosureToggleProps(),
-    }),
-    [isOpen, popupId, getDisclosureToggleProps],
-  );
+    };
+  }, [isOpen, popupId, getDisclosureToggleProps]);
 
   // Bridge the tree's keyboard handling to the disclosure, which owns the open
-  // state. Escape and Tab close the menu and return focus to the trigger (WCAG /
-  // WAI-ARIA menu pattern); every other key (arrows, Home/End, type-ahead,
-  // Enter) is delegated to the navigation tree.
+  // state. Escape and Tab close a command menu and return focus to the trigger
+  // (WAI-ARIA menu pattern). A panel is not a command row: Tab/Shift+Tab,
+  // Space, and typing stay native, and only Escape / nested ArrowLeft leave.
   const handleMenuKeyDown = useCallback(
     (
       event: React.KeyboardEvent,
       treeKeyDown?: (e: React.KeyboardEvent) => void,
     ) => {
-      if (event.key === "Escape" || event.key === "Tab") {
-        // Tab must not move focus to the next control while the menu is open.
+      const target = event.target;
+      const isInsidePanel =
+        target instanceof HTMLElement &&
+        target.closest("[data-contextual-menu-panel]") !== null;
+
+      if (isInsidePanel) {
+        if (event.key === "Escape") {
+          if (closeOnEscape) {
+            close();
+            // @note Impure — returns focus to the trigger.
+            targetRef.current?.focus();
+          }
+          return;
+        }
+        if (event.key === "ArrowLeft") {
+          treeKeyDown?.(event);
+        }
+        return;
+      }
+
+      if (event.key === "Tab" || event.key === "Escape") {
+        // Consume Escape even when the menu stays open so the tree cannot map
+        // it to CLOSE and steal focus back to the trigger.
+        if (event.key === "Escape" && !closeOnEscape) return;
+        // Tab must not move focus to the next control while a command menu is open.
         if (event.key === "Tab") event.preventDefault();
         close();
         // @note Impure — returns focus to the trigger.
@@ -180,8 +236,38 @@ const useContextualMenu = ({
       }
       treeKeyDown?.(event);
     },
-    [close, targetRef],
+    [close, closeOnEscape, targetRef],
   );
+
+  // A ContextualMenu can own several portalled surfaces. Handle outside
+  // pointer-down once here instead of letting useDisclosure race its single
+  // popup ref against nested portals.
+  useEffect(() => {
+    if (!isOpen || !closeOnOutsideClick) return;
+    const handlePointerDown = (event: PointerEvent) => {
+      const node = event.target as Node | null;
+      if (!node || targetRef.current?.contains(node)) return;
+      const belongsToMenu = event
+        .composedPath()
+        .some(
+          (entry) =>
+            entry instanceof HTMLElement &&
+            entry.dataset.contextualMenuOwner === popupId,
+        );
+      if (!belongsToMenu) close();
+    };
+    document.addEventListener("pointerdown", handlePointerDown);
+    return () => document.removeEventListener("pointerdown", handlePointerDown);
+  }, [isOpen, closeOnOutsideClick, targetRef, popupId, close]);
+
+  useEffect(() => {
+    if (!isOpen || !closeOnEscape) return;
+    const handleEscape = (event: KeyboardEvent) => {
+      if (event.key === "Escape") close();
+    };
+    document.addEventListener("keydown", handleEscape);
+    return () => document.removeEventListener("keydown", handleEscape);
+  }, [isOpen, closeOnEscape, close]);
 
   // Menu-role ARIA getters, composing the base navigation prop-getters (for
   // roving tabindex + refs) with the contextual-menu ARIA presets.

--- a/packages/react/ds-global/src/lib/hooks/useWindowDimensions/types.ts
+++ b/packages/react/ds-global/src/lib/hooks/useWindowDimensions/types.ts
@@ -1,4 +1,8 @@
 export interface UseWindowDimensionProps {
+  /** Whether viewport listeners should be installed. Defaults to true. */
+  enabled?: boolean;
+  /** Whether window and visual viewport scroll listeners are needed. Defaults to true. */
+  listenToScroll?: boolean;
   /** Delay in milliseconds before the resize event is triggered */
   resizeDelay?: number;
   /** Delay in milliseconds before the scroll event is triggered */

--- a/packages/react/ds-global/src/lib/hooks/useWindowDimensions/useWindowDimensions.ts
+++ b/packages/react/ds-global/src/lib/hooks/useWindowDimensions/useWindowDimensions.ts
@@ -9,6 +9,8 @@ import type {
  * Hook to get the window dimensions and scroll position.
  */
 export default function useWindowDimensions({
+  enabled = true,
+  listenToScroll = true,
   onResize,
   onScroll,
   resizeDelay = 100,
@@ -37,7 +39,7 @@ export default function useWindowDimensions({
   );
 
   useEffect(() => {
-    if (isServer) return;
+    if (isServer || !enabled) return;
     const handleResize = debounce(() => {
       setWindowWidth(window.innerWidth);
       setWindowHeight(window.innerHeight);
@@ -51,7 +53,7 @@ export default function useWindowDimensions({
     }, scrollDelay);
 
     window.addEventListener("resize", handleResize);
-    window.addEventListener("scroll", handleScroll);
+    if (listenToScroll) window.addEventListener("scroll", handleScroll);
 
     // The visual viewport changes on pinch-zoom (and on-screen keyboards) WITHOUT
     // firing a window `resize`, so anything positioned from viewport bounds would
@@ -59,21 +61,30 @@ export default function useWindowDimensions({
     // page zoom already fires the window `resize` above, so it is covered too.)
     const viewport = window.visualViewport;
     viewport?.addEventListener("resize", handleResize);
-    viewport?.addEventListener("scroll", handleScroll);
+    if (listenToScroll) viewport?.addEventListener("scroll", handleScroll);
 
     // Initial trigger in case the values need to be passed immediately after mount
     void handleResize();
-    void handleScroll();
+    if (listenToScroll) void handleScroll();
 
     return () => {
       handleResize.cancel();
       handleScroll.cancel();
       window.removeEventListener("resize", handleResize);
-      window.removeEventListener("scroll", handleScroll);
+      if (listenToScroll) window.removeEventListener("scroll", handleScroll);
       viewport?.removeEventListener("resize", handleResize);
-      viewport?.removeEventListener("scroll", handleScroll);
+      if (listenToScroll) viewport?.removeEventListener("scroll", handleScroll);
     };
-  }, [onResize, onScroll, resizeDelay, scrollDelay, result, isServer]);
+  }, [
+    enabled,
+    listenToScroll,
+    onResize,
+    onScroll,
+    resizeDelay,
+    scrollDelay,
+    result,
+    isServer,
+  ]);
 
   return result;
 }

--- a/packages/react/ds-global/src/lib/hooks/useWindowFitment/useWindowFitment.tests.ts
+++ b/packages/react/ds-global/src/lib/hooks/useWindowFitment/useWindowFitment.tests.ts
@@ -1,5 +1,12 @@
-import { describe, expect, it } from "vitest";
-import { computeArrowOffset } from "./useWindowFitment.js";
+import { act, renderHook } from "@testing-library/react";
+import type { MutableRefObject } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useResizeObserver } from "../useResizeObserver/index.js";
+import { useWindowDimensions } from "../useWindowDimensions/index.js";
+import useWindowFitment, { computeArrowOffset } from "./useWindowFitment.js";
+
+vi.mock("../useResizeObserver/index.js");
+vi.mock("../useWindowDimensions/index.js");
 
 /** Build a minimal DOMRect-like object for the fields computeArrowOffset reads. */
 const makeRect = (
@@ -103,6 +110,169 @@ describe("computeArrowOffset", () => {
     expect(computeArrowOffset("bottom", target, staleRect)).toEqual({
       axis: "x",
       offset: 50,
+    });
+  });
+});
+
+describe("useWindowFitment scroll positioning", () => {
+  let target: HTMLButtonElement;
+  let popup: HTMLDivElement;
+  let targetTop: number;
+  let viewport: EventTarget;
+  let animationFrames: FrameRequestCallback[];
+
+  beforeEach(() => {
+    targetTop = 100;
+    target = document.createElement("button");
+    popup = document.createElement("div");
+    document.body.append(target, popup);
+    target.getBoundingClientRect = () => makeRect(100, targetTop, 80, 20);
+    popup.getBoundingClientRect = () => makeRect(0, 0, 100, 60);
+
+    vi.mocked(useResizeObserver).mockImplementation((element) =>
+      element === popup
+        ? { width: 100, height: 60 }
+        : { width: 80, height: 20 },
+    );
+    vi.mocked(useWindowDimensions).mockReturnValue({
+      windowWidth: 1024,
+      windowHeight: 768,
+      scrollWidth: 0,
+      scrollHeight: 0,
+    });
+
+    viewport = new EventTarget();
+    Object.defineProperty(window, "visualViewport", {
+      configurable: true,
+      value: viewport,
+    });
+    animationFrames = [];
+    vi.spyOn(window, "requestAnimationFrame").mockImplementation((callback) => {
+      animationFrames.push(callback);
+      return animationFrames.length;
+    });
+    vi.spyOn(window, "cancelAnimationFrame").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    target.remove();
+    popup.remove();
+    vi.restoreAllMocks();
+  });
+
+  const renderOpenFitment = () => {
+    const hook = renderHook(() =>
+      useWindowFitment({
+        isOpen: true,
+        preferredDirections: ["block-end"],
+      }),
+    );
+    (
+      hook.result.current.targetRef as MutableRefObject<HTMLElement | null>
+    ).current = target;
+    (
+      hook.result.current.popupRef as MutableRefObject<HTMLDivElement | null>
+    ).current = popup;
+    hook.rerender();
+    return hook;
+  };
+
+  const flushAnimationFrame = () => {
+    const callback = animationFrames.shift();
+    if (callback) act(() => callback(performance.now()));
+  };
+
+  it("repositions on capture-phase ancestor scrolling", () => {
+    const hook = renderOpenFitment();
+    expect(hook.result.current.bestPosition?.position.top).toBe(120);
+
+    targetTop = 240;
+    const ancestor = document.createElement("div");
+    ancestor.append(target);
+    document.body.append(ancestor);
+    act(() => ancestor.dispatchEvent(new Event("scroll")));
+    flushAnimationFrame();
+
+    expect(hook.result.current.bestPosition?.position.top).toBe(260);
+    ancestor.remove();
+  });
+
+  it("repositions on visual viewport scrolling", () => {
+    const hook = renderOpenFitment();
+    targetTop = 180;
+    act(() => viewport.dispatchEvent(new Event("scroll")));
+    flushAnimationFrame();
+
+    expect(hook.result.current.bestPosition?.position.top).toBe(200);
+  });
+
+  it("installs listeners only while open and cleans up pending frames", () => {
+    const windowAdd = vi.spyOn(window, "addEventListener");
+    const windowRemove = vi.spyOn(window, "removeEventListener");
+    const viewportAdd = vi.spyOn(viewport, "addEventListener");
+    const viewportRemove = vi.spyOn(viewport, "removeEventListener");
+
+    const hook = renderHook(({ open }) => useWindowFitment({ isOpen: open }), {
+      initialProps: { open: false },
+    });
+    expect(windowAdd).not.toHaveBeenCalledWith(
+      "scroll",
+      expect.any(Function),
+      true,
+    );
+
+    hook.rerender({ open: true });
+    expect(windowAdd).toHaveBeenCalledWith(
+      "scroll",
+      expect.any(Function),
+      true,
+    );
+    expect(viewportAdd).toHaveBeenCalledWith("scroll", expect.any(Function));
+    act(() => viewport.dispatchEvent(new Event("scroll")));
+    hook.unmount();
+
+    expect(windowRemove).toHaveBeenCalledWith(
+      "scroll",
+      expect.any(Function),
+      true,
+    );
+    expect(viewportRemove).toHaveBeenCalledWith("scroll", expect.any(Function));
+    expect(window.cancelAnimationFrame).toHaveBeenCalled();
+  });
+
+  it("remeasures when reopened after the trigger moved without a scroll event", () => {
+    const hook = renderHook(
+      ({ open }) =>
+        useWindowFitment({
+          isOpen: open,
+          preferredDirections: ["block-end"],
+        }),
+      { initialProps: { open: true } },
+    );
+    (
+      hook.result.current.targetRef as MutableRefObject<HTMLElement | null>
+    ).current = target;
+    (
+      hook.result.current.popupRef as MutableRefObject<HTMLDivElement | null>
+    ).current = popup;
+    hook.rerender({ open: true });
+    expect(hook.result.current.bestPosition?.position.top).toBe(120);
+
+    hook.rerender({ open: false });
+    targetTop = 240;
+    hook.rerender({ open: true });
+
+    expect(hook.result.current.bestPosition?.position.top).toBe(260);
+  });
+
+  it("keeps a fully off-screen trigger at its natural popup position", () => {
+    targetTop = 900;
+    const hook = renderOpenFitment();
+
+    expect(hook.result.current.bestPosition).toMatchObject({
+      position: { top: 920, left: 90 },
+      fits: false,
+      autoFitOffset: { top: 0, left: 0 },
     });
   });
 });

--- a/packages/react/ds-global/src/lib/hooks/useWindowFitment/useWindowFitment.tsx
+++ b/packages/react/ds-global/src/lib/hooks/useWindowFitment/useWindowFitment.tsx
@@ -2,6 +2,7 @@ import {
   type CSSProperties,
   useCallback,
   useEffect,
+  useLayoutEffect,
   useMemo,
   useRef,
   useState,
@@ -19,6 +20,12 @@ import type {
   WindowFitmentPlacement,
   WindowFitmentSide,
 } from "./types.js";
+
+// `useLayoutEffect` logs a warning on the server, so fall back to `useEffect`
+// there. On the client we keep the pre-paint remeasure so a reopened popup
+// never paints at a stale coordinate.
+const useIsomorphicLayoutEffect =
+  typeof window === "undefined" ? useEffect : useLayoutEffect;
 
 /** A resolved PHYSICAL placement — what the fitment core consumes internally. */
 type PhysicalPlacement = {
@@ -139,6 +146,7 @@ const useWindowFitment = <
   maxWidth = "350px",
   resizeDelay = 150,
   scrollDelay = 150,
+  isOpen,
   onBestPositionChange,
   autoFit = false,
   direction: directionProp,
@@ -153,8 +161,15 @@ const useWindowFitment = <
   // Bumped when the anchored element's `dir` flips with no layout change, so the
   // logical→physical resolution re-runs (see the MutationObserver effect below).
   const [dirVersion, setDirVersion] = useState(0);
+  const [positionVersion, setPositionVersion] = useState(0);
+  const positioningActive = isOpen ?? true;
 
-  const windowDimensions = useWindowDimensions({ resizeDelay, scrollDelay });
+  const windowDimensions = useWindowDimensions({
+    resizeDelay,
+    scrollDelay,
+    enabled: positioningActive,
+    listenToScroll: false,
+  });
   const targetSize = useResizeObserver(targetRef?.current);
   const popupSize = useResizeObserver(popupRef?.current);
 
@@ -310,6 +325,12 @@ const useWindowFitment = <
       if (isServer) return;
       let fallbackPosition: BestPosition | undefined;
       let fallbackScore = Number.POSITIVE_INFINITY;
+      const targetOutsideBounds =
+        !!bounds &&
+        (targetRect.bottom <= bounds.top ||
+          targetRect.top >= bounds.bottom ||
+          targetRect.right <= bounds.left ||
+          targetRect.left >= bounds.right);
 
       if (!placements.length) {
         throw new Error("Preferred directions must not be empty.");
@@ -339,7 +360,7 @@ const useWindowFitment = <
         // only as the fallback when no side fits naturally.
         const absolutePosition = { ...naturalPosition };
         const autoFitOffset = { top: 0, left: 0 };
-        if (autoFit && bounds) {
+        if (autoFit && bounds && !targetOutsideBounds) {
           if (absolutePosition.top < bounds.top) {
             autoFitOffset.top = bounds.top - absolutePosition.top;
             absolutePosition.top = bounds.top;
@@ -436,7 +457,40 @@ const useWindowFitment = <
     isServer,
     directionProp,
     dirVersion,
+    positionVersion,
   ]);
+
+  // Element scroll does not bubble, but a capture listener on window observes
+  // scrolling ancestors. One animation frame coalesces nested/window/visual
+  // viewport events into a single fresh geometry read.
+  useEffect(() => {
+    if (isServer || !positioningActive) return;
+    let frameId: number | undefined;
+    const schedulePositionUpdate = () => {
+      if (frameId !== undefined) return;
+      frameId = requestAnimationFrame(() => {
+        frameId = undefined;
+        setPositionVersion((version) => version + 1);
+      });
+    };
+    window.addEventListener("scroll", schedulePositionUpdate, true);
+    const viewport = window.visualViewport;
+    viewport?.addEventListener("scroll", schedulePositionUpdate);
+    return () => {
+      window.removeEventListener("scroll", schedulePositionUpdate, true);
+      viewport?.removeEventListener("scroll", schedulePositionUpdate);
+      if (frameId !== undefined) cancelAnimationFrame(frameId);
+    };
+  }, [isServer, positioningActive]);
+
+  // Closed popups drop their scroll listeners, so a later open would otherwise
+  // reuse the last `bestPosition` until something else (scroll, resize) bumps
+  // geometry. Remeasure synchronously before paint so the popup never appears
+  // at the previous trigger's coordinates — or stays off-screen until scroll.
+  useIsomorphicLayoutEffect(() => {
+    if (isServer || !positioningActive) return;
+    setPositionVersion((version) => version + 1);
+  }, [isServer, positioningActive]);
 
   // Re-resolve when the document's <html dir> flips (a language toggle) with no
   // size/scroll change. A single observer on the root — the one source of truth.


### PR DESCRIPTION
## Done

Adds `displayItemsType: "panel"` so ContextualMenu can host a filter-style surface (search, checkboxes, Select all / Clear) without treating that surface as a command row.

A panel is a `role="group"` inside the existing menu popup. Pointer and Tab reach the controls; typing stays in the field; Escape closes and returns focus to the trigger. Mixed panel + command rows in one menu are not supported. `custom` stays a selectable command row.

The styled trigger path uses `triggerProps` (Pragma Button) and needs a forwarded Button ref so the menu can position against the real node and return focus on close. `closeOnEscape` is on ContextualMenu, matching Popover. Fitment remeasures on open and follows scroll while the menu is open. Command-row leading icons get an `> .icon` box. Expanded fill is native-trigger only (`:not(.button)`), so it does not paint over a Button trigger.

## QA

- [ ] Open **Components / ContextualMenu / Styled Trigger With Interactive Panel**.
  - Secondary Button trigger with filter icon, “Tags”, and a count badge.
  - Menu opens below the trigger.
  - Search, checkboxes, Select all, and Clear work with pointer and Tab. Typing in Search does not type-ahead the menu.
  - Escape closes and returns focus to the trigger.
- [ ] Default / nested / RTL stories still open, arrow-navigate, and dismiss as before.
- [ ] Native trigger (no `triggerProps`) still gets the expanded fill; a Button trigger does not.

### PR readiness check

- [ ] PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format, using one of the allowed types: `feat`, `fix`, `docs`, `refactor`, `chore`, `test`, `ci`, `revert`.
  - The matching type label is applied automatically from the title — there is no type label to add by hand.
  - Breaking changes are marked with `!` in the title (e.g. `feat(router)!: …`), which adds the `breaking` label.
- [ ] The code follows the appropriate [code standards](https://github.com/canonical/web-code-standards)
- [ ] All packages define the required scripts in `package.json`:
  - [ ] All packages: `check`, `check:fix`, and `test`.
  - [ ] Packages with build steps: `build` to build the package for development or distribution, `build:all` to build **all** artifacts. See [CONTRIBUTING.md](../old/CONTRIBUTING.md#24-full-artifact-builds-buildall) for details.
- [ ] If this PR introduces a **new package**: first-time publish has been done manually from inside the package directory using `npm publish --access public` (first-time publishing is not automated). Run `bun run publish:status` from the repo root to verify. Then configure an OIDC [trusted publisher](https://docs.npmjs.com/trusted-publishers) for the package on npmjs.com (repo `canonical/pragma`, workflow `tag.yml`) and set publishing access to disallow tokens, so the automated release workflow can publish future versions.
- [ ] If this PR does not require visual testing, add the `Chromatic: skip` label to skip Chromatic.

## Screenshots

Storybook: Components / ContextualMenu / Styled Trigger With Interactive Panel.
<img width="1179" height="748" alt="image" src="https://github.com/user-attachments/assets/30e688fc-2231-4ee6-b20d-e9dd8a6b6a07" />

