### PR TITLE
feat(dataviews): connected Filters and Pagination parts

### DIFF
--- a/packages/react/dataviews/README.md
+++ b/packages/react/dataviews/README.md
@@ -1,6 +1,6 @@
 # @canonical/dataviews-react
 
-React bindings for Canonical collection views, built on `@canonical/dataviews-core`: the `DataViews` root, the provider context, the four scoped observation hooks, and the `DataTable` renderer.
+React bindings for Canonical collection views, built on `@canonical/dataviews-core`: the `DataViews` root with its connected `Filters` and `Pagination` parts, the provider context, the four scoped observation hooks, and the `DataTable` renderer.
 
 > **Stability: pre-1.0 / experimental.** The API is still consolidating and breaking changes may land between minor versions. Every breaking change ships with a conventional-commit subject and a CHANGELOG entry — those are the migration record. Pin a minor version if you need stability today.
 
@@ -19,9 +19,76 @@ Under active development; the public surface grows change by change. The current
 - **`useDataViewsValue(handle)`** — observe one channel; re-render only when it publishes.
 - **`useDataViewsField(handle)`** — a field's input buffer, applied semantic value and feedback, with `edit`/`set`/`clear` routed through the provider.
 - **`useDataViewsCell(provider)`** — the current cell's scope (row id, column id, read-only row/fields/selected channels), installed by the table renderer; throws outside a rendered cell or on a witness mismatch.
+- **`DataViews.Filters`** — the connected query-editing part. Which fields it offers and which operators each accepts come from the provider — its schema, and the capabilities its source declares — so it never offers a restriction the source would refuse, takes no query props, and has no draft query to keep in step with the applied one. Throws when the provider was created without the source's capabilities.
+- **`DataViews.Pagination`** — the connected window navigation. Its destinations are the ones the collection can actually reach: a source that publishes a filtered total gets numbered pages and a last one, a source that publishes no count gets a Next offered only while the page is full, and a pending replacement claims no total at all.
 - **`DataTable`** — the row renderer: div rows over ARIA table roles, one shared column track list, sorting, selection and resizing. It takes its provider explicitly, so it behaves the same standalone and inside a `DataViews` root.
 
-The remaining connected parts (Filters, Views, Summary, Actions, Pagination) land in later changes.
+The remaining connected parts (Views, Summary, Actions) land in later changes.
+
+## Composition recipes
+
+### The connected parts
+
+```tsx
+const machinesProvider = createDataViewsProvider({
+  schema,
+  // What the source can execute: Filters offers nothing beyond it, and the
+  // binding refuses a provider told anything else.
+  capabilities: source.capabilities,
+});
+createSourceBinding({ host: machinesProvider, adapter: source });
+
+<DataViews provider={machinesProvider}>
+  <DataViews.Filters labels={{ status: "Status", cpu: "Cores" }} />
+
+  <DataTable provider={machinesProvider} columns={columns} label="Machines" />
+
+  <div className="collection-footer">
+    <DataViews.Pagination label="Machines pagination" />
+  </div>
+</DataViews>
+```
+
+Both parts read the enclosing root: they take presentation choices — a name,
+visible field labels, the page sizes to offer — and never a second copy of
+the query, the window or the selection the provider already owns. Ordinary
+wrappers and custom children sit between them; moving pagination means moving
+an element, not asking for a slot.
+
+### Keeping the query in the URL
+
+```tsx
+function MachinesUrlQuery({ platform }: { platform: PlatformLocation }) {
+  // Building the binding subscribes to nothing; observing does, so it
+  // happens in an effect and a discarded render leaves nothing behind.
+  const binding = useMemo(
+    () =>
+      createLocationBinding({
+        host: machinesProvider,
+        location: createPlatformLocation(platform),
+      }),
+    [platform],
+  );
+  useEffect(() => binding.observe(), [binding]);
+  const issues = useDataViewsValue(binding.issues);
+  return issues.length === 0 ? null : (
+    <ul className="query-issues">
+      {issues.map((issue, index) => (
+        // One parameter can be refused for several reasons.
+        <li key={`${index}:${issue.parameter}`}>{issue.reason}</li>
+      ))}
+    </ul>
+  );
+}
+```
+
+`createSourceBinding`, `createLocationBinding` and `createPlatformLocation`
+come from `@canonical/dataviews-core`. Every edit the filters make writes the
+canonical query to the location, and back, forward or a pasted URL is adopted
+by the provider — one authority, no mirroring effect. A link carrying a clause
+the grammar, the schema or the source refuses is not adopted: it stays in the
+URL and its reasons are published on `binding.issues`, for the host to show
+beside the controls. The parts read the provider either way.
 
 ## Styles
 

--- a/packages/react/dataviews/package.json
+++ b/packages/react/dataviews/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@canonical/dataviews-react",
-  "description": "React bindings for @canonical/dataviews-core: the DataViews root, provider context, the four scoped observation hooks, and the DataTable renderer",
+  "description": "React bindings for @canonical/dataviews-core: the DataViews root with its connected Filters and Pagination parts, provider context, the four scoped observation hooks, and the DataTable renderer",
   "version": "0.37.0",
   "type": "module",
   "module": "dist/esm/index.js",

--- a/packages/react/dataviews/src/index.ts
+++ b/packages/react/dataviews/src/index.ts
@@ -1,7 +1,8 @@
 /**
  * @canonical/dataviews-react — React bindings for collection views: the
- * DataViews root, provider context, the four scoped observation hooks and
- * the DataTable renderer, built on @canonical/dataviews-core.
+ * DataViews root with its connected Filters and Pagination parts, provider
+ * context, the four scoped observation hooks and the DataTable renderer,
+ * built on @canonical/dataviews-core.
  *
  * @packageDocumentation
  */

--- a/packages/react/dataviews/src/index.types.test.ts
+++ b/packages/react/dataviews/src/index.types.test.ts
@@ -1,0 +1,68 @@
+/**
+ * Compile-time contract tests for the package's public type surface: every
+ * exported type is reachable through the barrel, and the connected parts'
+ * props take their root's native props except the ones each part derives.
+ */
+
+import type {
+  RowRecord,
+  SchemaFieldDefinition,
+} from "@canonical/dataviews-core";
+import { describe, expectTypeOf, it } from "vitest";
+import type {
+  CellScopeValue,
+  DataTableCellProps,
+  DataTableColumn,
+  DataTableProps,
+  DataTableStatus,
+  DataViewsProps,
+  FiltersProps,
+  PaginationProps,
+  UseDataViewsCellResult,
+  UseDataViewsFieldResult,
+  UseDataViewsResult,
+} from "./index.js";
+
+type Fields = readonly SchemaFieldDefinition[];
+
+/** Every type the package root re-exports, as one enumerable tuple. */
+type EveryPublicType = [
+  CellScopeValue,
+  DataTableCellProps,
+  DataTableColumn,
+  DataTableProps<Fields, RowRecord>,
+  DataTableStatus,
+  DataViewsProps<Fields>,
+  FiltersProps,
+  PaginationProps,
+  UseDataViewsCellResult,
+  UseDataViewsFieldResult<unknown>,
+  UseDataViewsResult<Fields>,
+];
+
+describe("public surface types", () => {
+  it("re-exports the full type surface from the barrel", () => {
+    expectTypeOf<EveryPublicType>().not.toBeAny();
+    expectTypeOf<EveryPublicType["length"]>().toEqualTypeOf<11>();
+  });
+});
+
+describe("connected part props", () => {
+  it("keeps what Filters derives out of its props", () => {
+    // Its controls come from the provider, its name from its legend and the
+    // fieldset's group role is its own.
+    expectTypeOf<FiltersProps>().not.toHaveProperty("children");
+    expectTypeOf<FiltersProps>().not.toHaveProperty("role");
+    expectTypeOf<FiltersProps>().not.toHaveProperty("aria-label");
+    expectTypeOf<FiltersProps>().not.toHaveProperty("aria-labelledby");
+    expectTypeOf<FiltersProps>().toHaveProperty("disabled");
+  });
+
+  it("keeps what Pagination derives out of its props", () => {
+    expectTypeOf<PaginationProps>().not.toHaveProperty("children");
+    expectTypeOf<PaginationProps>().not.toHaveProperty("role");
+    expectTypeOf<PaginationProps>().not.toHaveProperty("aria-label");
+    expectTypeOf<PaginationProps>().not.toHaveProperty("aria-labelledby");
+    expectTypeOf<PaginationProps>().toHaveProperty("id");
+  });
+});

--- a/packages/react/dataviews/src/lib/DataViews/Provider.tsx
+++ b/packages/react/dataviews/src/lib/DataViews/Provider.tsx
@@ -1,10 +1,12 @@
 import type {
   DataViewsProvider,
+  RowRecord,
   SchemaFieldDefinition,
 } from "@canonical/dataviews-core";
 import { isIdentity } from "@canonical/dataviews-core";
 import type { ReactElement } from "react";
 import DataViewsContext from "./Context.js";
+import { Filters, Pagination } from "./common/index.js";
 import type { DataViewsProps } from "./types.js";
 
 /**
@@ -14,22 +16,28 @@ import type { DataViewsProps } from "./types.js";
  * Pure composition — no single root element (AGENTS.md rule 6): the root is
  * a context mount, not a DOM node.
  */
-export default function DataViews<
+function DataViews<
   TFields extends readonly SchemaFieldDefinition[],
->({ provider, children }: DataViewsProps<TFields>): ReactElement {
+  TRow extends object = RowRecord,
+>({ provider, children }: DataViewsProps<TFields, TRow>): ReactElement {
   if (!isIdentity(provider?.identity)) {
     throw new Error(
       "DataViews requires a provider created by createDataViewsProvider",
     );
   }
-  // The context stores the widest provider shape; the hooks' identity
-  // witness narrows it back to the caller's schema at runtime.
-  const value = provider as unknown as DataViewsProvider<
-    readonly SchemaFieldDefinition[]
-  >;
+  // The context stores the widest provider shape, schema and record type
+  // alike; the hooks' identity witness narrows it back at runtime.
+  const value = provider as DataViewsProvider<readonly SchemaFieldDefinition[]>;
   return (
     <DataViewsContext.Provider value={value}>
       {children}
     </DataViewsContext.Provider>
   );
 }
+
+/** The connected query-editing part of the composition. */
+DataViews.Filters = Filters;
+/** The connected window-navigation part of the composition. */
+DataViews.Pagination = Pagination;
+
+export default DataViews;

--- a/packages/react/dataviews/src/lib/DataViews/common/Filters/Filters.test.tsx
+++ b/packages/react/dataviews/src/lib/DataViews/common/Filters/Filters.test.tsx
@@ -1,0 +1,377 @@
+/**
+ * The connected filters part: controls derived from the schema and the
+ * source's declared capabilities, edits that land on the applied query, and
+ * invalid input that keeps the restriction already in force. Each case is
+ * mutation-tested against that contract.
+ */
+import type {
+  DataViewsProvider,
+  SourceCapabilities,
+} from "@canonical/dataviews-core";
+import {
+  createDataViewsProvider,
+  createSchema,
+} from "@canonical/dataviews-core";
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { StrictMode } from "react";
+import { describe, expect, it } from "vitest";
+import DataViews from "../../Provider.js";
+import Filters from "./Filters.js";
+
+const schema = createSchema([
+  {
+    field: "status",
+    kind: "choices",
+    options: ["failed", "cancelled", "ready"],
+  },
+  { field: "cpu", kind: "number", min: 0, max: 64 },
+  { field: "updated", kind: "date" },
+  { field: "owner", kind: "flag" },
+]);
+
+type Fields = typeof schema.fields;
+
+/** A source declaring every operator the schema allows. */
+const everything: SourceCapabilities = {
+  filter: {
+    status: ["eq"],
+    cpu: ["gte", "lte"],
+    updated: ["gte", "lte"],
+    owner: ["isSet"],
+  },
+  search: [],
+  sort: [],
+  sortTerms: 0,
+  group: [],
+  count: "filtered",
+};
+
+const makeProvider = (
+  capabilities: SourceCapabilities = everything,
+): DataViewsProvider<Fields> =>
+  createDataViewsProvider<Fields>({ schema, capabilities });
+
+const mount = (
+  provider: DataViewsProvider<Fields>,
+  props: Parameters<typeof Filters>[0] = {},
+) =>
+  render(
+    <DataViews provider={provider}>
+      <Filters {...props} />
+    </DataViews>,
+  );
+
+describe("DataViews.Filters", () => {
+  it("is reachable as the composition's Filters part", () => {
+    expect(DataViews.Filters).toBe(Filters);
+  });
+
+  it("fails clearly outside a DataViews root", () => {
+    expect(() => render(<Filters />)).toThrow(
+      "DataViews.Filters must be used inside a DataViews root",
+    );
+  });
+
+  it("fails clearly when the provider was not told what its source executes", () => {
+    const provider = createDataViewsProvider<Fields>({ schema });
+    expect(() => mount(provider)).toThrow(
+      "DataViews.Filters requires a provider given the source's capabilities; pass them to createDataViewsProvider",
+    );
+  });
+
+  it("offers one control per field and legal operator, and no others", () => {
+    mount(makeProvider());
+    // Three options and the flag; two bounds on each of two fields.
+    expect(screen.getAllByRole("checkbox")).toHaveLength(4);
+    expect(screen.getAllByRole("textbox")).toHaveLength(2);
+    expect(screen.queryByLabelText("owner from")).toBeNull();
+    expect(screen.getByRole("group", { name: "Filters" })).toBeInTheDocument();
+    expect(screen.getByRole("group", { name: "status" })).toBeInTheDocument();
+    expect(
+      screen.getByRole("checkbox", { name: "failed" }),
+    ).toBeInTheDocument();
+    // A number is typed as text with a numeric keyboard, so what was typed
+    // is what is validated.
+    expect(screen.getByLabelText("cpu from")).toHaveAttribute("type", "text");
+    expect(screen.getByLabelText("cpu from")).toHaveAttribute(
+      "inputmode",
+      "decimal",
+    );
+    expect(screen.getByLabelText("cpu to")).toHaveAttribute("type", "text");
+    expect(screen.getByLabelText("cpu to")).not.toHaveAttribute("readonly");
+    expect(screen.getByRole("checkbox", { name: "failed" })).toBeEnabled();
+    expect(screen.getByLabelText("updated from")).toHaveAttribute(
+      "type",
+      "date",
+    );
+    expect(screen.getByRole("checkbox", { name: "owner" })).toBeInTheDocument();
+    // A choices field has one operator, so it gets no bounds.
+    expect(screen.queryByLabelText("status from")).toBeNull();
+  });
+
+  it("names the group and its fields from the supplied labels", () => {
+    mount(makeProvider(), {
+      label: "Narrow the machines",
+      labels: { status: "Status", cpu: "Cores" },
+    });
+    expect(
+      screen.getByRole("group", { name: "Narrow the machines" }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("group", { name: "Status" })).toBeInTheDocument();
+    expect(screen.getByLabelText("Cores from")).toBeInTheDocument();
+    // A field with no entry keeps its own name.
+    expect(screen.getByLabelText("updated to")).toBeInTheDocument();
+  });
+
+  it("edits the applied query through the equality set", () => {
+    const provider = makeProvider();
+    mount(provider);
+    fireEvent.click(screen.getByRole("checkbox", { name: "failed" }));
+    expect(provider.result.get().slice.filter).toEqual([
+      { field: "status", operator: "eq", operands: ["failed"] },
+    ]);
+
+    fireEvent.click(screen.getByRole("checkbox", { name: "ready" }));
+    expect(provider.result.get().slice.filter).toEqual([
+      { field: "status", operator: "eq", operands: ["failed", "ready"] },
+    ]);
+    expect(screen.getByRole("checkbox", { name: "failed" })).toBeChecked();
+    expect(
+      screen.getByRole("checkbox", { name: "cancelled" }),
+    ).not.toBeChecked();
+
+    fireEvent.click(screen.getByRole("checkbox", { name: "failed" }));
+    expect(provider.result.get().slice.filter).toEqual([
+      { field: "status", operator: "eq", operands: ["ready"] },
+    ]);
+  });
+
+  it("removes the predicate when the last option is cleared", () => {
+    const provider = makeProvider();
+    mount(provider);
+    fireEvent.click(screen.getByRole("checkbox", { name: "failed" }));
+    fireEvent.click(screen.getByRole("checkbox", { name: "failed" }));
+    // Not an empty restriction matching nothing: no restriction.
+    expect(provider.result.get().slice.filter).toEqual([]);
+  });
+
+  it("applies and removes a presence predicate", () => {
+    const provider = makeProvider();
+    mount(provider);
+    const owner = screen.getByRole("checkbox", { name: "owner" });
+    fireEvent.click(owner);
+    expect(provider.result.get().slice.filter).toEqual([
+      { field: "owner", operator: "isSet", operands: [] },
+    ]);
+    expect(owner).toBeChecked();
+    fireEvent.click(owner);
+    expect(provider.result.get().slice.filter).toEqual([]);
+    expect(owner).not.toBeChecked();
+  });
+
+  it("applies a bound and offers to clear it only once it applies", () => {
+    const provider = makeProvider();
+    mount(provider);
+    expect(screen.queryByRole("button", { name: "Clear cpu from" })).toBeNull();
+    fireEvent.change(screen.getByLabelText("cpu from"), {
+      target: { value: "4" },
+    });
+    expect(provider.result.get().slice.filter).toEqual([
+      { field: "cpu", operator: "gte", operands: [4] },
+    ]);
+    fireEvent.click(screen.getByRole("button", { name: "Clear cpu from" }));
+    expect(provider.result.get().slice.filter).toEqual([]);
+    expect(screen.queryByRole("button", { name: "Clear cpu from" })).toBeNull();
+  });
+
+  it("keeps the applied bound on an invalid edit and says so", () => {
+    const provider = makeProvider();
+    mount(provider);
+    const input = screen.getByLabelText("cpu from");
+    fireEvent.change(input, { target: { value: "4" } });
+    fireEvent.change(input, { target: { value: "99" } });
+
+    expect(provider.result.get().slice.filter).toEqual([
+      { field: "cpu", operator: "gte", operands: [4] },
+    ]);
+    expect(input).toHaveAttribute("aria-invalid", "true");
+    const feedback = screen.getByText(
+      "99 is above the maximum of 64. The previous restriction still applies.",
+    );
+    expect(input).toHaveAttribute("aria-describedby", feedback.id);
+    expect(feedback).toHaveAttribute("role", "status");
+  });
+
+  it("does not claim a restriction still applies when none does", () => {
+    const provider = makeProvider();
+    mount(provider);
+    fireEvent.change(screen.getByLabelText("cpu from"), {
+      target: { value: "99" },
+    });
+    expect(
+      screen.getByText("99 is above the maximum of 64."),
+    ).toBeInTheDocument();
+    expect(provider.result.get().slice.filter).toEqual([]);
+  });
+
+  it("shows the text typed, and reads text that is not a number as invalid", () => {
+    const provider = makeProvider();
+    mount(provider);
+    const input = screen.getByLabelText("cpu from");
+    fireEvent.change(input, { target: { value: "-" } });
+    expect(input).toHaveValue("-");
+    expect(input).toHaveAttribute("aria-invalid", "true");
+    expect(screen.getByText("Not a number.")).toBeInTheDocument();
+  });
+
+  it("points at no description while there is nothing to say", () => {
+    const provider = makeProvider();
+    mount(provider);
+    const input = screen.getByLabelText("cpu from");
+    expect(input).not.toHaveAttribute("aria-describedby");
+    // The status region is mounted before it has anything to say, so the
+    // first message is announced.
+    expect(document.getElementById(`${input.id}-feedback`)).toHaveAttribute(
+      "role",
+      "status",
+    );
+    fireEvent.change(input, { target: { value: "4" } });
+    expect(input).not.toHaveAttribute("aria-describedby");
+    fireEvent.click(screen.getByRole("button", { name: "Clear cpu from" }));
+    expect(input).not.toHaveAttribute("aria-describedby");
+  });
+
+  it("reads an emptied bound as incomplete, never as a removal", () => {
+    const provider = makeProvider();
+    mount(provider);
+    const input = screen.getByLabelText("cpu from");
+    fireEvent.change(input, { target: { value: "4" } });
+    fireEvent.change(input, { target: { value: "" } });
+    expect(provider.result.get().slice.filter).toEqual([
+      { field: "cpu", operator: "gte", operands: [4] },
+    ]);
+    expect(input).toHaveAttribute("aria-invalid", "false");
+    // The restriction still applies, and the message says so.
+    const feedback = screen.getByText(
+      "Enter a value to change this restriction. The previous restriction still applies.",
+    );
+    expect(input).toHaveAttribute("aria-describedby", feedback.id);
+  });
+
+  it("asks for a value when an empty bound applies nothing", () => {
+    mount(makeProvider());
+    const input = screen.getByLabelText("cpu from");
+    fireEvent.change(input, { target: { value: "lots" } });
+    fireEvent.change(input, { target: { value: "" } });
+    expect(
+      screen.getByText("Enter a value to apply this restriction."),
+    ).toBeInTheDocument();
+  });
+
+  it("offers only what the source declares it can execute", () => {
+    mount(
+      makeProvider({
+        ...everything,
+        filter: { status: ["eq"], cpu: ["gte"] },
+      }),
+    );
+    expect(screen.getByRole("group", { name: "status" })).toBeInTheDocument();
+    expect(screen.getByLabelText("cpu from")).toBeInTheDocument();
+    expect(screen.queryByLabelText("cpu to")).toBeNull();
+    expect(screen.queryByLabelText("updated from")).toBeNull();
+    expect(screen.queryByRole("checkbox", { name: "owner" })).toBeNull();
+  });
+
+  it("keeps an undeclared restriction that stands clearable, then withdraws it", () => {
+    const provider = makeProvider({ ...everything, filter: {} });
+    mount(provider);
+    expect(screen.queryByRole("checkbox")).toBeNull();
+    act(() => {
+      provider.adopt(
+        {
+          filter: [
+            { field: "status", operator: "eq", operands: ["failed"] },
+            { field: "cpu", operator: "lte", operands: [8] },
+            { field: "owner", operator: "isSet", operands: [] },
+          ],
+          search: null,
+          sort: [],
+          group: null,
+        },
+        { page: 1, size: 50 },
+      );
+    });
+    // Nothing else removes it, so each stays offered while it stands — for
+    // removal only: nothing can be added the source never declared.
+    expect(screen.getByRole("checkbox", { name: "cancelled" })).toBeDisabled();
+    expect(screen.getByRole("checkbox", { name: "failed" })).toBeEnabled();
+    expect(screen.getByLabelText("cpu to")).toHaveAttribute("readonly");
+    fireEvent.click(screen.getByRole("checkbox", { name: "failed" }));
+    fireEvent.click(screen.getByRole("button", { name: "Clear cpu to" }));
+    fireEvent.click(screen.getByRole("checkbox", { name: "owner" }));
+    expect(provider.result.get().slice.filter).toEqual([]);
+    expect(screen.queryByRole("checkbox")).toBeNull();
+    expect(screen.queryByLabelText("cpu to")).toBeNull();
+  });
+
+  it("shows the query the provider adopted from elsewhere", () => {
+    const provider = makeProvider();
+    mount(provider);
+    act(() => {
+      provider.adopt(
+        {
+          filter: [
+            { field: "status", operator: "eq", operands: ["cancelled"] },
+            { field: "cpu", operator: "gte", operands: [8] },
+          ],
+          search: null,
+          sort: [],
+          group: null,
+        },
+        { page: 1, size: 50 },
+      );
+    });
+    expect(screen.getByRole("checkbox", { name: "cancelled" })).toBeChecked();
+    expect(screen.getByLabelText("cpu from")).toHaveValue("8");
+  });
+
+  it("edits and follows the provider under StrictMode", () => {
+    const provider = makeProvider();
+    render(
+      <StrictMode>
+        <DataViews provider={provider}>
+          <Filters />
+        </DataViews>
+      </StrictMode>,
+    );
+    fireEvent.click(screen.getByRole("checkbox", { name: "failed" }));
+    fireEvent.change(screen.getByLabelText("cpu from"), {
+      target: { value: "4" },
+    });
+    expect(provider.result.get().slice.filter).toEqual([
+      { field: "status", operator: "eq", operands: ["failed"] },
+      { field: "cpu", operator: "gte", operands: [4] },
+    ]);
+    act(() => {
+      provider.adopt(
+        {
+          filter: [{ field: "status", operator: "eq", operands: ["ready"] }],
+          search: null,
+          sort: [],
+          group: null,
+        },
+        { page: 1, size: 50 },
+      );
+    });
+    expect(screen.getByRole("checkbox", { name: "ready" })).toBeChecked();
+    expect(screen.getByRole("checkbox", { name: "failed" })).not.toBeChecked();
+    expect(screen.getByLabelText("cpu from")).toHaveValue("");
+  });
+
+  it("passes native fieldset props through and merges the class name", () => {
+    mount(makeProvider(), { className: "compact", disabled: true });
+    const group = screen.getByRole("group", { name: "Filters" });
+    expect(group).toHaveClass("ds", "data-views-filters", "compact");
+    expect(screen.getByLabelText("cpu from")).toBeDisabled();
+  });
+});

--- a/packages/react/dataviews/src/lib/DataViews/common/Filters/Filters.tsx
+++ b/packages/react/dataviews/src/lib/DataViews/common/Filters/Filters.tsx
@@ -1,0 +1,97 @@
+import type {
+  PredicateOperand,
+  PredicateOperator,
+} from "@canonical/dataviews-core";
+import type { ReactElement } from "react";
+import { Fragment, useContext } from "react";
+import DataViewsContext from "../../Context.js";
+import { BoundFilter, ChoicesFilter, FlagFilter } from "./common/index.js";
+import handleFor from "./handleFor.js";
+import type { FiltersProps } from "./types.js";
+
+const componentCssClassName = "ds data-views-filters";
+
+/**
+ * The collection's query-editing controls.
+ *
+ * Which fields are on offer and which operators each accepts come from the
+ * provider — its schema, and what its source declares it can execute — not
+ * from props: a restriction the source would refuse is never offered, and
+ * there is no second query to keep in step with the applied one. Edits go
+ * straight to the applied query — an invalid or incomplete edit keeps the
+ * restriction that is already in force and says so beside the control.
+ */
+export default function Filters({
+  label = "Filters",
+  labels,
+  className,
+  ...rest
+}: FiltersProps): ReactElement {
+  const provider = useContext(DataViewsContext);
+  if (provider === null) {
+    throw new Error("DataViews.Filters must be used inside a DataViews root");
+  }
+  const { capabilities } = provider;
+  if (capabilities === null) {
+    throw new Error(
+      "DataViews.Filters requires a provider given the source's capabilities; pass them to createDataViewsProvider",
+    );
+  }
+  const declares = (field: string, operator: PredicateOperator): boolean =>
+    capabilities.filter[field]?.includes(operator) === true;
+  return (
+    <fieldset
+      {...rest}
+      className={[componentCssClassName, className].filter(Boolean).join(" ")}
+    >
+      <legend className="legend">{label}</legend>
+      {provider.schema.fields.map((definition) => {
+        const { field } = definition;
+        const name = labels?.[field] ?? field;
+        if (definition.kind === "choices") {
+          return (
+            <ChoicesFilter
+              key={field}
+              options={definition.options}
+              handle={handleFor<ReadonlySet<PredicateOperand>>(
+                provider,
+                field,
+                "eq",
+              )}
+              label={name}
+              declared={declares(field, "eq")}
+            />
+          );
+        }
+        if (definition.kind === "flag") {
+          return (
+            <FlagFilter
+              key={field}
+              handle={handleFor<boolean>(provider, field, "isSet")}
+              label={name}
+              declared={declares(field, "isSet")}
+            />
+          );
+        }
+        return (
+          <Fragment key={field}>
+            <BoundFilter
+              handle={handleFor<number | string>(provider, field, "gte")}
+              label={name}
+              bound="gte"
+              kind={definition.kind}
+              declared={declares(field, "gte")}
+            />
+            <BoundFilter
+              handle={handleFor<number | string>(provider, field, "lte")}
+              label={name}
+              bound="lte"
+              kind={definition.kind}
+              declared={declares(field, "lte")}
+            />
+          </Fragment>
+        );
+      })}
+    </fieldset>
+  );
+}

--- a/packages/react/dataviews/src/lib/DataViews/common/Filters/common/BoundFilter/BoundFilter.tsx
+++ b/packages/react/dataviews/src/lib/DataViews/common/Filters/common/BoundFilter/BoundFilter.tsx
@@ -1,0 +1,103 @@
+import type { FieldFeedback } from "@canonical/dataviews-core";
+import type { ReactElement } from "react";
+import { useId } from "react";
+import useDataViewsField from "../../../../hooks/useDataViewsField.js";
+import type { BoundFilterProps } from "./types.js";
+
+const componentCssClassName = "ds data-views-filters-bound";
+
+const BOUND_WORDING = { gte: "from", lte: "to" } as const;
+
+const STILL_APPLIES = "The previous restriction still applies.";
+
+/** A schema reason as the start of a sentence. */
+const sentenceOf = (reason: string): string =>
+  `${reason.charAt(0).toUpperCase()}${reason.slice(1)}.`;
+
+/**
+ * What to say beside the input, or null when there is nothing to say.
+ *
+ * An invalid or emptied edit retains the applied predicate, so the message
+ * says the prior restriction still applies: the results on screen are
+ * still filtered and the text on screen is not what filtered them.
+ */
+const feedbackTextOf = (
+  feedback: FieldFeedback,
+  retained: boolean,
+): string | null => {
+  switch (feedback.kind) {
+    case "none":
+    case "applied":
+      return null;
+    case "incomplete":
+      return retained
+        ? `Enter a value to change this restriction. ${STILL_APPLIES}`
+        : "Enter a value to apply this restriction.";
+    case "invalid":
+      return feedback.retainsPredicate
+        ? `${sentenceOf(feedback.reason)} ${STILL_APPLIES}`
+        : sentenceOf(feedback.reason);
+  }
+};
+
+/**
+ * One bound of a number or date field.
+ *
+ * Emptying the input is incomplete, not a removal: the applied bound stays
+ * until it is explicitly cleared, which is what the clear control is for.
+ * A number is typed as text, so what the user typed is what is validated
+ * and shown — a number input would hand over an empty value instead.
+ */
+export default function BoundFilter({
+  handle,
+  label,
+  bound,
+  kind,
+  declared,
+}: BoundFilterProps): ReactElement | null {
+  const field = useDataViewsField(handle);
+  const inputId = useId();
+  const retained = field.applied.kind === "value";
+  if (!declared && !retained) {
+    return null;
+  }
+  const feedbackId = `${inputId}-feedback`;
+  const message = feedbackTextOf(field.feedback, retained);
+  const name = `${label} ${BOUND_WORDING[bound]}`;
+  return (
+    <div className={componentCssClassName}>
+      <label htmlFor={inputId} className="label">
+        {name}
+      </label>
+      <input
+        id={inputId}
+        className="input"
+        type={kind === "number" ? "text" : "date"}
+        inputMode={kind === "number" ? "decimal" : undefined}
+        value={field.input}
+        // Undeclared, the bound can only be cleared, never replaced.
+        readOnly={!declared}
+        aria-invalid={field.feedback.kind === "invalid"}
+        aria-describedby={message === null ? undefined : feedbackId}
+        onChange={(event) => {
+          field.edit(event.target.value);
+        }}
+      />
+      {retained ? (
+        <button
+          type="button"
+          className="clear"
+          onClick={() => {
+            field.clear();
+          }}
+        >
+          {`Clear ${name}`}
+        </button>
+      ) : null}
+      {/* Mounted even when empty, so a message appearing is announced. */}
+      <p id={feedbackId} className="feedback" role="status">
+        {message}
+      </p>
+    </div>
+  );
+}

--- a/packages/react/dataviews/src/lib/DataViews/common/Filters/common/BoundFilter/index.ts
+++ b/packages/react/dataviews/src/lib/DataViews/common/Filters/common/BoundFilter/index.ts
@@ -1,0 +1,2 @@
+export { default as BoundFilter } from "./BoundFilter.js";
+export type * from "./types.js";

--- a/packages/react/dataviews/src/lib/DataViews/common/Filters/common/BoundFilter/types.ts
+++ b/packages/react/dataviews/src/lib/DataViews/common/Filters/common/BoundFilter/types.ts
@@ -1,0 +1,28 @@
+import type {
+  PredicateOperator,
+  ProviderFieldHandle,
+  SchemaFieldDefinition,
+} from "@canonical/dataviews-core";
+
+/**
+ * Props of one bound filter.
+ *
+ * Exempt from the native-prop extension convention: an internal renderer
+ * deriving its root from the schema field it was built for, not forwarding
+ * a caller's native props.
+ */
+export type BoundFilterProps = {
+  /** The provider handle for this field's lower or upper bound. */
+  readonly handle: ProviderFieldHandle<number | string>;
+  /** The field's visible name; the bound's own wording is added to it. */
+  readonly label: string;
+  /** Which bound this control edits. */
+  readonly bound: Extract<PredicateOperator, "gte" | "lte">;
+  /** The field's kind, which decides the control. */
+  readonly kind: Extract<SchemaFieldDefinition["kind"], "number" | "date">;
+  /**
+   * Whether the source declares this bound. An undeclared one is offered
+   * only while it stands, and only for removal.
+   */
+  readonly declared: boolean;
+};

--- a/packages/react/dataviews/src/lib/DataViews/common/Filters/common/ChoicesFilter/ChoicesFilter.tsx
+++ b/packages/react/dataviews/src/lib/DataViews/common/Filters/common/ChoicesFilter/ChoicesFilter.tsx
@@ -1,0 +1,57 @@
+import type { PredicateOperand } from "@canonical/dataviews-core";
+import type { ReactElement } from "react";
+import useDataViewsField from "../../../../hooks/useDataViewsField.js";
+import type { ChoicesFilterProps } from "./types.js";
+
+const componentCssClassName = "ds data-views-filters-choices";
+
+const NONE_SELECTED: ReadonlySet<PredicateOperand> = new Set();
+
+/**
+ * One closed-set filter: a checkbox per option, so the applied set is
+ * visible and reachable without opening anything. Membership is the whole
+ * state — the last option cleared removes the predicate rather than
+ * applying an empty restriction that matches nothing.
+ */
+export default function ChoicesFilter({
+  options,
+  handle,
+  label,
+  declared,
+}: ChoicesFilterProps): ReactElement | null {
+  const field = useDataViewsField(handle);
+  if (!declared && field.applied.kind === "empty") {
+    return null;
+  }
+  const selected =
+    field.applied.kind === "value" ? field.applied.value : NONE_SELECTED;
+  return (
+    <fieldset className={componentCssClassName}>
+      <legend className="legend">{label}</legend>
+      {options.map((option) => (
+        <label key={String(option)} className="option">
+          <input
+            type="checkbox"
+            checked={selected.has(option)}
+            // Undeclared, the set may only shrink: adding an option would
+            // be a restriction the source never offered.
+            disabled={!declared && !selected.has(option)}
+            onChange={() => {
+              const next = options.filter((candidate) =>
+                candidate === option
+                  ? !selected.has(option)
+                  : selected.has(candidate),
+              );
+              if (next.length === 0) {
+                field.clear();
+                return;
+              }
+              field.set(next);
+            }}
+          />
+          {String(option)}
+        </label>
+      ))}
+    </fieldset>
+  );
+}

--- a/packages/react/dataviews/src/lib/DataViews/common/Filters/common/ChoicesFilter/index.ts
+++ b/packages/react/dataviews/src/lib/DataViews/common/Filters/common/ChoicesFilter/index.ts
@@ -1,0 +1,2 @@
+export { default as ChoicesFilter } from "./ChoicesFilter.js";
+export type * from "./types.js";

--- a/packages/react/dataviews/src/lib/DataViews/common/Filters/common/ChoicesFilter/types.ts
+++ b/packages/react/dataviews/src/lib/DataViews/common/Filters/common/ChoicesFilter/types.ts
@@ -1,0 +1,25 @@
+import type {
+  PredicateOperand,
+  ProviderFieldHandle,
+} from "@canonical/dataviews-core";
+
+/**
+ * Props of one closed-set filter.
+ *
+ * Exempt from the native-prop extension convention: an internal renderer
+ * deriving its root from the schema field it was built for, not forwarding
+ * a caller's native props.
+ */
+export type ChoicesFilterProps = {
+  /** The field's option values, in schema order. */
+  readonly options: readonly (string | number)[];
+  /** The provider handle for this field's equality predicate. */
+  readonly handle: ProviderFieldHandle<ReadonlySet<PredicateOperand>>;
+  /** The group's visible name. */
+  readonly label: string;
+  /**
+   * Whether the source declares this field's equality predicate. An undeclared
+   * one is offered only while it stands, and only for removal.
+   */
+  readonly declared: boolean;
+};

--- a/packages/react/dataviews/src/lib/DataViews/common/Filters/common/FlagFilter/FlagFilter.tsx
+++ b/packages/react/dataviews/src/lib/DataViews/common/Filters/common/FlagFilter/FlagFilter.tsx
@@ -1,0 +1,40 @@
+import type { ReactElement } from "react";
+import useDataViewsField from "../../../../hooks/useDataViewsField.js";
+import type { FlagFilterProps } from "./types.js";
+
+const componentCssClassName = "ds data-views-filters-flag";
+
+/**
+ * One presence filter: the predicate is either applied or absent, so the
+ * checkbox applies it and unchecking removes it. There is no third state
+ * asserting the field is unset — the grammar has no operator for that.
+ */
+export default function FlagFilter({
+  handle,
+  label,
+  declared,
+}: FlagFilterProps): ReactElement | null {
+  const field = useDataViewsField(handle);
+  const applied = field.applied.kind === "value";
+  if (!declared && !applied) {
+    return null;
+  }
+  return (
+    <div className={componentCssClassName}>
+      <label className="option">
+        <input
+          type="checkbox"
+          checked={applied}
+          onChange={() => {
+            if (applied) {
+              field.clear();
+              return;
+            }
+            field.set([]);
+          }}
+        />
+        {label}
+      </label>
+    </div>
+  );
+}

--- a/packages/react/dataviews/src/lib/DataViews/common/Filters/common/FlagFilter/index.ts
+++ b/packages/react/dataviews/src/lib/DataViews/common/Filters/common/FlagFilter/index.ts
@@ -1,0 +1,2 @@
+export { default as FlagFilter } from "./FlagFilter.js";
+export type * from "./types.js";

--- a/packages/react/dataviews/src/lib/DataViews/common/Filters/common/FlagFilter/types.ts
+++ b/packages/react/dataviews/src/lib/DataViews/common/Filters/common/FlagFilter/types.ts
@@ -1,0 +1,20 @@
+import type { ProviderFieldHandle } from "@canonical/dataviews-core";
+
+/**
+ * Props of one presence filter.
+ *
+ * Exempt from the native-prop extension convention: an internal renderer
+ * deriving its root from the schema field it was built for, not forwarding
+ * a caller's native props.
+ */
+export type FlagFilterProps = {
+  /** The provider handle for this field's presence predicate. */
+  readonly handle: ProviderFieldHandle<boolean>;
+  /** The field's visible name. */
+  readonly label: string;
+  /**
+   * Whether the source declares this field's presence predicate. An undeclared
+   * one is offered only while it stands, and only for removal.
+   */
+  readonly declared: boolean;
+};

--- a/packages/react/dataviews/src/lib/DataViews/common/Filters/common/index.ts
+++ b/packages/react/dataviews/src/lib/DataViews/common/Filters/common/index.ts
@@ -1,0 +1,3 @@
+export * from "./BoundFilter/index.js";
+export * from "./ChoicesFilter/index.js";
+export * from "./FlagFilter/index.js";

--- a/packages/react/dataviews/src/lib/DataViews/common/Filters/handleFor.ts
+++ b/packages/react/dataviews/src/lib/DataViews/common/Filters/handleFor.ts
@@ -1,0 +1,25 @@
+import type {
+  DataViewsProvider,
+  PredicateOperator,
+  ProviderFieldHandle,
+  SchemaFieldDefinition,
+} from "@canonical/dataviews-core";
+
+/**
+ * Read one field handle off a provider by its address.
+ *
+ * The context stores the widest provider shape, whose field map is keyed by
+ * an open string rather than the literal field names of one schema. The
+ * caller reaches this by walking that same schema, and names the applied
+ * type that field's kind publishes; nothing here checks it.
+ */
+export default function handleFor<TApplied>(
+  provider: DataViewsProvider<readonly SchemaFieldDefinition[]>,
+  field: string,
+  operator: PredicateOperator,
+): ProviderFieldHandle<TApplied> {
+  const byField = provider.fields as unknown as Readonly<
+    Record<string, Readonly<Record<string, ProviderFieldHandle<TApplied>>>>
+  >;
+  return byField[field][operator];
+}

--- a/packages/react/dataviews/src/lib/DataViews/common/Filters/index.ts
+++ b/packages/react/dataviews/src/lib/DataViews/common/Filters/index.ts
@@ -1,0 +1,2 @@
+export { default as Filters } from "./Filters.js";
+export type * from "./types.js";

--- a/packages/react/dataviews/src/lib/DataViews/common/Filters/types.ts
+++ b/packages/react/dataviews/src/lib/DataViews/common/Filters/types.ts
@@ -1,0 +1,27 @@
+import type { ComponentProps } from "react";
+
+type OwnProps = {
+  /** The group's legend, which names it. Defaults to "Filters". */
+  readonly label?: string;
+  /**
+   * Visible names for fields, keyed by field name. A field with no entry is
+   * named by its own field name. Presentation only: the fields on offer and
+   * the operators they accept come from the provider's schema and its
+   * source's declared capabilities.
+   */
+  readonly labels?: Readonly<Partial<Record<string, string>>>;
+};
+
+/**
+ * Props of the connected filters part. The root is a `fieldset` naming the
+ * group, so it extends native fieldset props — `disabled` reaches every
+ * control for free. `children` is excluded: the controls are derived from
+ * the provider, not composed by hand. So are `role`, which would override
+ * the fieldset's `group` role, and `aria-label` and `aria-labelledby`,
+ * which would override the name it takes from `label`.
+ */
+export type FiltersProps = OwnProps &
+  Omit<
+    ComponentProps<"fieldset">,
+    keyof OwnProps | "children" | "role" | "aria-label" | "aria-labelledby"
+  >;

--- a/packages/react/dataviews/src/lib/DataViews/common/Pagination/Pagination.test.tsx
+++ b/packages/react/dataviews/src/lib/DataViews/common/Pagination/Pagination.test.tsx
@@ -1,0 +1,247 @@
+/**
+ * The connected pagination part: destinations the collection can actually
+ * reach, and counts that describe the rows on screen. Each case is
+ * mutation-tested against that contract.
+ */
+import type { DataViewsProvider } from "@canonical/dataviews-core";
+import {
+  createDataViewsProvider,
+  createSchema,
+} from "@canonical/dataviews-core";
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { StrictMode } from "react";
+import { describe, expect, it } from "vitest";
+import DataViews from "../../Provider.js";
+import Pagination from "./Pagination.js";
+
+const schema = createSchema([
+  { field: "status", kind: "choices", options: ["failed", "ready"] },
+]);
+
+type Fields = typeof schema.fields;
+type Machine = { readonly id: string };
+
+const makeProvider = (size = 2): DataViewsProvider<Fields, Machine> =>
+  createDataViewsProvider<Fields, Machine>({
+    schema,
+    window: { page: 1, size },
+  });
+
+const machines = (count: number): readonly Machine[] =>
+  Array.from({ length: count }, (_unused, index) => ({ id: `m${index}` }));
+
+/** Deliver one page for the request the provider currently wants. */
+const load = (
+  provider: DataViewsProvider<Fields, Machine>,
+  rows: readonly Machine[],
+  count: number | null,
+): void => {
+  const pending = provider.result.get().pendingRequestId ?? provider.refresh();
+  if (pending === null) {
+    throw new Error("expected a pending request");
+  }
+  act(() => {
+    provider.complete(pending, { status: "success", rows, count });
+  });
+};
+
+const mount = (
+  provider: DataViewsProvider<Fields, Machine>,
+  props: Parameters<typeof Pagination>[0] = {},
+) =>
+  render(
+    <DataViews provider={provider}>
+      <Pagination {...props} />
+    </DataViews>,
+  );
+
+/** The whole position readout: the announced page plus any total. */
+const position = () => screen.getByRole("status").parentElement;
+const previous = () => screen.getByRole("button", { name: "Previous" });
+const next = () => screen.getByRole("button", { name: "Next" });
+
+describe("DataViews.Pagination", () => {
+  it("is reachable as the composition's Pagination part", () => {
+    expect(DataViews.Pagination).toBe(Pagination);
+  });
+
+  it("fails clearly outside a DataViews root", () => {
+    expect(() => render(<Pagination />)).toThrow(
+      "DataViews.Pagination must be used inside a DataViews root",
+    );
+  });
+
+  it("names the navigation and announces the position as a status", () => {
+    mount(makeProvider());
+    expect(
+      screen.getByRole("navigation", { name: "Pagination" }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("status")).toHaveTextContent(/^Page 1$/);
+  });
+
+  it("announces the page, and leaves the total out of the announcement", () => {
+    const provider = makeProvider();
+    mount(provider);
+    load(provider, machines(2), 5);
+    expect(position()).toHaveTextContent(/^Page 1 of 3$/);
+    expect(screen.getByRole("status")).toHaveTextContent(/^Page 1$/);
+  });
+
+  it("takes its accessible name from the label", () => {
+    mount(makeProvider(), { label: "Machines pagination" });
+    expect(
+      screen.getByRole("navigation", { name: "Machines pagination" }),
+    ).toBeInTheDocument();
+  });
+
+  it("counts the pages a filtered total makes reachable", () => {
+    const provider = makeProvider();
+    mount(provider);
+    load(provider, machines(2), 5);
+    expect(position()).toHaveTextContent(/^Page 1 of 3$/);
+    expect(previous()).toBeDisabled();
+    expect(next()).toBeEnabled();
+  });
+
+  it("offers no last page when the source publishes no count", () => {
+    const provider = makeProvider();
+    mount(provider);
+    load(provider, machines(2), null);
+    expect(position()).toHaveTextContent(/^Page 1$/);
+    // A full page is evidence there may be another; a short one is not.
+    expect(next()).toBeEnabled();
+    load(provider, machines(1), null);
+    expect(next()).toBeDisabled();
+  });
+
+  it("stops at the last page a count declares", () => {
+    const provider = makeProvider();
+    mount(provider);
+    load(provider, machines(2), 4);
+    fireEvent.click(next());
+    expect(provider.result.get().window).toEqual({ page: 2, size: 2 });
+    load(provider, machines(2), 4);
+    expect(position()).toHaveTextContent(/^Page 2 of 2$/);
+    expect(next()).toBeDisabled();
+    expect(previous()).toBeEnabled();
+    fireEvent.click(previous());
+    expect(provider.result.get().window).toEqual({ page: 1, size: 2 });
+  });
+
+  it("steps one page from wherever it is", () => {
+    const provider = makeProvider();
+    mount(provider);
+    load(provider, machines(2), 6);
+    fireEvent.click(next());
+    load(provider, machines(2), 6);
+    fireEvent.click(next());
+    load(provider, machines(2), 6);
+    expect(position()).toHaveTextContent(/^Page 3 of 3$/);
+    fireEvent.click(previous());
+    expect(provider.result.get().window).toEqual({ page: 2, size: 2 });
+    load(provider, machines(2), 6);
+    fireEvent.click(next());
+    expect(provider.result.get().window).toEqual({ page: 3, size: 2 });
+  });
+
+  it("steps back from past the last page to the last one there is", () => {
+    const provider = createDataViewsProvider<Fields, Machine>({
+      schema,
+      window: { page: 9, size: 2 },
+    });
+    mount(provider);
+    load(provider, [], 4);
+    expect(position()).toHaveTextContent(/^Page 9 of 2$/);
+    fireEvent.click(previous());
+    expect(provider.result.get().window).toEqual({ page: 2, size: 2 });
+  });
+
+  it("keeps one page when the collection is empty", () => {
+    const provider = makeProvider();
+    mount(provider);
+    load(provider, [], 0);
+    expect(position()).toHaveTextContent(/^Page 1 of 1$/);
+    expect(next()).toBeDisabled();
+  });
+
+  it("claims no total while a replacement request is in flight", () => {
+    const provider = makeProvider();
+    mount(provider);
+    load(provider, machines(2), 5);
+    act(() => {
+      provider.navigateWindow(2);
+    });
+    // The previous query's total does not describe the pending one, and the
+    // rows still on screen are not the ones Next would page past.
+    expect(position()).toHaveTextContent(/^Page 2$/);
+    expect(next()).toBeDisabled();
+    load(provider, machines(2), 5);
+    expect(position()).toHaveTextContent(/^Page 2 of 3$/);
+    expect(next()).toBeEnabled();
+  });
+
+  it("resets to the first page when the page size changes", () => {
+    const provider = makeProvider();
+    mount(provider);
+    load(provider, machines(2), 40);
+    fireEvent.click(next());
+    load(provider, machines(2), 40);
+    fireEvent.change(screen.getByLabelText("Rows per page"), {
+      target: { value: "25" },
+    });
+    // The old page number counted rows of a different size.
+    expect(provider.result.get().window).toEqual({ page: 1, size: 25 });
+  });
+
+  it("always offers the applied size, in order", () => {
+    mount(makeProvider(2));
+    expect(
+      screen
+        .getAllByRole("option")
+        .map((option) => (option as HTMLOptionElement).value),
+    ).toEqual(["2", "10", "25", "50", "100"]);
+    expect(screen.getByLabelText("Rows per page")).toHaveValue("2");
+  });
+
+  it("offers each size once", () => {
+    mount(makeProvider(25), { sizes: [25, 50, 25] });
+    expect(
+      screen
+        .getAllByRole("option")
+        .map((option) => (option as HTMLOptionElement).value),
+    ).toEqual(["25", "50"]);
+  });
+
+  it("follows the window and pages under StrictMode", () => {
+    const provider = makeProvider();
+    render(
+      <StrictMode>
+        <DataViews provider={provider}>
+          <Pagination />
+        </DataViews>
+      </StrictMode>,
+    );
+    load(provider, machines(2), 5);
+    expect(position()).toHaveTextContent(/^Page 1 of 3$/);
+    fireEvent.click(next());
+    expect(provider.result.get().window).toEqual({ page: 2, size: 2 });
+    load(provider, machines(2), 5);
+    expect(position()).toHaveTextContent(/^Page 2 of 3$/);
+  });
+
+  it("offers exactly the sizes it was given when one is applied", () => {
+    mount(makeProvider(25), { sizes: [25, 50] });
+    expect(
+      screen
+        .getAllByRole("option")
+        .map((option) => (option as HTMLOptionElement).value),
+    ).toEqual(["25", "50"]);
+  });
+
+  it("passes native nav props through and merges the class name", () => {
+    mount(makeProvider(), { className: "footer", id: "machines-pages" });
+    const nav = screen.getByRole("navigation", { name: "Pagination" });
+    expect(nav).toHaveClass("ds", "data-views-pagination", "footer");
+    expect(nav).toHaveAttribute("id", "machines-pages");
+  });
+});

--- a/packages/react/dataviews/src/lib/DataViews/common/Pagination/Pagination.tsx
+++ b/packages/react/dataviews/src/lib/DataViews/common/Pagination/Pagination.tsx
@@ -1,0 +1,105 @@
+import type { ReactElement } from "react";
+import { useContext, useId } from "react";
+import DataViewsContext from "../../Context.js";
+import useDataViewsValue from "../../hooks/useDataViewsValue.js";
+import type { PaginationProps } from "./types.js";
+
+const componentCssClassName = "ds data-views-pagination";
+
+const DEFAULT_SIZES: readonly number[] = [10, 25, 50, 100];
+
+/**
+ * Window navigation for the collection.
+ *
+ * The destinations are the ones the collection can actually reach. A source
+ * that publishes a filtered total gets a last page and a "page n of m"; one
+ * that publishes no count gets a Next offered only while the current page is
+ * full, and no invented last page. While a replacement request is in flight
+ * the previous query's total is not this query's, so no total is claimed and
+ * Next waits for the results it would be paging past.
+ */
+export default function Pagination({
+  label = "Pagination",
+  sizes = DEFAULT_SIZES,
+  className,
+  ...rest
+}: PaginationProps): ReactElement {
+  const provider = useContext(DataViewsContext);
+  if (provider === null) {
+    throw new Error(
+      "DataViews.Pagination must be used inside a DataViews root",
+    );
+  }
+  const state = useDataViewsValue(provider.result);
+  const sizeId = useId();
+  const { page, size } = state.window;
+  const current = state.resultsMatchCurrentQuery;
+  const total = current ? state.result.count : null;
+  const pages = total === null ? null : Math.max(1, Math.ceil(total / size));
+  // Without a total, a full page is the evidence there may be another one;
+  // a short page is not, and rows a superseded query produced are evidence
+  // of nothing at all.
+  const rows = state.result.rows;
+  const pageIsFull = rows !== null && rows.length === size;
+  const hasNext = pages === null ? pageIsFull && current : page < pages;
+  // A page past the last — an old link, a shrunken result — steps back to
+  // the last page there is, not one page at a time.
+  const back = pages !== null && page > pages ? pages : page - 1;
+  const given = [...new Set(sizes)];
+  const offered = given.includes(size)
+    ? given
+    : [...given, size].sort((a, b) => a - b);
+  return (
+    <nav
+      {...rest}
+      aria-label={label}
+      className={[componentCssClassName, className].filter(Boolean).join(" ")}
+    >
+      <button
+        type="button"
+        className="previous"
+        disabled={page <= 1}
+        onClick={() => {
+          provider.navigateWindow(back);
+        }}
+      >
+        Previous
+      </button>
+      <p className="position">
+        {/* Only the page the user moves to is announced; the total settles
+            with the results and would otherwise announce twice. */}
+        <span role="status">{`Page ${page}`}</span>
+        {pages === null ? null : ` of ${pages}`}
+      </p>
+      <button
+        type="button"
+        className="next"
+        disabled={!hasNext}
+        onClick={() => {
+          provider.navigateWindow(page + 1);
+        }}
+      >
+        Next
+      </button>
+      <label htmlFor={sizeId} className="size-label">
+        Rows per page
+      </label>
+      <select
+        id={sizeId}
+        className="size"
+        value={size}
+        onChange={(event) => {
+          // A new page size is a new window: the old page number counted
+          // rows of a different size, so it cannot survive the change.
+          provider.navigateWindow(1, Number(event.target.value));
+        }}
+      >
+        {offered.map((option) => (
+          <option key={option} value={option}>
+            {option}
+          </option>
+        ))}
+      </select>
+    </nav>
+  );
+}

--- a/packages/react/dataviews/src/lib/DataViews/common/Pagination/index.ts
+++ b/packages/react/dataviews/src/lib/DataViews/common/Pagination/index.ts
@@ -1,0 +1,2 @@
+export { default as Pagination } from "./Pagination.js";
+export type * from "./types.js";

--- a/packages/react/dataviews/src/lib/DataViews/common/Pagination/types.ts
+++ b/packages/react/dataviews/src/lib/DataViews/common/Pagination/types.ts
@@ -1,0 +1,24 @@
+import type { ComponentProps } from "react";
+
+type OwnProps = {
+  /** The navigation's accessible name. Defaults to "Pagination". */
+  readonly label?: string;
+  /**
+   * The page sizes offered. The applied size is always among them, so the
+   * control can never misreport the window it is describing.
+   */
+  readonly sizes?: readonly number[];
+};
+
+/**
+ * Props of the connected pagination part. The root is a `nav`, so it
+ * extends native nav props. `children` is excluded: the destinations are
+ * derived from the window and what the source can count. So are `role`,
+ * which would override the nav's `navigation` role, and `aria-label` and
+ * `aria-labelledby`, which would override the name it takes from `label`.
+ */
+export type PaginationProps = OwnProps &
+  Omit<
+    ComponentProps<"nav">,
+    keyof OwnProps | "children" | "role" | "aria-label" | "aria-labelledby"
+  >;

--- a/packages/react/dataviews/src/lib/DataViews/common/index.ts
+++ b/packages/react/dataviews/src/lib/DataViews/common/index.ts
@@ -1,0 +1,2 @@
+export * from "./Filters/index.js";
+export * from "./Pagination/index.js";

--- a/packages/react/dataviews/src/lib/DataViews/index.ts
+++ b/packages/react/dataviews/src/lib/DataViews/index.ts
@@ -1,4 +1,6 @@
 export type { CellScopeValue } from "./CellScopeContext.js";
+export type { FiltersProps } from "./common/Filters/index.js";
+export type { PaginationProps } from "./common/Pagination/index.js";
 export * from "./hooks/index.js";
 export { default as DataViews } from "./Provider.js";
 export type { DataViewsProps } from "./types.js";

--- a/packages/react/dataviews/src/lib/DataViews/types.ts
+++ b/packages/react/dataviews/src/lib/DataViews/types.ts
@@ -1,16 +1,28 @@
 import type {
   DataViewsProvider,
+  RowRecord,
   SchemaFieldDefinition,
 } from "@canonical/dataviews-core";
 import type { ReactNode } from "react";
 
-type OwnProps<TFields extends readonly SchemaFieldDefinition[]> = {
+type OwnProps<
+  TFields extends readonly SchemaFieldDefinition[],
+  TRow extends object,
+> = {
   /** The provider created by `createDataViewsProvider` for this collection. */
-  readonly provider: DataViewsProvider<TFields>;
+  readonly provider: DataViewsProvider<TFields, TRow>;
   /** The composition's children; optional for host-specific shells. */
   readonly children?: ReactNode;
 };
 
-/** Props of the DataViews root. A context mount, not a DOM element. */
-export type DataViewsProps<TFields extends readonly SchemaFieldDefinition[]> =
-  OwnProps<TFields>;
+/**
+ * Props of the DataViews root. A context mount, not a DOM element.
+ *
+ * The record type travels with the provider: a provider built for a row
+ * type mounts as itself rather than as the widest record shape, which the
+ * channel's own invariance would otherwise refuse.
+ */
+export type DataViewsProps<
+  TFields extends readonly SchemaFieldDefinition[],
+  TRow extends object = RowRecord,
+> = OwnProps<TFields, TRow>;


### PR DESCRIPTION
## Done

Adds the first two connected parts of the collection view: filtering and pagination.

- **`DataViews.Filters`** edits the query directly, from the provider's schema. It offers only the fields and operators the source declares it can execute. A filter that is already standing but the source cannot run stays visible and removable, not editable, so the query is never silently changed. Each control is named, keyboard-operable, and announces its own state.
- **`DataViews.Pagination`** renders native window navigation with honest totals: no total while results do not match the current query, and Next only while the page is full. It announces the page once, rather than on every settle.
- Both parts read the enclosing root. They take presentation choices (a name, visible field labels, the page sizes to offer), never a second copy of the query, window or selection the provider already owns.
- The README gains two composition recipes: the connected parts, and keeping the query in the URL with `createLocationBinding`, including how refused URL clauses surface for the host to show.

Merge order: #1222 must land first — this is based on it, so the diff here is only the two parts.

## QA

- `bun run check` green at the root (68 projects).
- `@canonical/dataviews-core`: 552 tests; `@canonical/dataviews-react`: 154 tests. Both at 100% branch/function/line/statement coverage; both builds emit.

### PR readiness check

- [x] PR title follows the Conventional Commits format.
- [x] The code follows the appropriate code standards.
- [x] The package defines `check`, `check:fix`, `test`, `build`, `build:all`.
- [x] No stories for these parts yet, so no visual diff for Chromatic — Chromatic: skip applied.

Chromatic: skip

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0143BZrKuhi4j3YdemH5SbqD
