### PR TITLE
fix(Tabs): read the medium stroke token by its defined name

### DIFF
--- a/packages/react/ds-global/src/lib/component/Tabs/styles.css
+++ b/packages/react/ds-global/src/lib/component/Tabs/styles.css
@@ -14,7 +14,7 @@
    * and scrolls horizontally on overflow.
    */
   :root {
-    --tabs-border-width: var(--dimension-strokeThickness-medium, 1px);
+    --tabs-border-width: var(--dimension-stroke-thickness-medium, 1px);
   }
 
   .ds.tabs {


### PR DESCRIPTION
## Done

- `Tabs/styles.css` read `--dimension-strokeThickness-medium`, a name no `@canonical/design-tokens` release defines; the token is `--dimension-stroke-thickness-medium`. The declaration therefore always fell back to its `1px`. Tabs rendered correctly only because the token is also 1px, and any change to the token would never have reached Tabs. This reads the token by its defined name; the fallback stays.

## QA

- `bun run check` green at the root and in `ds-global`.
- No visual change: the token resolves to the same 1px the fallback supplied.

### PR readiness check

- [x] PR title follows the Conventional Commits format.
- [x] The code follows the appropriate code standards.
- [x] No visual diff — Chromatic: skip label applied.

Chromatic: skip

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0143BZrKuhi4j3YdemH5SbqD
