### PR TITLE
fix(cli): read prefix declarations, not prose

### DIFF
--- a/packages/cli/pragma/src/capabilities/sources/sources.test.ts
+++ b/packages/cli/pragma/src/capabilities/sources/sources.test.ts
@@ -33,6 +33,7 @@ import {
 } from "../../kernel/runtime/paths.js";
 import {
   detectPrefixClashes,
+  harvestPrefixes,
   resolvePackageJson,
 } from "../../kernel/runtime/refs/resolve.js";
 import { createLazyStore } from "../../kernel/runtime/store.js";
@@ -331,6 +332,60 @@ describe("sources update — conflicting @prefix detection (A5)", () => {
       "https://a.test/#",
       "https://b.test/#",
     ]);
+  });
+
+  it("ignores a prefix declaration inside a string literal", () => {
+    // The code-standards pack ships guidance ABOUT Turtle: its `cs:code`
+    // examples contain declarations, including a deliberately discouraged one.
+    // Scanning raw text reported a clash on every single update for a file that
+    // asserts no triple in that namespace at all.
+    const clashes = detectPrefixClashes([
+      { content: "@prefix ex: <https://a.test/#> .\nex:One a ex:T ." },
+      {
+        content: [
+          "@prefix cs: <https://cs.test/#> .",
+          'cs:rule cs:code """',
+          "# Bad: do not do this",
+          "@prefix ex: <https://wrong.test/data/> .",
+          '""" .',
+        ].join("\n"),
+      },
+    ]);
+
+    expect(clashes).toEqual([]);
+  });
+
+  it("does not let a literal rebind a real prefix in the harvested map", () => {
+    // Worse than a spurious warning: last-wins meant a code sample could
+    // overwrite a real namespace, so every entity of the losing package
+    // compacted to the wrong prefix.
+    const prefixes = harvestPrefixes([
+      { content: "@prefix ex: <https://a.test/#> .\nex:One a ex:T ." },
+      {
+        content: [
+          'cs:rule cs:code """',
+          "@prefix ex: <https://wrong.test/data/> .",
+          '""" .',
+        ].join("\n"),
+      },
+    ]);
+
+    expect(prefixes.ex).toBe("https://a.test/#");
+  });
+
+  it("still reads declarations that follow a literal in the same file", () => {
+    // Masking must not swallow the rest of the file.
+    const prefixes = harvestPrefixes([
+      {
+        content: [
+          'cs:rule cs:code """@prefix ignored: <https://no.test/> .""" .',
+          "@prefix real: <https://yes.test/#> .",
+        ].join("\n"),
+      },
+    ]);
+
+    expect(prefixes.real).toBe("https://yes.test/#");
+    expect(prefixes.ignored).toBeUndefined();
   });
 
   it("does NOT flag harmless same-label/same-IRI redeclarations", () => {

--- a/packages/cli/pragma/src/kernel/runtime/refs/resolve.ts
+++ b/packages/cli/pragma/src/kernel/runtime/refs/resolve.ts
@@ -204,8 +204,7 @@ const PREFIX_DECL = /(?:^|\s)@?prefix\s+([^\s:]+):\s*<([^>]*)>/gi;
  * @returns The same text with literal contents replaced by blanks.
  */
 function blankLiterals(content: string): string {
-  const keepNewlines = (text: string): string =>
-    text.replace(/[^\n]/g, " ");
+  const keepNewlines = (text: string): string => text.replace(/[^\n]/g, " ");
   return content
     .replace(/"""[\s\S]*?"""/g, keepNewlines)
     .replace(/'''[\s\S]*?'''/g, keepNewlines)

--- a/packages/cli/pragma/src/kernel/runtime/refs/resolve.ts
+++ b/packages/cli/pragma/src/kernel/runtime/refs/resolve.ts
@@ -185,6 +185,35 @@ function readStorySources(
 const PREFIX_DECL = /(?:^|\s)@?prefix\s+([^\s:]+):\s*<([^>]*)>/gi;
 
 /**
+ * Blank out every Turtle string literal, so a prefix scan reads declarations
+ * and not prose.
+ *
+ * A long literal can legally contain the text `@prefix ex: <iri> .`, and one
+ * genuinely does: the code-standards pack ships guidance ABOUT Turtle, whose
+ * `cs:code` examples include a deliberately discouraged declaration. Scanning
+ * raw text saw it as real, which made `sources update` report a `ds:` clash on
+ * every run for a file that asserts no `ds:` triple at all — and worse, let a
+ * code sample win the last-wins race in {@link harvestPrefixes} and rebind a
+ * real prefix.
+ *
+ * Long forms are blanked before short ones, so the `"""` delimiters are not
+ * mistaken for an empty `""` followed by prose. Newlines inside a literal are
+ * preserved so a later `^`-anchored match still sees the true line structure.
+ *
+ * @param content - Turtle source text.
+ * @returns The same text with literal contents replaced by blanks.
+ */
+function blankLiterals(content: string): string {
+  const keepNewlines = (text: string): string =>
+    text.replace(/[^\n]/g, " ");
+  return content
+    .replace(/"""[\s\S]*?"""/g, keepNewlines)
+    .replace(/'''[\s\S]*?'''/g, keepNewlines)
+    .replace(/"(?:[^"\\\n]|\\.)*"/g, keepNewlines)
+    .replace(/'(?:[^'\\\n]|\\.)*'/g, keepNewlines);
+}
+
+/**
  * Harvest a package's own `@prefix` / `PREFIX` declarations from its TTL text.
  *
  * ke's `createStore` does NOT fold parsed-Turtle prefixes into `store.prefixes`
@@ -201,7 +230,7 @@ export function harvestPrefixes(
 ): Record<string, string> {
   const prefixes: Record<string, string> = {};
   for (const { content } of sources) {
-    for (const match of content.matchAll(PREFIX_DECL)) {
+    for (const match of blankLiterals(content).matchAll(PREFIX_DECL)) {
       const [, label, iri] = match;
       if (label !== undefined && iri !== undefined) prefixes[label] = iri;
     }
@@ -234,7 +263,7 @@ export function detectPrefixClashes(
 ): PrefixClash[] {
   const byLabel = new Map<string, string[]>();
   for (const { content } of sources) {
-    for (const match of content.matchAll(PREFIX_DECL)) {
+    for (const match of blankLiterals(content).matchAll(PREFIX_DECL)) {
       const [, label, iri] = match;
       if (label === undefined || iri === undefined) continue;
       const iris = byLabel.get(label) ?? [];


### PR DESCRIPTION
## Done

`pragma sources update` reports a prefix clash on **every single run**:

```
Prefix "ds:" is declared with conflicting IRIs across packs
(https://ds.canonical.com/ vs https://ds.canonical.com/data/);
last wins, so some entities may compact to the wrong prefix.
```

No pack declares that second IRI. It appears exactly once, on line 163 of the code-standards pack's guidance *about Turtle*, inside a `cs:code """..."""` block — as a deliberately discouraged example. That file parses to 79 quads and asserts nothing whatsoever in the `ds:` namespace.

Both prefix scanners matched a regex against raw source text, so neither could tell a declaration from a code sample.

- For the **clash detector** that is a permanent false alarm, and it lands on the one pack whose job is to hold Turtle examples. Worse than the noise itself: it makes a genuine clash indistinguishable from the standing one.
- For **`harvestPrefixes`** it is not cosmetic. The map it builds is last-wins, so a code sample inside a literal could rebind a real prefix and compact an entire package's entities to the wrong name.

Both now scan text whose string literals have been blanked. Long forms are blanked before short ones, so `"""` delimiters are never read as an empty `""` followed by prose, and newlines inside literals are preserved so line structure survives for anchored matching.

Measured over the **486 sources a real update reads**, across all five configured packs:

| | before | after |
| --- | --- | --- |
| Prefix clashes reported | 1 | 0 |
| `ds:` harvests to | correct, by luck of ordering | correct, by construction |

`dt:`, `anatomy:` and `cs:` each harvest to their correct IRI, and 486 is exactly the source count a real `sources update` reports, so this is the live corpus rather than a fixture.

Three tests. Two fail without the change; the third guards the masking from swallowing a declaration that legitimately follows a literal in the same file, which is the obvious way to overshoot this fix.

## QA

```
cd packages/cli/pragma
bun install
bun run check
bun run test:vitest
```

The regression, which is red on `main`:

```
npx vitest run src/capabilities/sources/sources.test.ts
```

To watch the false alarm disappear against real packs, run `pragma sources update` before and after. On `main` the `ds:` clash line is printed; with this change it is not, and nothing else about the build changes.

Full package suite: **1,829 passed**, 13 skipped, 5 todo. One behavioural journey timed out at its 5-second limit while another full suite ran concurrently on the same machine; it passes in isolation at 20 passed, and it performs a real resolve and build, so it is timing-sensitive rather than affected by this change.

### PR readiness check

- [x] PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format.
- [x] The code follows the appropriate code standards.
- [x] Tests cover the new behaviour, and two of the three fail without the fix.
- [x] If this PR does not require visual testing, add the `Chromatic: skip` label to skip Chromatic.

## Screenshots

Not applicable — no visual surface. `Chromatic: skip` applies.