### PR TITLE
fix(react-ds-global): export TooltipEngine and add ContextualMenu surfaceClassName

### DIFF
--- a/packages/react/ds-global/src/lib/component/ContextualMenu/ContextualMenu.tests.tsx
+++ b/packages/react/ds-global/src/lib/component/ContextualMenu/ContextualMenu.tests.tsx
@@ -50,6 +50,16 @@ describe("ContextualMenu", () => {
     expect(screen.getAllByRole("menuitem", { hidden: true })).toHaveLength(3);
   });
 
+  it("applies surfaceClassName to the portaled menu surface, not the trigger's own wrapper", () => {
+    renderMenu({ surfaceClassName: "custom-surface" });
+    expect(screen.getByRole("menu", { hidden: true })).toHaveClass(
+      "custom-surface",
+    );
+    expect(
+      screen.getByRole("button", { name: "Actions" }).closest(".ds"),
+    ).not.toHaveClass("custom-surface");
+  });
+
   it("calls onSelect and closes when an item is activated", () => {
     const onSelect = vi.fn();
     renderMenu({ onSelect });

--- a/packages/react/ds-global/src/lib/component/ContextualMenu/ContextualMenu.tsx
+++ b/packages/react/ds-global/src/lib/component/ContextualMenu/ContextualMenu.tsx
@@ -29,6 +29,7 @@ const ContextualMenu = ({
   items,
   label,
   className,
+  surfaceClassName,
   preferredDirections,
   distance,
   gutter,
@@ -144,6 +145,7 @@ const ContextualMenu = ({
         "contextual-menu__surface",
         "modal",
         bestPosition?.positionName,
+        surfaceClassName,
       ]
         .filter(Boolean)
         .join(" ")}

--- a/packages/react/ds-global/src/lib/component/ContextualMenu/types.ts
+++ b/packages/react/ds-global/src/lib/component/ContextualMenu/types.ts
@@ -45,6 +45,14 @@ type OwnProps = Pick<
   open?: boolean;
   /** Called when the open state changes. */
   onOpenChange?: (open: boolean) => void;
+  /**
+   * Class name applied to the menu's portaled popup surface. The surface
+   * portals to `document.body`, so it is not a DOM descendant of the root —
+   * `className` cannot reach it (custom-property inheritance follows the
+   * rendered DOM tree, and the portal breaks that ancestry). The one hook
+   * for theming the surface itself, not just the trigger.
+   */
+  surfaceClassName?: string;
 };
 
 export type ContextualMenuProps = OwnProps &

--- a/packages/react/ds-global/src/lib/component/Tooltip/index.ts
+++ b/packages/react/ds-global/src/lib/component/Tooltip/index.ts
@@ -1,3 +1,3 @@
 export { default as Tooltip } from "./Tooltip.js";
 export type * from "./types.js";
-export { default as withTooltip } from "./withTooltip.js";
+export { default as withTooltip, TooltipEngine } from "./withTooltip.js";

--- a/packages/react/ds-global/src/lib/component/Tooltip/withTooltip.tests.tsx
+++ b/packages/react/ds-global/src/lib/component/Tooltip/withTooltip.tests.tsx
@@ -2,7 +2,7 @@ import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { createPortal } from "react-dom";
 import { describe, expect, it, vi } from "vitest";
 import type { WithTooltipOptions } from "./index.js";
-import { withTooltip } from "./index.js";
+import { TooltipEngine, withTooltip } from "./index.js";
 
 vi.mock("react-dom", () => ({
   createPortal: vi.fn((children) => children),
@@ -105,5 +105,51 @@ describe("withTooltip", () => {
   it("sets the wrapped component's displayName", () => {
     const Tooltipped = withTooltip(Trigger, Message);
     expect(Tooltipped.displayName).toBe("withTooltip(Trigger)");
+  });
+});
+
+describe("TooltipEngine", () => {
+  const Target = ({ state }: { state: string }) => (
+    <button type="button">{`Target (${state})`}</button>
+  );
+
+  it("renders the message as a live prop — reactive to rerender", async () => {
+    const { rerender } = render(
+      <TooltipEngine Message="Collapse">
+        <Target state="expanded" />
+      </TooltipEngine>,
+    );
+    fireEvent.pointerEnter(screen.getByRole("button"));
+    expect(await screen.findByText("Collapse")).toBeInTheDocument();
+
+    rerender(
+      <TooltipEngine Message="Expand">
+        <Target state="collapsed" />
+      </TooltipEngine>,
+    );
+    fireEvent.pointerEnter(screen.getByRole("button"));
+    expect(await screen.findByText("Expand")).toBeInTheDocument();
+  });
+
+  it("keeps the same target element identity across rerenders", () => {
+    const { rerender } = render(
+      <TooltipEngine Message="Collapse">
+        <Target state="expanded" />
+      </TooltipEngine>,
+    );
+    const targetBefore = document.querySelector(
+      ".ds.tooltip-area > .target",
+    ) as HTMLElement;
+    rerender(
+      <TooltipEngine Message="Expand">
+        <Target state="collapsed" />
+      </TooltipEngine>,
+    );
+    const targetAfter = document.querySelector(
+      ".ds.tooltip-area > .target",
+    ) as HTMLElement;
+    // One stable element across prop changes — switching between two
+    // withTooltip-wrapped types would remount the target.
+    expect(targetAfter).toBe(targetBefore);
   });
 });

--- a/packages/react/ds-global/src/lib/component/Tooltip/withTooltip.tsx
+++ b/packages/react/ds-global/src/lib/component/Tooltip/withTooltip.tsx
@@ -21,7 +21,7 @@ const componentCssClassName = "ds tooltip-area";
  * is the shared implementation that {@link withTooltip} builds on — it renders
  * the wrapped component as its `children` target.
  */
-const TooltipEngine = ({
+export const TooltipEngine = ({
   children,
   style,
   className,
@@ -138,8 +138,15 @@ const TooltipEngine = ({
 /**
  * A higher-order component that wraps a component with a tooltip. It is the
  * single public tooltip primitive: it owns the engine (hover-mode
- * {@link useDisclosure}, client-only portal, arrow positioning) and renders the
- * wrapped component as the tooltip target.
+ * {@link useDisclosure}, client-only portal, arrow positioning) and renders
+ * the wrapped component as the tooltip target.
+ *
+ * `Message` is fixed at wrap time — not reactive to the wrapped component's
+ * props. When the message must follow prop state (e.g. a toggle whose
+ * tooltip names the current action), render {@link TooltipEngine} directly
+ * with a live `Message`; one stable element type also keeps the target
+ * mounted across state changes, preserving focus and hover state.
+ *
  * @param Component The component type to wrap.
  * @param Message The content of the tooltip.
  * @param popupProps Tooltip options — positioning, sizing, timing, plus `open`,


### PR DESCRIPTION
## Done

Two supporting fixes for the SideNavigation rebuild stack (the following PRs in this series consume both):

- **Export `TooltipEngine`** from `@canonical/react-ds-global`. `withTooltip` fixes its `Message` at wrap time, so a component whose tooltip must follow its own prop state (e.g. a toggle naming the action for each state) had to pick between two wrapped component types — remounting the target on every state flip and dropping focus and hover state. Such consumers now render `TooltipEngine` directly with `Message` as a live prop; the trade-off is documented on `withTooltip`.
- **Add `surfaceClassName` to `ContextualMenu`** (drive-by in the same package): the menu's popup surface portals to `document.body`, so the root's `className` cannot reach it — this is the one hook for theming the surface itself. Covered by ContextualMenu tests.

## QA

- `bun run check` and `bun run test` pass from the repo root (66 projects).
- `TooltipEngine` tests: message reactive to rerender; target element identity stable across prop changes.

### PR readiness check

- [x] PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format, using one of the allowed types: `feat`, `fix`, `docs`, `refactor`, `chore`, `test`, `ci`, `revert`.
  - The matching type label is applied automatically from the title — there is no type label to add by hand.
  - Breaking changes are marked with `!` in the title (e.g. `feat(router)!: …`), which adds the `breaking` label.
- [x] The code follows the appropriate [code standards](https://github.com/canonical/web-code-standards)
- [x] All packages define the required scripts in `package.json`:
  - [x] All packages: `check`, `check:fix`, and `test`.
  - [x] Packages with build steps: `build` to build the package for development or distribution, `build:all` to build **all** artifacts. See [CONTRIBUTING.md](../old/CONTRIBUTING.md#24-full-artifact-builds-buildall) for details.
- [ ] If this PR introduces a **new package**: first-time publish has been done manually from inside the package directory with `npm publish --access public` (first-time publishing is not automated). Run `bun run publish:status` from the repo root to verify. Then configure an OIDC [trusted publisher](https://docs.npmjs.com/trusted-publishers) for the package on npmjs.com (repo `canonical/pragma`, workflow `tag.yml`) and set publishing access to disallow tokens, so the automated release workflow can publish future versions.
- [x] If this PR does not require visual testing, add the `Chromatic: skip` label to skip Chromatic.
