### PR TITLE
fix(dataviews): keep DataTable's resize controls in view and within bounds

### DIFF
--- a/packages/react/dataviews/README.md
+++ b/packages/react/dataviews/README.md
@@ -95,10 +95,16 @@ const columns = [
 ```
 
 Fixed columns keep their width, flexible ones compress within their bounds,
-and the table scrolls horizontally once the remainder no longer fits. Resizing
-works from the pointer and from the keyboard — arrow keys step the edge,
-Escape abandons a drag — and a user-fixed width is never quietly shrunk to
-suit the viewport. Pass a shared `presentation` to give two tables on one
+and the table scrolls horizontally once the remainder no longer fits. The last
+column takes whatever width the others leave, past its own maximum when there
+is room to spare. Resizing works from the pointer
+and from the keyboard — arrow keys step the edge, Escape abandons a drag — and
+a user-fixed width is never quietly shrunk to suit the viewport. Every resize
+is held to the column's declared `minPx` and `maxPx`, however often it has
+been resized, and a column widened past the container scrolls the table to
+keep its edge in view. The last column has no resize control, even when it is
+declared `resizable`: its trailing edge is the table's own edge, with nothing
+beyond it to resize against. Pass a shared `presentation` to give two tables on one
 provider the same user arrangement.
 
 ### Empty, loading and failed

--- a/packages/react/dataviews/src/lib/DataTable/DataTable.test.tsx
+++ b/packages/react/dataviews/src/lib/DataTable/DataTable.test.tsx
@@ -771,6 +771,7 @@ describe("DataTable", () => {
             resizable: true,
             sizing: { kind: "flex", weight: 1, minPx: 50 },
           },
+          { id: "status", header: "Status" },
         ]}
         label="Machines"
       />,
@@ -783,7 +784,7 @@ describe("DataTable", () => {
       screen
         .getByRole("table", { name: "Machines" })
         .style.getPropertyValue("--data-table-columns"),
-    ).toBe("66px");
+    ).toBe("66px 96px");
   });
 
   it("shows a live drag in the published tracks without committing it", () => {
@@ -796,11 +797,15 @@ describe("DataTable", () => {
       const provider = makeProvider();
       const presentation = createPresentation([
         { id: "name", sizing: { kind: "flex", weight: 1, minPx: 50 } },
+        { id: "status", sizing: { kind: "flex", weight: 1, minPx: 96 } },
       ]);
       render(
         <DataTable
           provider={provider}
-          columns={[{ id: "name", header: "Name", resizable: true }]}
+          columns={[
+            { id: "name", header: "Name", resizable: true },
+            { id: "status", header: "Status" },
+          ]}
           label="Machines"
           presentation={presentation}
         />,
@@ -819,7 +824,7 @@ describe("DataTable", () => {
           .style.getPropertyValue("--data-table-columns"),
         // The column reserved 50px against a zero-width container, and the
         // pointer travelled 180 from there.
-      ).toBe("230px");
+      ).toBe("230px 96px");
       // The authority is untouched until the pointer is released.
       expect(presentation.state.overrides.name).toBeUndefined();
     } finally {
@@ -923,6 +928,247 @@ describe("DataTable", () => {
         .style.getPropertyValue("--data-table-columns"),
     ).toBe("66px 96px");
     expect(renders).toEqual([]);
+  });
+
+  it("offers no resize control on the table's trailing edge", () => {
+    const provider = makeProvider();
+    const { rerender } = render(
+      <DataTable
+        provider={provider}
+        columns={[
+          { id: "name", header: "Name", resizable: true },
+          { id: "status", header: "Status", resizable: true },
+        ]}
+        label="Machines"
+      />,
+    );
+    load(provider, [machine("m-1", "alpha")]);
+    // Status declares itself resizable, but no column follows it to trade
+    // width with, so neither a pointer nor a key can reach its edge.
+    expect(screen.getAllByRole("separator")).toHaveLength(1);
+    expect(screen.getByRole("separator")).toHaveAccessibleName("Name");
+    rerender(
+      <DataTable
+        provider={provider}
+        columns={[{ id: "name", header: "Name", resizable: true }]}
+        label="Machines"
+      />,
+    );
+    expect(screen.queryByRole("separator")).toBeNull();
+  });
+
+  it("gives the last column whatever width the others leave, live", () => {
+    const notified: ResizeObserverCallback[] = [];
+    class StubObserver {
+      constructor(callback: ResizeObserverCallback) {
+        notified.push(callback);
+      }
+      observe(): void {}
+      unobserve(): void {}
+      disconnect(): void {}
+    }
+    const frames: FrameRequestCallback[] = [];
+    vi.stubGlobal("ResizeObserver", StubObserver);
+    vi.stubGlobal("requestAnimationFrame", (callback: FrameRequestCallback) => {
+      frames.push(callback);
+      return frames.length;
+    });
+    try {
+      const provider = makeProvider();
+      render(
+        <DataTable
+          provider={provider}
+          columns={[
+            {
+              id: "name",
+              header: "Name",
+              resizable: true,
+              sizing: { kind: "fixed", px: 100 },
+            },
+            {
+              id: "status",
+              header: "Status",
+              sizing: { kind: "fixed", px: 100 },
+            },
+          ]}
+          label="Machines"
+        />,
+      );
+      const measure = (width: number): void => {
+        act(() => {
+          for (const observer of notified) {
+            observer(
+              [{ contentRect: { width } }] as unknown as ResizeObserverEntry[],
+              {} as ResizeObserver,
+            );
+          }
+        });
+      };
+      const tracks = (): string =>
+        screen
+          .getByRole("table", { name: "Machines" })
+          .style.getPropertyValue("--data-table-columns");
+      measure(400);
+      expect(tracks()).toBe("100px 300px");
+      fireEvent.pointerDown(screen.getByRole("separator"), { clientX: 0 });
+      fireEvent.pointerMove(window, { clientX: 50 });
+      act(() => {
+        for (const frame of frames.splice(0)) {
+          frame(0);
+        }
+      });
+      // The last column follows the edge being dragged, before any commit.
+      expect(tracks()).toBe("150px 250px");
+      fireEvent.pointerUp(window);
+      expect(tracks()).toBe("150px 250px");
+      // Once the columns no longer fit, nothing is stretched: the table
+      // scrolls instead.
+      measure(200);
+      expect(tracks()).toBe("150px 100px");
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+
+  it("holds every resize to the column's declared bounds", () => {
+    const provider = makeProvider();
+    render(
+      <DataTable
+        provider={provider}
+        columns={[
+          {
+            id: "name",
+            header: "Name",
+            resizable: true,
+            sizing: { kind: "flex", weight: 1, minPx: 50, maxPx: 80 },
+          },
+          { id: "status", header: "Status" },
+        ]}
+        label="Machines"
+      />,
+    );
+    load(provider, [machine("m-1", "alpha")]);
+    const handle = screen.getByRole("separator");
+    const tracks = (): string =>
+      screen
+        .getByRole("table", { name: "Machines" })
+        .style.getPropertyValue("--data-table-columns");
+    expect(handle).toHaveAttribute("aria-valuemax", "80");
+    fireEvent.keyDown(handle, { key: "ArrowRight" });
+    expect(tracks()).toBe("66px 96px");
+    // The first step committed a fixed override; the declared maximum still
+    // stops the second step, and the third moves nothing.
+    fireEvent.keyDown(handle, { key: "ArrowRight" });
+    expect(tracks()).toBe("80px 96px");
+    fireEvent.keyDown(handle, { key: "ArrowRight" });
+    expect(tracks()).toBe("80px 96px");
+  });
+
+  it("scrolls the table to keep a moved edge in view", () => {
+    const frames: FrameRequestCallback[] = [];
+    vi.stubGlobal("requestAnimationFrame", (callback: FrameRequestCallback) => {
+      frames.push(callback);
+      return frames.length;
+    });
+    try {
+      const provider = makeProvider();
+      render(
+        <DataTable
+          provider={provider}
+          columns={[
+            {
+              id: "name",
+              header: "Name",
+              resizable: true,
+              sizing: { kind: "fixed", px: 100 },
+            },
+            { id: "status", header: "Status" },
+          ]}
+          label="Machines"
+        />,
+      );
+      load(provider, [machine("m-1", "alpha")]);
+      const table = screen.getByRole("table", { name: "Machines" });
+      const handle = screen.getByRole("separator");
+      const box = (left: number, width: number) =>
+        ({
+          left,
+          right: left + width,
+          top: 0,
+          bottom: 40,
+          width,
+          height: 40,
+          x: left,
+          y: 0,
+        }) as DOMRect;
+      // The table's visible width runs from 10 to 130.
+      let scrolled = 0;
+      Object.defineProperty(table, "clientWidth", { value: 120 });
+      Object.defineProperty(table, "scrollLeft", {
+        get: () => scrolled,
+        set: (next: number) => {
+          scrolled = next;
+        },
+      });
+      table.getBoundingClientRect = () => box(10, 122);
+      const place = (left: number): void => {
+        handle.getBoundingClientRect = () => box(left, 16);
+      };
+      place(150);
+      fireEvent.keyDown(handle, { key: "ArrowRight" });
+      expect(scrolled).toBe(36);
+      place(-6);
+      fireEvent.keyDown(handle, { key: "ArrowLeft" });
+      expect(scrolled).toBe(20);
+      place(40);
+      fireEvent.keyDown(handle, { key: "ArrowRight" });
+      expect(scrolled).toBe(20);
+      // A drag reveals the edge on every render it causes: the capture, each
+      // published frame, and the commit.
+      place(200);
+      fireEvent.pointerDown(handle, { clientX: 0 });
+      expect(scrolled).toBe(106);
+      place(230);
+      fireEvent.pointerMove(window, { clientX: 40 });
+      act(() => {
+        for (const frame of frames.splice(0)) {
+          frame(0);
+        }
+      });
+      expect(scrolled).toBe(222);
+      fireEvent.pointerUp(window);
+      expect(scrolled).toBe(338);
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+
+  it("holds a resize to the presentation's declared bounds, not the column's", () => {
+    const provider = makeProvider();
+    const presentation = createPresentation([
+      { id: "name", sizing: { kind: "flex", weight: 1, minPx: 50 } },
+      { id: "status", sizing: { kind: "flex", weight: 1, minPx: 96 } },
+    ]);
+    render(
+      <DataTable
+        provider={provider}
+        columns={[
+          { id: "name", header: "Name", resizable: true },
+          { id: "status", header: "Status" },
+        ]}
+        label="Machines"
+        presentation={presentation}
+      />,
+    );
+    load(provider, [machine("m-1", "alpha")]);
+    const handle = screen.getByRole("separator");
+    // The column declares nothing, so on its own it would default to a 96px
+    // minimum; the shared presentation, which the widths are solved from,
+    // declares 50. The column sits at 50, and a step left moves nothing.
+    expect(handle).toHaveAttribute("aria-valuemin", "50");
+    expect(handle).toHaveAttribute("aria-valuenow", "50");
+    fireEvent.keyDown(handle, { key: "ArrowLeft" });
+    expect(presentation.state.overrides.name).toBeUndefined();
   });
 
   it("marks the table busy while a request is in flight", () => {

--- a/packages/react/dataviews/src/lib/DataTable/DataTable.tsx
+++ b/packages/react/dataviews/src/lib/DataTable/DataTable.tsx
@@ -11,7 +11,12 @@ import {
 import type { CSSProperties, ReactElement, Ref } from "react";
 import { useCallback, useEffect, useId, useMemo, useRef } from "react";
 import useDataViewsValue from "../DataViews/hooks/useDataViewsValue.js";
-import { sameColumnModel, sameColumns, sizingOf } from "./columnKeys.js";
+import {
+  boundsOf,
+  sameColumnModel,
+  sameColumns,
+  sizingOf,
+} from "./columnKeys.js";
 import { HeaderCell, SelectAllCell, TableBody } from "./common/index.js";
 import defaultStatusText from "./defaultStatusText.js";
 import {
@@ -63,9 +68,9 @@ const selectionSizing: ColumnSizing = { kind: "fixed", px: 40 };
  *
  * Its rows are divs consuming one shared track list, published once on the
  * container as a custom property. Fixed columns keep their declared width,
- * flexible ones compress within their bounds, and the container scrolls when
- * the remainder no longer fits — there is no automatic hiding, pairing or
- * renderer switching.
+ * flexible ones compress within their bounds, the last column takes whatever
+ * width the others leave, and the container scrolls when the remainder no
+ * longer fits — there is no automatic hiding, pairing or renderer switching.
  */
 export default function DataTable<
   TFields extends readonly SchemaFieldDefinition[],
@@ -207,6 +212,10 @@ export default function DataTable<
               )}
               setSort={provider.setSort}
               interaction={interaction}
+              resizable={
+                column.resizable === true && position < rendered.length - 1
+              }
+              bounds={boundsOf(activePresentation.state.declared[column.id])}
               width={geometry.widths[position + selectionOffset]}
               labelId={`${baseId}-${column.id}`}
             />

--- a/packages/react/dataviews/src/lib/DataTable/columnKeys.test.ts
+++ b/packages/react/dataviews/src/lib/DataTable/columnKeys.test.ts
@@ -7,6 +7,7 @@
 import type { ColumnToSize } from "@canonical/dataviews-core";
 import { describe, expect, it } from "vitest";
 import {
+  boundsOf,
   sameColumnModel,
   sameColumns,
   sameTracks,
@@ -23,6 +24,33 @@ describe("sizingOf", () => {
     expect(sizingOf({ ...name, sizing: { kind: "fixed", px: 40 } })).toEqual({
       kind: "fixed",
       px: 40,
+    });
+  });
+});
+
+describe("boundsOf", () => {
+  it("holds a flexible column to its declared minimum and maximum", () => {
+    expect(
+      boundsOf({ kind: "flex", weight: 1, minPx: 120, maxPx: 240 }),
+    ).toEqual({ min: 120, max: 240 });
+  });
+
+  it("leaves a flexible column without a maximum unbounded above", () => {
+    expect(boundsOf({ kind: "flex", weight: 1, minPx: 120 })).toEqual({
+      min: 120,
+      max: Number.POSITIVE_INFINITY,
+    });
+    // The default sizing is flexible too, with its 96px minimum.
+    expect(boundsOf(sizingOf(name))).toEqual({
+      min: 96,
+      max: Number.POSITIVE_INFINITY,
+    });
+  });
+
+  it("lets a fixed column go anywhere from zero", () => {
+    expect(boundsOf({ kind: "fixed", px: 80 })).toEqual({
+      min: 0,
+      max: Number.POSITIVE_INFINITY,
     });
   });
 });

--- a/packages/react/dataviews/src/lib/DataTable/columnKeys.ts
+++ b/packages/react/dataviews/src/lib/DataTable/columnKeys.ts
@@ -25,6 +25,19 @@ export const sizingOf = (column: DataTableColumn): ColumnSizing =>
   column.sizing ?? defaultSizing;
 
 /**
+ * The widths a resize may leave a column at, from its declared sizing —
+ * never from a user override, so a column resized once is held to the same
+ * bounds the next time. A flexible column is held to its minimum and
+ * maximum; a fixed one may go anywhere from zero.
+ */
+export const boundsOf = (
+  sizing: ColumnSizing,
+): { readonly min: number; readonly max: number } =>
+  sizing.kind === "flex"
+    ? { min: sizing.minPx, max: sizing.maxPx ?? Number.POSITIVE_INFINITY }
+    : { min: 0, max: Number.POSITIVE_INFINITY };
+
+/**
  * The column facts everything below the rendered tree is derived from: the
  * presentation's declared tracks, the observed field names, the solved
  * geometry and one row scope per identity.

--- a/packages/react/dataviews/src/lib/DataTable/common/HeaderCell/HeaderCell.tsx
+++ b/packages/react/dataviews/src/lib/DataTable/common/HeaderCell/HeaderCell.tsx
@@ -34,6 +34,8 @@ export default function HeaderCell({
   sort,
   setSort,
   interaction,
+  resizable,
+  bounds,
   width,
   labelId,
 }: HeaderCellProps): ReactElement {
@@ -69,11 +71,12 @@ export default function HeaderCell({
           {column.header}
         </span>
       )}
-      {column.resizable === true ? (
+      {resizable ? (
         <ResizeHandle
           interaction={interaction}
           columnId={column.id}
           width={width}
+          {...bounds}
           labelledBy={labelId}
         />
       ) : null}

--- a/packages/react/dataviews/src/lib/DataTable/common/HeaderCell/types.ts
+++ b/packages/react/dataviews/src/lib/DataTable/common/HeaderCell/types.ts
@@ -17,6 +17,17 @@ export type HeaderCellProps = {
   /** Replace the applied ordering. */
   readonly setSort: (sort: readonly SortTerm[]) => void;
   readonly interaction: GridInteraction;
+  /**
+   * Offer a resize control at this heading's trailing edge. False for the
+   * last column whatever it declares: its trailing edge is the table's own
+   * edge.
+   */
+  readonly resizable: boolean;
+  /**
+   * The widths a resize may leave this column at, from the declared sizing
+   * the table's widths are solved from.
+   */
+  readonly bounds: { readonly min: number; readonly max: number };
   /** The column's resolved width, for a resize capture. */
   readonly width: number;
   /** The id this header's label carries, for the resize control's name. */

--- a/packages/react/dataviews/src/lib/DataTable/common/ResizeHandle/ResizeHandle.test.tsx
+++ b/packages/react/dataviews/src/lib/DataTable/common/ResizeHandle/ResizeHandle.test.tsx
@@ -33,7 +33,11 @@ const releasePointer = (type: "pointerUp" | "pointerCancel"): void => {
   fireEvent[type](window);
 };
 
-const mount = (): {
+const mount = ({
+  width = 100,
+}: {
+  readonly width?: number;
+} = {}): {
   presentation: Presentation;
   interaction: GridInteraction;
   handle: HTMLElement;
@@ -48,7 +52,9 @@ const mount = (): {
       <ResizeHandle
         interaction={interaction}
         columnId="name"
-        width={100}
+        width={width}
+        min={50}
+        max={300}
         labelledBy="name-label"
       />
     </>,
@@ -204,6 +210,8 @@ describe("ResizeHandle", () => {
         interaction={interaction}
         columnId="name"
         width={100}
+        min={50}
+        max={Number.POSITIVE_INFINITY}
         labelledBy="name-label"
       />,
     );
@@ -212,5 +220,72 @@ describe("ResizeHandle", () => {
     movePointer(400);
     flushFrames();
     expect(presentation.state.overrides.name).toBeUndefined();
+  });
+
+  it("reports the bounds it holds the column to", () => {
+    const { handle } = mount();
+    expect(handle).toHaveAttribute("aria-valuemin", "50");
+    expect(handle).toHaveAttribute("aria-valuemax", "300");
+    // Without a maximum ARIA would imply 100, so the width is also spoken.
+    expect(handle).toHaveAttribute("aria-valuetext", "100 pixels");
+  });
+
+  it("holds a later resize to the declared bounds, not to the override", () => {
+    const { presentation, handle } = mount();
+    fireEvent.keyDown(handle, { key: "ArrowRight" });
+    // The first resize committed a fixed override, which carries no bounds
+    // of its own: the declared ones must still hold every later drag.
+    expect(presentation.effective("name")).toEqual({ kind: "fixed", px: 116 });
+    fireEvent.pointerDown(handle, { clientX: 100 });
+    movePointer(1000);
+    flushFrames();
+    releasePointer("pointerUp");
+    expect(presentation.effective("name")).toEqual({ kind: "fixed", px: 300 });
+    fireEvent.pointerDown(handle, { clientX: 100 });
+    movePointer(-1000);
+    flushFrames();
+    releasePointer("pointerUp");
+    expect(presentation.effective("name")).toEqual({ kind: "fixed", px: 50 });
+  });
+
+  it("steps no further than a bound, after an override too", () => {
+    const { presentation, handle } = mount({ width: 290 });
+    fireEvent.keyDown(handle, { key: "ArrowLeft" });
+    // The column now carries a fixed override with no bounds of its own.
+    expect(presentation.effective("name")).toEqual({ kind: "fixed", px: 274 });
+    fireEvent.keyDown(handle, { key: "ArrowRight" });
+    expect(presentation.effective("name")).toEqual({ kind: "fixed", px: 300 });
+  });
+
+  it("commits nothing at a bound, and still owns the key", () => {
+    const { presentation, handle } = mount({ width: 300 });
+    expect(fireEvent.keyDown(handle, { key: "ArrowRight" })).toBe(false);
+    expect(presentation.state.overrides.name).toBeUndefined();
+  });
+
+  it("reveals nothing outside a table, through a drag and after it", () => {
+    const presentation = createPresentation([
+      { id: "name", sizing: { kind: "flex", weight: 1, minPx: 50 } },
+    ]);
+    const interaction = createGridInteraction(presentation);
+    const view = (width: number) => (
+      <ResizeHandle
+        interaction={interaction}
+        columnId="name"
+        width={width}
+        min={50}
+        max={Number.POSITIVE_INFINITY}
+        labelledBy="name-label"
+      />
+    );
+    const { rerender } = render(view(100));
+    const handle = screen.getByRole("separator");
+    expect(handle).not.toHaveAttribute("aria-valuemax");
+    fireEvent.pointerDown(handle, { clientX: 100 });
+    rerender(view(120));
+    releasePointer("pointerUp");
+    rerender(view(140));
+    rerender(view(160));
+    expect(interaction.state.status).toBe("idle");
   });
 });

--- a/packages/react/dataviews/src/lib/DataTable/common/ResizeHandle/ResizeHandle.tsx
+++ b/packages/react/dataviews/src/lib/DataTable/common/ResizeHandle/ResizeHandle.tsx
@@ -1,5 +1,5 @@
 import type { ReactElement } from "react";
-import { useEffect, useRef } from "react";
+import { useEffect, useLayoutEffect, useRef } from "react";
 import type { ResizeHandleProps } from "./types.js";
 
 const componentCssClassName = "ds data-table-resize";
@@ -8,23 +8,64 @@ const componentCssClassName = "ds data-table-resize";
 const KEYBOARD_STEP = 16;
 
 /**
+ * Scroll the table the control sits in — that one container, nothing above
+ * it — just far enough that the control is inside the table's visible width.
+ * A column widened past the container pushes its own edge out of view, and
+ * the reader must never lose the edge they are moving.
+ */
+const reveal = (control: HTMLElement): void => {
+  const table = control.closest<HTMLElement>('[role="table"]');
+  if (table === null) {
+    return;
+  }
+  const edge = control.getBoundingClientRect();
+  const start = table.getBoundingClientRect().left + table.clientLeft;
+  const end = start + table.clientWidth;
+  if (edge.right > end) {
+    table.scrollLeft += edge.right - end;
+  } else if (edge.left < start) {
+    table.scrollLeft -= start - edge.left;
+  }
+};
+
+/**
  * One column's resize control.
  *
  * Pointer dragging and the keyboard drive the same commands and the same
  * clamping, so resizing never requires a drag: arrow keys step the edge and
- * Escape abandons a drag in progress, as a cancelled pointer does. Pointer
- * previews are coalesced to one geometry publication per animation frame.
+ * Escape abandons a drag in progress, as a cancelled pointer does. Every path
+ * is held to the column's declared bounds, however often the column has been
+ * resized before, and every move keeps the control in view. Pointer previews
+ * are coalesced to one geometry publication per animation frame.
  */
 export default function ResizeHandle({
   interaction,
   columnId,
   width,
+  min,
+  max,
   labelledBy,
 }: ResizeHandleProps): ReactElement {
   // The live drag's teardown, held across the re-renders its own previews
   // cause: listeners registered by one render must be removed by the same
   // closure, not by whatever identity the next render produces.
   const teardown = useRef<(() => void) | null>(null);
+  // The control whose edge just moved, until the render showing the move has
+  // brought it into view. A drag in progress keeps it set.
+  const moved = useRef<HTMLElement | null>(null);
+
+  const clamp = (next: number): number => Math.min(max, Math.max(min, next));
+
+  useLayoutEffect(() => {
+    const control = moved.current;
+    if (control === null) {
+      return;
+    }
+    if (teardown.current === null) {
+      moved.current = null;
+    }
+    reveal(control);
+  });
 
   const abandonDrag = (): void => {
     teardown.current?.();
@@ -39,11 +80,12 @@ export default function ResizeHandle({
     [],
   );
 
-  const beginDrag = (clientX: number): void => {
+  const beginDrag = (control: HTMLElement, clientX: number): void => {
     // A second pointer can go down before the first comes up — trivially,
     // on touch. The drag already running is abandoned here rather than
     // stranding its three window listeners and a pending frame.
     abandonDrag();
+    moved.current = control;
     interaction.startResize(columnId, clientX, width);
     let frame = 0;
     let latestX = clientX;
@@ -55,7 +97,9 @@ export default function ResizeHandle({
       }
       frame = requestAnimationFrame(() => {
         frame = 0;
-        interaction.preview(latestX);
+        // The pointer is translated to the position that lands on the
+        // clamped width, so the edge stops at a bound and stays there.
+        interaction.preview(clientX + clamp(width + latestX - clientX) - width);
       });
     };
     const onPointerUp = (): void => {
@@ -82,9 +126,16 @@ export default function ResizeHandle({
     teardown.current = stop;
   };
 
-  const step = (delta: number): void => {
+  const step = (control: HTMLElement, delta: number): void => {
+    const next = clamp(width + delta);
+    if (Math.abs(next - width) < 0.5) {
+      // At a bound, to within the solver's rounding: nothing moves, and
+      // nothing is committed.
+      return;
+    }
+    moved.current = control;
     interaction.startResize(columnId, 0, width);
-    interaction.preview(delta);
+    interaction.preview(next - width);
     interaction.commit();
   };
 
@@ -99,14 +150,17 @@ export default function ResizeHandle({
       aria-orientation="vertical"
       aria-labelledby={labelledBy}
       aria-valuenow={Math.round(width)}
+      aria-valuemin={min}
+      aria-valuemax={Number.isFinite(max) ? max : undefined}
+      aria-valuetext={`${Math.round(width)} pixels`}
       onPointerDown={(event) => {
-        beginDrag(event.clientX);
+        beginDrag(event.currentTarget, event.clientX);
       }}
       onKeyDown={(event) => {
         if (event.key === "ArrowLeft") {
-          step(-KEYBOARD_STEP);
+          step(event.currentTarget, -KEYBOARD_STEP);
         } else if (event.key === "ArrowRight") {
-          step(KEYBOARD_STEP);
+          step(event.currentTarget, KEYBOARD_STEP);
         } else if (event.key === "Escape") {
           abandonDrag();
           interaction.cancel();

--- a/packages/react/dataviews/src/lib/DataTable/common/ResizeHandle/types.ts
+++ b/packages/react/dataviews/src/lib/DataTable/common/ResizeHandle/types.ts
@@ -12,6 +12,10 @@ export type ResizeHandleProps = {
   readonly columnId: string;
   /** The column's currently resolved width, captured when a resize begins. */
   readonly width: number;
+  /** The narrowest width a resize may leave, from the column's declared sizing. */
+  readonly min: number;
+  /** The widest width a resize may leave; infinite when the column has no maximum. */
+  readonly max: number;
   /** The id of the element naming this column. */
   readonly labelledBy: string;
 };

--- a/packages/react/dataviews/src/lib/DataTable/hooks/useTableGeometry.ts
+++ b/packages/react/dataviews/src/lib/DataTable/hooks/useTableGeometry.ts
@@ -2,6 +2,7 @@ import type {
   ColumnToSize,
   GridInteraction,
   Presentation,
+  ResolvedColumn,
 } from "@canonical/dataviews-core";
 import { columnTemplate, resolveColumns } from "@canonical/dataviews-core";
 import { useCallback, useMemo, useState } from "react";
@@ -9,6 +10,28 @@ import useDataViewsState from "../../DataViews/hooks/useDataViewsState.js";
 import { sameTracks } from "../columnKeys.js";
 import type { TableGeometry } from "./types.js";
 import useStableValue from "./useStableValue.js";
+
+/**
+ * Give the last column whatever width the others leave, even past its own
+ * maximum: its trailing edge is the table's own edge, so it is never resized
+ * on its own and grows and shrinks as the columns before it are. Nothing
+ * changes once the columns no longer fit, or before the container is
+ * measured.
+ */
+const fillLast = (
+  columns: readonly ResolvedColumn[],
+  available: number | null,
+): readonly ResolvedColumn[] => {
+  const last = columns.at(-1);
+  if (available === null || last === undefined) {
+    return columns;
+  }
+  const spare =
+    available - columns.reduce((total, column) => total + column.width, 0);
+  return spare > 0
+    ? [...columns.slice(0, -1), { id: last.id, width: last.width + spare }]
+    : columns;
+};
 
 /**
  * Resolve one mounted table's geometry.
@@ -66,10 +89,8 @@ export default function useTableGeometry(
     () => resolveColumns(tracks, width ?? 0),
     [tracks, width],
   );
-  const widths = useMemo(
-    () => resolved.map((column) => column.width),
-    [resolved],
-  );
+  const filled = useMemo(() => fillLast(resolved, width), [resolved, width]);
+  const widths = useMemo(() => filled.map((column) => column.width), [filled]);
 
   const preview =
     interactionState.status === "resizing"
@@ -81,9 +102,25 @@ export default function useTableGeometry(
   // solved vector is handed over rather than re-solved: before the
   // container is measured the tracks are declarative, and after it they are
   // the widths just resolved.
+  // A live preview is substituted before the last column is filled, so the
+  // last column follows the edge being dragged rather than waiting for the
+  // commit.
+  const live =
+    width === null
+      ? null
+      : preview === undefined
+        ? filled
+        : fillLast(
+            resolved.map((column) =>
+              column.id === preview.id
+                ? { id: column.id, width: preview.width }
+                : column,
+            ),
+            width,
+          );
   return {
     attach,
-    template: columnTemplate(tracks, width === null ? null : resolved, preview),
+    template: columnTemplate(tracks, live),
     widths,
   };
 }

--- a/packages/react/dataviews/src/lib/DataTable/types.ts
+++ b/packages/react/dataviews/src/lib/DataTable/types.ts
@@ -39,7 +39,17 @@ export type DataTableColumn = {
   readonly sizing?: ColumnSizing;
   /** Offer sorting on this column's field. */
   readonly sortable?: boolean;
-  /** Offer resizing of this column. */
+  /**
+   * Offer resizing of this column from its trailing edge, by pointer or
+   * keyboard, held to the declared bounds of its sizing every time.
+   *
+   * The last column never offers it, whatever this says: its trailing edge is
+   * the table's own edge, with nothing beyond it to resize against. It takes
+   * whatever width the columns before it leave — past its own `maxPx` or
+   * fixed width when there is room to spare — so it grows and shrinks as they
+   * are resized, and keeps its resolved width once they no longer fit and the
+   * table scrolls.
+   */
   readonly resizable?: boolean;
 };
 


### PR DESCRIPTION
## Done

Fixes the edge cases of column resizing.

- **No handle on the last column.** A resize handle resizes the column on its left, so the one on the table's trailing edge resized nothing sensible, and dragging it slid the handle under the table's own clipped overflow. The last column now has no handle, even when marked `resizable`; its right edge is the table's edge. It takes the remaining width, live during a drag. The column type's TSDoc documents this. The design agrees: its final header cell is an action cell with no resize affordance.
- **A handle is never hidden.** When a handle's edge moves, whether mid-drag, after a commit or on an arrow-key step, the handle scrolls its own table, and nothing above it, just enough to stay visible. Resizing a column past the container widens the table into its horizontal scroll.
- **Every resize respects the declared bounds.** Before, only the first resize did: later ones were clamped against the saved width, so a column could grow past its `maxPx` or shrink below its `minPx`. The bounds are read from the table's shared presentation, so two tables sharing one arrangement agree. The handle reports its bounds and announces its width in pixels, and at a bound an arrow key does nothing.
- Header cells no longer clip their content, which is where the handle lives.

Tests pin each of these: no separator after the last column, the last column's fill, bounds held after a saved width, bounds taken from a shared presentation, and the table scrolling for keyboard and pointer.

Merge order: #1220 must land first — this is based on it.

## QA

- `bun run check` green at the root.
- `@canonical/dataviews-react`: 113 tests, 100% branch/function/line/statement coverage; `build` emits.

### PR readiness check

- [x] PR title follows the Conventional Commits format.
- [x] The code follows the appropriate code standards.
- [x] Visual surface — Chromatic runs.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0143BZrKuhi4j3YdemH5SbqD
