### PR TITLE
chore(cli): re-derive the perf ceilings, and keep the pass manual

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -203,6 +203,12 @@ precedent.
   does not, however important that package is.
 - **If you believe you need a workflow change, say why in the PR body** and
   expect it to be challenged.
+- **One target is deliberately off CI and must stay off it:** the `pragma`
+  CLI's perf-budget pass (`packages/cli/pragma`, `bun run test:perf`). Owner
+  ruling 2026-08-30, restated 2026-09-10 — a wall-clock spawn measurement
+  cannot mean anything on a shared runner. Nothing reaches it today: not
+  `test`, not an Nx target, not a hook. Putting it back on any CI target
+  reverses a ruling; see `docs/CI.md` and `packages/cli/pragma/BUDGETS.md`.
 ### React component props — extend the root element's native props
 
 A React component's props type **must extend the native props of the element it

--- a/docs/CI.md
+++ b/docs/CI.md
@@ -127,6 +127,23 @@ Chromatic workflows use a shared template (`.github/workflows/chromatic._templat
 
 On pull requests, Chromatic requires manual approval for visual changes. On pushes to main, changes are automatically accepted as new baselines. This allows reviewing visual changes during PR review while keeping baselines current after merge.
 
+## What CI deliberately does not run
+
+### The `pragma` perf budgets
+
+`packages/cli/pragma` has a serial performance-budget pass (`bun run test:perf`, `vitest.perf.config.ts`) that spawns the shipped CLI entry and times it against the ceilings in `src/testing/perf/budgets.ts`. **It is not part of CI, by owner ruling of 2026-08-30, restated 2026-09-10, and it must not be added back.**
+
+The reason is not that the budgets do not matter. It is that a wall-clock spawn measurement cannot be made to mean anything on a shared runner: the same ceilings measured green on the reference machine and red on GitHub-hosted runners, and raising one of them moved the failure from the budget to Vitest's per-test timeout rather than clearing it. A gate that fails for the runner's reasons teaches contributors to re-run it, which is worse than no gate.
+
+So the pass is manual. Nothing invokes it automatically — not `pr.yml`, not `push.yml`, not `tag.yml`, no Nx target, no git hook, and not the package's own `test` script (which is why `nx affected -t test` no longer reaches it). Anyone can run it, and it stays enforced when they do.
+
+Two consequences are worth naming rather than discovering:
+
+- **A performance regression can reach `main` unobserved.** That is the accepted cost of the ruling. Where the pass should run instead — a scheduled job, a release gate, or a maintainer's run before a release — is an open question, recorded in `packages/cli/pragma/BUDGETS.md`.
+- **It needs a quiet machine.** Spawn latency inflates 2–3× under other load, so a red run on a busy box is usually measuring the box. `BUDGETS.md` documents the `--version` control that tells the two apart.
+
+If you believe this pass belongs in a workflow, you are reversing an owner ruling: say so explicitly in the PR body, per `AGENTS.md` ("CI workflows are global — do not add checks for one package").
+
 ## How to Release
 
 Releases require write access to the repository and must run from the main branch.

--- a/packages/cli/pragma/BUDGETS.md
+++ b/packages/cli/pragma/BUDGETS.md
@@ -7,7 +7,10 @@ hesitation. These budgets are enforced by the protected perf tests
 ceilings in `src/testing/perf/budgets.ts`. Node's own startup is INSIDE every
 sample, because the user pays it.
 
-> **They do not gate pull requests — owner ruling, 2026-08-30.** `test` no longer
+> **They do not gate pull requests — owner ruling, 2026-08-30, restated
+> 2026-09-10.** The restatement, the re-verification that nothing reaches the
+> pass indirectly, and the three ceilings that moved with it are in
+> "Re-derived 2026-09-10" at the end of this file. `test` no longer
 > chains `test:perf`, and that chain was the only path by which
 > `nx affected -t test` reached this suite. The tests and every ceiling are
 > unchanged, and still enforced for anyone who runs `bun run test:perf`.
@@ -460,3 +463,318 @@ is therefore the best available direct measure of that cost, and it is inside
 the noise band. Independent replications on this box (250-round `--version`-only
 interleave; 120-round three-case) put it at +0.07 to +0.5 ms. If a true control
 is ever wanted here, it has to be a process outside the module graph.
+
+## Re-derived 2026-09-10 — three ceilings moved, two left, one timeout raised
+
+Three of the five ceilings had drifted red on `origin/main` (`075bdbab7`), and
+for two causes that are both real work rather than measurement noise: the
+eagerly-imported capability barrel grew as the surface grew, and the embedded
+pack grew from 8 479 to 49 630 triples. This section re-derives all five by the
+rules the sections above establish. It does not revise any measurement above —
+those are the record of the boxes and artifacts they were taken on.
+
+**Why this pass is manual.** It is not run by CI, by owner ruling 2026-08-30,
+restated 2026-09-10: a wall-clock spawn measurement cannot be made to mean
+anything on a shared runner, so the budgets are enforced by whoever runs
+`bun run test:perf` on a quiet machine, and a regression can reach `main`
+unobserved in between. Verified again here that nothing reaches the pass
+indirectly — see "Durability of the ruling" at the end of this section.
+
+### Environment
+
+| | |
+|---|---|
+| OS / CPU | Linux 6.18.44 x86_64 · Intel Core Ultra 7 165U (14 threads) · 62 GB RAM |
+| Runtime | `node` v24.18.1 (the runtime the entry ships for), `bun` 1.4.0, `vitest` 4.1.2 |
+| Artifact | `dist/src/bin.js` — the `tsc` emit from `bun run build`, spawned as `node dist/src/bin.js`, exactly as `budgets.test.ts` does |
+| Embedded pack | 49 630 triples / 4 167 entities (`contentHash 83746a38…`, generated 2026-09-08) |
+| Surface | 22 capability modules (16 authored + 6 declared stories) · 42 MCP tools |
+
+This is the same physical box as the "paired A/B" and "embedded pack becomes
+the real graph" sections above, which is what licenses the within-box
+comparisons below. It is **not** the day-1 reference box: its cold process
+start is *faster* (`--version` median 34.8 ms here against the reference box's
+45.5 ms), so where a reference-box projection is quoted it is a projection, not
+an observation.
+
+### Method, and the load gate that makes it honest
+
+Protocol as prescribed above: interleaved round-robin over the cells, rotating
+the start index each round so drift lands on every cell equally, 45 rounds with
+5 discarded as warmups → **40 kept samples per cell**, fresh `XDG_*` dirs per
+cell, and a `pragma --version` **control measured in the same run** so every
+figure can be quoted net of process start.
+
+The fast-path cells and the store cell were measured in **separate runs**.
+Interleaving them is not free: with `__store-probe` in the rotation the
+fast-path cells came out ~15 ms slower (help work 82.8 ms against 69.1 ms),
+because a 500 ms store boot between two 100 ms spawns churns the page cache.
+That is a measurement artifact, not a cost the user pays, so the cells that
+share a statistic share a run.
+
+**A repetition was accepted only if its own `--version` control had a median
+at or below 40 ms.** This box's quiet band is a control median of 33–39 ms
+(sample minimum ~26 ms); when other work is running it goes to 60–110 ms, and
+the netted *work* figures then inflate superlinearly — help work ranged 66 ms
+to 233 ms across repetitions, tracking nothing but the control. Netting alone
+does not rescue a contended run, because a longer piece of work is more exposed
+to contention (the same point the "multiplier, not the increment" argument
+makes above). So contended repetitions are **discarded, not averaged in**:
+
+| cells | repetitions run | accepted (control ≤ 40 ms) | rejected controls |
+|---|---|---|---|
+| fast paths | 9 | 5 | 40.8 · 42.4 · 60.5 · 110.0 ms |
+| `__store-probe` | 7 | 4 | 44.5 · 60.2 · 71.4 ms |
+
+Every figure below is the **median across accepted repetitions** of that
+repetition's own statistic.
+
+### Measured
+
+| Cell | n | median | p95 | 10%-trimmed mean | work (net of control) |
+|---|---|---|---|---|---|
+| `pragma --version` (control) | 5 × 40 | **34.8 ms** | 43.3 ms | 35.9 ms | — |
+| `pragma --help` | 5 × 40 | **103.3 ms** | 134.0 ms | 107.7 ms | 69.1 ms |
+| `pragma __complete config` | 5 × 40 | 116.4 ms | 141.2 ms | 118.5 ms | 81.7 ms |
+| `pragma __complete skill lookup do` | 5 × 40 | **115.7 ms** | 145.0 ms | 118.6 ms | 81.4 ms |
+| `pragma __store-probe` | 4 × 40 | **536.0 ms** | 608.9 ms | 536.2 ms | 499.9 ms |
+| project config load (warm, in-process) | 40 | **0.011 ms** | 0.034 ms | 0.013 ms | — |
+| MCP `capabilities` (warm, in-process) | 40 | 0.506 ms | **0.732 ms** | 0.530 ms | — |
+
+The two in-process cells were measured against the same `dist/` under `node`,
+priming the cache / making one warm-up call first, exactly as
+`budgets.test.ts` does.
+
+### Where the fast paths' cost went
+
+Almost all of it is one import. Timing a single dynamic `import()` of the
+built modules and nothing else — 25 spawns per module, 5 discarded, three
+repetitions:
+
+| Module | import median | recorded in the A/B above |
+|---|---|---|
+| `capabilities/index.js` (the barrel) | **68.0 ms** | 37.6 ms |
+| `constants.js` | 5.0 ms | — |
+
+68.0 ms of import against 69.1 ms of measured `--help` work: the barrel **is**
+the fast path now. It has gained **+30.4 ms (1.81×)** since the recovery A/B,
+and the surface is where it went — 22 capability modules and 42 MCP tools, each
+contributing its spec and formatter modules to a barrel that is imported
+eagerly. Timed individually the heaviest are `prompt` (38.1 ms) and `graph`
+(36.1 ms), but no single module dominates; the cost is the count.
+
+**This is surface growth, not a lazy-boundary leak.**
+`src/capabilities/lazy.test.ts` is green (9/9): nothing on the static graph from
+`buildProgram` or `capabilities/index` value-imports
+`@canonical/summon-core/projection`, its Commander adapter, `commander`, a zod
+schema module, or a `collect*` run body. The deferral work recorded above still
+holds; there is simply more behind it. A future cut has to come from making the
+barrel itself lazy — registering capabilities from baked data the way
+`CREATE_CLI_SYNTAX` already does for flag spellings — and not from another
+round of moving run bodies.
+
+### Where the store verb's cost went
+
+The pack. `BUDGET_WARM_STORE_MS = 500` was derived against an 8 479-triple
+embed; the distribution now embeds **49 630 triples / 4 167 entities**, 5.85×
+the triples. Measured store work on this box went **+285.4 ms → +499.9 ms**,
+a factor of **1.752** — sublinear in triple count, because boot loads the
+n-quads dump rather than parsing TTL and rebuilds the schema from the
+extraction artifact rather than running a live 7-pass compile. That design is
+what keeps a 5.85× pack to a 1.75× cost, and it is worth saying that it worked.
+
+### The arithmetic
+
+**`BUDGET_HELP_MS`: 130 → 210.** Rule: 2× the measured median.
+
+```
+measured median (5 accepted reps × 40)   = 103.3 ms
+rule                = 2 × 103.3          = 206.6 ms
+ceiling             = ceil(206.6 / 10) × 10   = 210 ms
+```
+
+Cross-checked against the reference box, holding the measured work constant:
+`45.5 + 69.1 = 114.6` ms median → 2× = **229 ms**. The projection is *looser*
+than the local rule, so 210 is the tight side of the rule — the same
+relationship 130 had to its own projection (~162 ms) when it was set.
+
+**`BUDGET_COMPLETE_MS`: 150 → 240.** Rule: 2× the measured median of the
+slower of the two cases, which is the name-source case.
+
+```
+measured median, __complete skill lookup do  = 115.7 ms
+rule                = 2 × 115.7              = 231.4 ms
+ceiling             = ceil(231.4 / 10) × 10   = 240 ms
+sanity: 2 × trimmed mean = 2 × 118.6 = 237.2  → the same 240
+```
+
+Cross-check on the reference box: `45.5 + 81.4 = 126.9` ms → 2× = **254 ms**,
+again looser. The noun case is now within a millisecond of the name-source case
+(116.4 vs 115.7 median), where it used to be the faster of the two; the
+filesystem walk is no longer what distinguishes them, the shared barrel is.
+
+**`BUDGET_WARM_STORE_MS`: 500 → 850.** Rule: `ceil(projected p95 × 1.25 / 50) × 50`,
+the route that produced 500, with one new input — the within-box growth
+multiplier, both of whose terms were measured on this box under the same netted
+protocol.
+
+```
+within-box growth multiplier  = 499.9 / 285.4                  = 1.752
+reference store work, old pack = 101.5 × 2.83                   = 287.2 ms
+reference store work, new pack = 287.2 × 1.752                  = 503.2 ms
+projected reference median     = 45.5 + 503.2                   = 548.7 ms
+reference p95/median, this command = 176 / 147                  = 1.197
+projected p95                  = 548.7 × 1.197                  = 656.9 ms
+ceiling                        = ceil(656.9 × 1.25 / 50) × 50   = 850 ms
+```
+
+The local-only route agrees to within 6%: this box's own measured p95 is
+608.9 ms, and `ceil(608.9 × 1.25 / 50) × 50` = **800**. The reference-box
+number is taken because that is the route the standing ceiling came from, and
+because a ceiling derived only on the box in front of you is a ceiling that
+moves with the box.
+
+850 remains **1.55×** the projected median, still tighter than the 2×-of-median
+rule the fast paths use. It is **2.83×** the designed `<300ms` target, where
+500 was 1.67×, and that ratio is the honest headline of this whole
+re-derivation: the `<300ms` target was set against a 23-triple sample, held
+against 8 479, and cannot be reached at all by a 49 630-triple pack whose store
+work alone is ~500 ms. `warmStoreVerb: "<300ms"` stays in the surface covenant
+as the aspiration — but it is now an aspiration that needs a different boot
+strategy (a lazily-materialised or partitioned store), not a tuning pass.
+
+### Deliberately not moved
+
+**`BUDGET_PROJECT_CONFIG_MS` stays 10 ms.** Warm median 0.011 ms, p95 0.034 ms
+— about 900× of headroom. The 2×-median rule would give 0.02 ms, which would
+assert nothing but scheduler jitter. 10 ms is a gross-regression guard (a cache
+that stopped hitting) and that is the whole of its job.
+
+**`BUDGET_MCP_P95_WARM_MS` stays 100 ms.** The warm call did grow with the
+catalog — p95 0.732 ms and trimmed mean 0.530 ms over 42 tools, against
+p95 ≈ 0.4 ms at 38 — but that is still ~137× of headroom. Worth noting as a
+trend (the catalog's per-call overhead is not free) and not worth a tighter
+number, for the same reason: a ceiling near a sub-millisecond median would
+measure the scheduler.
+
+### Summary
+
+| Constant | Designed | Median | p95 | Old ceiling | New ceiling | Rule applied |
+|---|---|---|---|---|---|---|
+| `BUDGET_HELP_MS` | 50 (unmet) | 103.3 ms | 134.0 ms | 130 | **210** | 2× median = 206.6 |
+| `BUDGET_COMPLETE_MS` | 50 (unmet) | 115.7 ms | 145.0 ms | 150 | **240** | 2× median = 231.4 |
+| `BUDGET_PROJECT_CONFIG_MS` | 10 warm | 0.011 ms | 0.034 ms | 10 | **10** | left — 900× headroom |
+| `BUDGET_WARM_STORE_MS` | 300 (unmet) | 536.0 ms | 608.9 ms | 500 | **850** | ceil(projected p95 × 1.25 / 50) × 50 |
+| `BUDGET_MCP_P95_WARM_MS` | 100 | 0.506 ms | 0.732 ms | 100 | **100** | left — 137× headroom |
+
+The designed 50 ms fast-path target and the designed 300 ms store target both
+stay recorded as **designed and unmet**. Neither was moved.
+
+### What was red on `main` before this change
+
+Measured against `origin/main` `075bdbab7` with the ceilings it shipped:
+
+| Case | Statistic asserted | Observed | Ceiling then |
+|---|---|---|---|
+| `warm store-backed verb` | median | 550.5 · 573.6 · 568.1 ms (three retries, all red) | 500 |
+| `pragma --help` | p95 | 131.0 · 132.8 · 134.0 · 134.1 · 140.2 ms (every accepted repetition) | 130 |
+
+`--help` is red on **p95 only** — its median, 103.3 ms, was still inside the
+130 ms ceiling. That is worth stating precisely, because it means the ceiling
+had already stopped being 2× a median and become roughly 1.25× one.
+`__complete` was not red (its trimmed mean sat at ~119 ms against 150), so its
+ceiling is raised here for consistency of derivation rather than to clear a
+failure — the same rule, the same measurement, the same cause.
+
+### How marginal the new ceilings are
+
+The 40-sample figures above characterise the box; they are not the statistic
+the tests assert. Replaying each case under **its own test's protocol** (`help`
+15 runs/3 warmups → 12 kept; `__complete` 30/5 → 25 kept; `__store-probe`
+12/3 → 9 kept, so its p95 is the maximum), repeatedly:
+
+| Case | trials | median of medians | median p95 | worst asserted statistic | new ceiling |
+|---|---|---|---|---|---|
+| `--help` | 12 | 115.0 ms | 142.1 ms | p95 200.2 ms | 210 |
+| `__complete skill lookup do` | 8 | 129.7 ms | 147.0 ms | trimmed mean 136.7 ms | 240 |
+| `__store-probe` | 15 | 576.2 ms | 667.7 ms | p95 807.5 ms quiet · 1556.5 ms contended | 850 |
+
+Two honest caveats fall out of that table.
+
+1. **`--help` has the least room of the three.** It is the only case still
+   asserted on a *raw* nearest-rank p95 at the bare ceiling, over 12 kept
+   samples — where p95 is effectively the maximum. 200.2 of 210 was the worst
+   of 12 replays. The available fix is the one `__complete` already got
+   (enforce the trimmed mean, keep p95 as a soft check with headroom); it is
+   **recorded here as an option, not taken**, because changing the statistic is
+   a different decision from re-deriving the number, and this pass did the
+   latter.
+2. **A contended box will still go red**, and should. The `__store-probe`
+   trial at p95 1556.5 ms was measured while other work was running; `retry: 2`
+   gives three attempts, which is enough for a quiet box and deliberately not
+   enough for a busy one. Check the control before believing a red run.
+
+### The other time limit: vitest's per-test timeout
+
+Raising `BUDGET_WARM_STORE_MS` did not make the pass green. It made the store
+case fail on **vitest's 5 s per-test timeout** instead, with the budget
+assertion passing underneath — precisely the outcome the 2026-08-30 banner
+above records from the last attempt ("raising one of them moved the failure
+from the budget to vitest's per-test timeout rather than clearing it").
+
+The timeout had been too small all along, and was invisible because of the
+order failures are reported in. Every spawn case is a **synchronous** test body
+(`spawnSync` in a loop), so vitest cannot interrupt it; the body runs to
+completion and whichever failure is noticed first is the one reported. While a
+ceiling was red the `AssertionError` won that race, and the timeout never
+surfaced. It was there in the numbers, though: the store case's own reported
+duration on `origin/main` was 20 878 ms across three retries — ~6.9 s per
+attempt against a 5 000 ms limit.
+
+A budget case must fail on its **budget**, never on the clock: a red ceiling
+tells you what regressed, a red clock tells you nothing. So `testTimeout` is
+derived from the ceilings rather than picked, from the case that binds:
+
+```
+__store-probe   12 runs × 850 ms  = 10 200 ms    ← binding
+__complete      30 runs × 240 ms  =  7 200 ms    (two cases)
+--help          15 runs × 210 ms  =  3 150 ms
+testTimeout = 2 × 10 200 ≈ 20 000 ms
+```
+
+The 2× is not headroom for slowness. It means every spawn in a run could land
+at twice its ceiling and the ASSERTION would still be the thing that reports.
+Whole-file runtime when healthy is ~17 s of tests, so this does not lengthen a
+good run; it only changes what a bad one says. Set in `vitest.perf.config.ts`,
+where the derivation is repeated next to the number.
+
+**Verified green three times running** with the new ceilings and the new
+timeout: 22/22 passed, 18.7 s / 19.5 s / 19.9 s, on a box whose control sat in
+the quiet band. On `origin/main` the same command failed 21/22 with all three
+store retries red.
+
+### Durability of the ruling
+
+Re-verified 2026-09-10, mechanically, that nothing reaches this pass:
+
+- no file under `.github/` mentions `test:perf`, `vitest.perf.config`, or
+  `perf` (the single `grep` hit is an unrelated comment in
+  `actions/lerna-version/version.sh`);
+- the package's `test` script is `check:packs:test && test:vitest`, and
+  `vitest.config.ts` excludes `src/testing/perf/**`;
+- `nx.json` declares no perf target, and its `test` default only
+  `dependsOn: ["^build"]`;
+- the repo has no `lefthook`, `husky`, or `.git/hooks` configuration;
+- no script in the root or package `package.json` chains it.
+
+The ruling is now restated where someone about to undo it will read it:
+`vitest.perf.config.ts`'s header, `docs/CI.md` ("What CI deliberately does not
+run"), and `AGENTS.md`'s "CI workflows are global" section. No test asserts the
+*contents* of a workflow file, and none was added — this repo does not do that
+anywhere, and a test that pins CI's shape from inside one package would be the
+package-scoped CI concern `AGENTS.md` forbids.
+
+Open question (1) from the 2026-08-30 banner — where the pass should run
+instead — is **still open**, and this re-derivation makes it more pressing
+rather than less: two of the three ceilings moved because real cost had
+accumulated unobserved between one manual run and the next.

--- a/packages/cli/pragma/src/testing/perf/budgets.test.ts
+++ b/packages/cli/pragma/src/testing/perf/budgets.test.ts
@@ -77,7 +77,9 @@ describe("perf budgets (PROTECTED)", () => {
     // so it flaked red under whole-suite CPU contention on slower-than-reference
     // hardware even though the median sat comfortably under budget (see
     // BUDGETS.md). p95 is kept as a SOFT signal against gross regressions, with
-    // headroom rather than at the bare ceiling. The 100 ms ceiling is unchanged.
+    // headroom rather than at the bare ceiling. That statistic change left the
+    // ceiling of the day (100 ms) untouched; BUDGET_COMPLETE_MS has been
+    // re-derived twice since, most recently to 240 on 2026-09-10.
     expect(result.trimmedMeanMs).toBeLessThanOrEqual(BUDGET_COMPLETE_MS);
     expect(result.p95Ms).toBeLessThanOrEqual(BUDGET_COMPLETE_MS * 1.5);
   });

--- a/packages/cli/pragma/src/testing/perf/budgets.ts
+++ b/packages/cli/pragma/src/testing/perf/budgets.ts
@@ -19,83 +19,159 @@
  * p95, and it lands TIGHTER than 2× its median); its arithmetic is written out
  * in full in BUDGETS.md, as are the measurements and environment for all of
  * them.
+ *
+ * A CEILING IS ALSO RELATIVE TO WHAT THE SURFACE HAS GROWN INTO. Re-derived
+ * again 2026-09-10, because three of the five had drifted red for two causes,
+ * both of them real work rather than noise: the eagerly-imported capability
+ * barrel grew 37.6 → 68.0 ms as the surface reached 22 capability modules and
+ * 42 MCP tools, and the embedded pack grew 8 479 → 49 630 triples. Every
+ * constant below names its cause, because a raised ceiling with no cause is
+ * just a lower standard. The two in-process ceilings were re-measured and
+ * DELIBERATELY LEFT ALONE — they have three orders of magnitude of headroom.
+ *
+ * THIS PASS IS NOT RUN BY CI — owner ruling 2026-08-30, restated 2026-09-10.
+ * Nothing reaches it indirectly either: `test` does not chain it, no Nx target
+ * or workflow names it, and the repo has no git hooks. See
+ * `vitest.perf.config.ts`, `docs/CI.md` and BUDGETS.md.
  */
 
 /**
- * `pragma --help` ceiling (ms). Designed 50; the rule is 2× the measured median.
+ * `pragma --help` ceiling (ms). Designed 50 — **not met, and recorded as such**
+ * for the same reason as {@link BUDGET_COMPLETE_MS}: node's own start is most
+ * of that number before pragma runs a line. The rule is 2× the measured median.
  *
- * Down from the provisional 220, which covered the create surface's eager
- * registration imports on the capabilities barrel. Those are gone — the
- * registered flag spellings are baked into `createSurface.generated.ts` at
- * build time, the mount's adapter loads behind `CliProjection.prepare()`, and
- * the bare-help path no longer loads Commander at all — and the lazy-graph
- * guard in `lazy.test.ts` pins all three so the cost cannot creep back
- * silently.
+ * Up from 130, re-derived 2026-09-10. 130 *was* the rule's own number, back
+ * when this path's work was 35.3 ms net of process start; it is not any more.
+ * The eagerly-imported capability barrel (`capabilities/index`) now costs
+ * **68.0 ms** to import where the recovery A/B measured 37.6 — the surface
+ * grew to 22 capability modules and 42 MCP tools, and each one puts its spec +
+ * formatter modules on this path. `lazy.test.ts` is green, so this is SURFACE
+ * GROWTH and not a lazy-boundary leak: summon-core's projection, its Commander
+ * adapter, `commander`, zod and oxigraph are all still absent from the
+ * fast-path graph. The barrel import is now essentially the whole of the cost
+ * (68.0 of 69.1 ms), which is where any future cut has to come from.
  *
- * MEASURED, paired: the pre-refactor tree and this one were each built and
- * spawned alternately, 40 kept samples per cell, so drift on a shared box hits
- * both arms. Median 74.6 → 64.7 ms; net of each arm's own `--version` control,
- * the work this path does went 49.3 → 35.3 ms (−28%). 2 × 64.7 = 129.5, so
- * 130 is the rule's own number rather than a number the rule tolerates. It is
- * also where this path sat before the regression. BUDGETS.md carries the full
- * table, the reference-box projection, and why this is the floor.
+ * MEASURED (2026-09-10; five load-gated repetitions × 40 kept samples,
+ * interleaved with an in-run `--version` control of 34.8 ms): median
+ * **103.3 ms**, p95 134.0 ms, work **69.1 ms** net of the control.
+ * `2 × 103.3 = 206.6`, so **210**. The reference-box projection cross-checks
+ * LOOSER, not tighter — `45.5 + 69.1 = 114.6` median → 2× = 229 — so 210 is
+ * the tight side of the rule, exactly as 130 was.
+ *
+ * What this can and cannot separate: at 210 against a 103 ms median it catches
+ * a doubling of the path and no longer catches the ~30 ms the barrel just
+ * gained. It is asserted on median AND raw p95 over 12 kept samples, where a
+ * nearest-rank p95 is effectively the maximum — the worst of 12 protocol
+ * replays here was 200.2 ms, so it holds but without much room. BUDGETS.md
+ * carries the table, the environment, and that flake characterisation.
  */
-export const BUDGET_HELP_MS = 130;
+export const BUDGET_HELP_MS = 210;
 
 /**
  * `pragma __complete …` ceiling (ms). Designed 50 — **not met, and recorded as
  * such**: the shipped entry cannot reach it, because node's own start is most
  * of that number before pragma runs a line.
  *
- * Down from the provisional 220 for the same reason as {@link BUDGET_HELP_MS}:
- * the eager create-surface imports both fast paths paid for are deferred, and
- * completion additionally sheds Commander — nothing on the `__complete`
- * closure imports it any more.
+ * Up from 150, re-derived 2026-09-10, and for the same single cause as
+ * {@link BUDGET_HELP_MS} — completion pays for the same grown capability
+ * barrel. It still sheds Commander (nothing on the `__complete` closure
+ * imports it), and it still costs ~12 ms more than `--help` because it walks
+ * the grammar and, in the name-source case, the skills directory.
  *
- * MEASURED in the same paired run: median 79.1 → 69.2 ms for the noun case and
- * 74.2 → 69.3 ms for the name-source case; net of the control, 53.7 → 39.7 ms
- * and 48.9 → 39.8 ms.
+ * MEASURED in the same runs, on the SLOWER of the two cases
+ * (`__complete skill lookup do`): median **115.7 ms**, 10%-trimmed mean
+ * 118.6 ms, p95 145.0 ms, work 81.4 ms net of the control. The noun case
+ * (`__complete config`) is median 116.4 / trimmed mean 118.5 ms — the two are
+ * now within a millisecond of each other. `2 × 115.7 = 231.4`, so **240**;
+ * 2× the trimmed mean gives 237.2, the same 240. The reference-box projection
+ * again cross-checks looser (`45.5 + 81.4 = 126.9` → 2× = 254), so 240 is the
+ * tight side of the rule.
  *
- * 2× the slower median is 138.5, BELOW this 150 — and it stays 150 anyway,
- * because a ceiling is relative to the box as well as the artifact. This box's
- * cold start is 25–30 ms against the reference box's 45.5; projecting the
- * measured work onto the reference box gives a ~85 ms median, whose 2× is
- * ~170. CI has already run this path at a ~100 ms trimmed mean. Cutting to 140
- * on a local median would be deriving a ceiling on hardware the suite does not
- * run on. Completion is typed interactively, so this stays the budget most
- * worth defending — see BUDGETS.md for the arithmetic.
+ * The ceiling is enforced on the trimmed mean, with p95 kept as a SOFT signal
+ * at 1.5× — the statistic change made in the p95-stabilization work, which is
+ * unaffected by this re-derivation. Worst trimmed mean across 8 protocol
+ * replays here: 136.7 ms, so 240 is not a marginal ceiling.
+ *
+ * Completion is typed interactively, so this stays the budget most worth
+ * defending, and it has now lost 90 ms of standard across two re-derivations
+ * with nothing bought back. See BUDGETS.md.
  */
-export const BUDGET_COMPLETE_MS = 150;
+export const BUDGET_COMPLETE_MS = 240;
 
-/** Warm project-config (`pragma.config.ts`) load ceiling (ms). Cache hit is sub-ms. */
+/**
+ * Warm project-config (`pragma.config.ts`) load ceiling (ms). Cache hit is
+ * sub-ms.
+ *
+ * RE-MEASURED 2026-09-10 and deliberately UNCHANGED: 40 warm
+ * `evaluateProjectConfig` calls after priming the content-hash cache give a
+ * median of **0.011 ms** and a p95 of 0.034 ms — roughly 900× of headroom. The
+ * 2×-median rule would put this at 0.02 ms, which would assert nothing but
+ * scheduler jitter. 10 ms is a gross-regression guard (a cache that stopped
+ * hitting, an import that stopped being cached) and that is all it is for.
+ */
 export const BUDGET_PROJECT_CONFIG_MS = 10;
 
 /**
  * Warm store-backed verb ceiling (ms) — a store boot from the cached n-quads
  * dump plus a query, through the shipped entry.
  *
- * Re-derived when the embed became the distribution's real 8 479-triple graph
- * instead of a 23-triple sample. Netted against a `--version` control from the
- * SAME binary in the SAME run (this box's process start swings 60–287 ms with
- * page-cache state alone), the real pack's store work is 2.83× the sample's —
- * the median of five repetitions across two protocols. Projected onto the
- * reference box, whose own toy store work is 147 − 45.5 = 101.5 ms: 45.5 +
- * 101.5 × 2.83 ≈ 333 ms median, and 333 × (176/147) ≈ 398 ms p95 using the
- * reference box's own dispersion for this command. `ceil(398 × 1.25 / 50) × 50`
- * = 500 — which is 1.6× the projected median, i.e. tighter than the
- * 2×-of-median rule the ceilings above use. Every input, every step, and the
- * raw measurements are in BUDGETS.md; the designed `<300ms` target stays in the
- * surface covenant, exactly as the 50 ms `help` target survived its 130 ms
- * ceiling.
+ * Up from 500, re-derived 2026-09-10. The cause is the pack, not the code: the
+ * embed went from the 8 479-triple graph the 500 was derived against to
+ * **49 630 triples / 4 167 entities** (5.85× the triples). Boot still loads
+ * the n-quads dump rather than parsing TTL and still rebuilds the schema from
+ * the extraction artifact rather than running a live 7-pass compile, which is
+ * why the cost grew 1.75× and not 5.85×.
+ *
+ * The arithmetic, on the same route that produced 500, with one new input —
+ * the within-box growth multiplier. This box's netted real store work was
+ * +285.4 ms against the 8 479-triple pack (five repetitions, recorded in
+ * BUDGETS.md) and is +499.9 ms against this one (four load-gated repetitions
+ * × 40 kept samples, 2026-09-10), so:
+ *
+ * ```
+ * within-box growth multiplier  = 499.9 / 285.4                = 1.752
+ * reference store work (old pack) = 101.5 × 2.83               = 287.2 ms
+ * reference store work (new pack) = 287.2 × 1.752              = 503.2 ms
+ * projected reference median      = 45.5 + 503.2               = 548.7 ms
+ * reference p95/median, this command = 176 / 147               = 1.197
+ * projected p95                   = 548.7 × 1.197              = 656.9 ms
+ * ceiling = ceil(656.9 × 1.25 / 50) × 50                       = 850 ms
+ * ```
+ *
+ * The local-only route agrees to within 6%: this box's own measured p95 is
+ * 608.9 ms and `ceil(608.9 × 1.25 / 50) × 50` = 800. The reference-box number
+ * is taken, because that is the route the standing ceiling came from.
+ *
+ * 850 is still **1.55×** the projected median, i.e. tighter than the
+ * 2×-of-median rule the fast paths use. But it is now **2.83×** the designed
+ * `<300ms` target, where 500 was 1.67× — and that gap is the honest headline:
+ * the designed target was set against a 23-triple sample and then held against
+ * 8 479, and a 49 630-triple pack whose store work alone is ~500 ms cannot
+ * reach 300 ms at all. `warmStoreVerb: "<300ms"` stays in the surface covenant
+ * as the aspiration, and it is now an aspiration that needs a different boot
+ * strategy rather than a tuning pass. Every input and every step is in
+ * BUDGETS.md.
+ *
+ * What this can and cannot separate: asserted on median AND p95 over 9 kept
+ * samples, where a nearest-rank p95 IS the maximum — kept deliberately,
+ * because this excess is real work rather than contention noise, and hiding
+ * real cost behind a robust statistic would make the budget lie.
  */
-export const BUDGET_WARM_STORE_MS = 500;
+export const BUDGET_WARM_STORE_MS = 850;
 
 /**
  * Warm in-process MCP tool-call ceiling (ms) — PR7 graduates this from seeded to
  * ENFORCED. Measured over a warm, storeless tool (`capabilities`): pure envelope
  * + dispatch, no store boot, no network, so it isolates the per-call overhead of
- * the grown 38-tool catalog. Measured p95 is ~0.4 ms here (huge headroom), so
- * 100 ms guards against a gross regression without flaking. `info` is
- * deliberately NOT used — its network update-check makes it ~55 ms (see BUDGETS.md).
+ * the grown tool catalog. `info` is deliberately NOT used — its network
+ * update-check makes it ~55 ms (see BUDGETS.md).
+ *
+ * RE-MEASURED 2026-09-10 and deliberately UNCHANGED. The catalog has grown
+ * 38 → 42 tools and the warm call grew with it — p95 **0.732 ms**, trimmed
+ * mean 0.530 ms over 40 calls, against ~0.4 ms p95 at 38 tools — but that is
+ * still ~137× of headroom under 100 ms. This is a gross-regression guard (a
+ * per-call store boot, a network read, a catalog rebuilt per call), and 100 ms
+ * is what lets it be one without flaking. Enforced on the trimmed mean with
+ * p95 as a second check (both ≤ 100).
  */
 export const BUDGET_MCP_P95_WARM_MS = 100;

--- a/packages/cli/pragma/vitest.perf.config.ts
+++ b/packages/cli/pragma/vitest.perf.config.ts
@@ -17,11 +17,28 @@ import { defineConfig } from "vitest/config";
  * coverage instrumentation — the only way spawn-latency budgets measure the
  * binary rather than the test runner. The ceilings themselves are unchanged.
  *
- * NOT RUN BY CI, by owner ruling 2026-08-30. `test` no longer chains this pass,
- * which is how `nx affected -t test` used to reach it, so nothing here gates a
- * pull request. It stays enforced for anyone who runs `bun run test:perf`, and
- * the ceilings are untouched. The reasoning, the measurements that forced the
- * ruling, and the two questions it deliberately left open are in BUDGETS.md.
+ * NOT RUN BY CI, by owner ruling 2026-08-30, RESTATED 2026-09-10. `test` no
+ * longer chains this pass, which is how `nx affected -t test` used to reach it,
+ * so nothing here gates a pull request. It stays enforced for anyone who runs
+ * `bun run test:perf`. The reasoning, the measurements that forced the ruling,
+ * and the two questions it deliberately left open are in BUDGETS.md.
+ *
+ * **DO NOT PUT THIS PASS BACK ON A CI TARGET.** Verified 2026-09-10 that
+ * nothing reaches it, directly or indirectly: no workflow in `.github/` names
+ * `test:perf` or `vitest.perf.config`; the package's `test` script is
+ * `check:packs:test && test:vitest` and `vitest.config.ts` excludes
+ * `src/testing/perf/**`; `nx.json` declares no perf target and its `test`
+ * default only `dependsOn: ["^build"]`; the repo has no lefthook/husky/git
+ * hooks. If you are adding a job, step, target or script chain that would
+ * reach this file, you are reversing an owner ruling — say so in the PR body
+ * and expect it to be challenged (`AGENTS.md`, "CI workflows are global").
+ * `docs/CI.md` says the same thing where a CI author will find it.
+ *
+ * It also needs a QUIET BOX, which CI is not and a shared dev box often is
+ * not. Spawn latency here inflates 2–3× under other processes' load, and the
+ * cheap tell is the `--version` control: ~35 ms median on the machine these
+ * ceilings were derived on, 60–110 ms when something else is busy. A red run
+ * whose control is above ~40 ms is measuring the box. See BUDGETS.md.
  */
 export default defineConfig({
   test: {
@@ -36,6 +53,27 @@ export default defineConfig({
       "./src/testing/tempRoot.globalSetup.ts",
     ],
     environment: "node",
+    // A budget case must fail on its BUDGET, never on the clock. Each case
+    // spawns the entry many times in one test body, so its floor is
+    // `runs × per-spawn ceiling` — vitest's 5 s default is below that for two
+    // of them and has been for a while, silently: the callbacks are
+    // synchronous (`spawnSync`), so vitest cannot interrupt them and reports
+    // whichever failure it notices first. While the ceilings were red the
+    // AssertionError won that race and the timeout never surfaced; raising the
+    // ceilings on 2026-09-10 made the timeout the reported failure with the
+    // budget green underneath, which is a strictly less informative red.
+    //
+    //   __store-probe   12 runs × 850 ms  = 10 200 ms   ← the binding case
+    //   __complete      30 runs × 240 ms  =  7 200 ms   (× 2 cases)
+    //   --help          15 runs × 210 ms  =  3 150 ms
+    //
+    // 2 × the binding case ≈ 20 000 ms, so every spawn in a run could land at
+    // twice its ceiling and the ASSERTION would still be what reports. That is
+    // the point of the margin — it is not headroom for slowness, it is
+    // headroom for the failure message to be the useful one. Whole-file
+    // runtime on the reference machine is ~30 s, so this does not lengthen a
+    // healthy run at all; it only changes what a sick one says.
+    testTimeout: 20_000,
     // No cross-file parallelism: the perf tests run one at a time (never
     // alongside each other or coverage workers), so a wall-clock spawn
     // measurement reflects the binary, not CPU contention or scheduler noise.


### PR DESCRIPTION
## Done

`bun run test:perf` was failing on `main` before this change, and for two reasons that hid each other.

- **Two ceilings were genuinely exceeded.** Re-derived by the rule the file already states — 2× the measured median for the fast paths, a projected p95 for the store — with the arithmetic written out at each constant and the environment recorded:

  | Constant | Designed | Median | Old | New |
  |---|---|---|---|---|
  | `BUDGET_HELP_MS` | 50, unmet | 103.3 ms | 130 | **210** |
  | `BUDGET_COMPLETE_MS` | 50, unmet | 115.7 ms | 150 | **240** |
  | `BUDGET_WARM_STORE_MS` | 300, unmet | 536.0 ms | 500 | **850** |
  | `BUDGET_PROJECT_CONFIG_MS` | 10 | 0.011 ms | 10 | left — 900× headroom |
  | `BUDGET_MCP_P95_WARM_MS` | 100 | 0.506 ms | 100 | left — 137× headroom |

  The designed 50 ms and 300 ms targets stay recorded as designed-and-unmet rather than quietly moved. Two constants are left alone deliberately: their medians are sub-millisecond, so the 2× rule would assert only jitter.
- **A per-test timeout was underneath.** Raising the ceilings did not make the pass green — it exposed vitest's 5 s default, which the failing assertions had been winning the race against. The store case's own duration on `main` was ~6.9 s per attempt. `testTimeout` is now derived rather than picked: 2 × (12 runs × 850 ms) ≈ 20000 ms.
- **The measurements refuse a contended box.** This machine drifts 1.5–2×, and netting against a control does not rescue a uniformly shifted run, so the harness gates on the in-run control median and **discards** rather than averages: 5 of 9 fast-path repetitions accepted, 4 of 7 store repetitions.
- **The pass stays manual, and that is now durable.** It is referenced by no workflow, no Nx target, no git hook and no script chain — verified mechanically. Its config header, `docs/CI.md`'s "what CI deliberately does not run", and an `AGENTS.md` bullet all now say so, so re-adding it is a deliberate act rather than an accident. No test asserts a workflow file's contents, because this repo does that nowhere.
- A dated section in `BUDGETS.md` records the new measurements beside the old; no past measurement was edited.
- Cause noted at the constants, for whoever reads them next: the eagerly-imported capability barrel grew 37.6 → 68.0 ms, and 68.0 of `--help`'s 69.1 ms of work is that barrel. `lazy.test.ts` is green, so this is surface growth rather than a lazy-boundary leak. Meanwhile the embedded pack grew 8479 → 49630 triples (5.85×) for a 1.75× store cost.

## QA

```bash
bun install && bun run --cwd packages/cli/pragma build
bun run --cwd packages/cli/pragma test:perf     # 22/22, ~20 s; run it twice
bun run check                                   # green, 66 projects
```

To see the state this replaces, run `test:perf` on `main`: 21 of 22, with all three warm-store retries red.

Two pre-existing conditions on this machine, neither caused here and both verified against `main` in the same worktree: the vanilla-adapter package's browser tests cannot launch Chromium, and the default test pass flakes 1–5 files under heavy load with 5 s timeouts in store-boot and spawn tests unrelated to this change.

### PR readiness check

- [x] PR title follows Conventional Commits
- [x] The code follows the appropriate code standards
- [x] All packages define the required scripts in `package.json`
- [x] No new package
- [x] No visual testing required — `Chromatic: skip` applied

## Screenshots

Not applicable — measurement constants and documentation.
