### PR TITLE
feat(dataviews): the pagination bar and the action bar

### DIFF
--- a/packages/react/dataviews/.storybook/styles.css
+++ b/packages/react/dataviews/.storybook/styles.css
@@ -1,1 +1,3 @@
 @import url("@canonical/styles");
+/* The input chrome the pagination bar's selects are themed on. */
+@import url("@canonical/react-ds-global-form/dist/esm/index.css");

--- a/packages/react/dataviews/README.md
+++ b/packages/react/dataviews/README.md
@@ -1,6 +1,6 @@
 # @canonical/dataviews-react
 
-React bindings for Canonical collection views, built on `@canonical/dataviews-core`: the `DataViews` root with its connected `Filters` and `Pagination` parts, the provider context, the four scoped observation hooks, and the `DataTable` renderer.
+React bindings for Canonical collection views, built on `@canonical/dataviews-core`: the `DataViews` root with its connected `Filters`, `Actions` and `Pagination` parts, the provider context, the four scoped observation hooks, the `DataTable` renderer and the `PaginationBar`.
 
 > **Stability: pre-1.0 / experimental.** The API is still consolidating and breaking changes may land between minor versions. Every breaking change ships with a conventional-commit subject and a CHANGELOG entry — those are the migration record. Pin a minor version if you need stability today.
 
@@ -20,80 +20,25 @@ Under active development; the public surface grows change by change. The current
 - **`useDataViewsField(handle)`** — a field's input buffer, applied semantic value and feedback, with `edit`/`set`/`clear` routed through the provider.
 - **`useDataViewsCell(provider)`** — the current cell's scope (row id, column id, read-only row/fields/selected channels), installed by the table renderer; throws outside a rendered cell or on a witness mismatch.
 - **`DataViews.Filters`** — the connected query-editing part. Which fields it offers and which operators each accepts come from the provider — its schema, and the capabilities its source declares — so it never offers a restriction the source would refuse, takes no query props, and has no draft query to keep in step with the applied one. Throws when the provider was created without the source's capabilities.
-- **`DataViews.Pagination`** — the connected window navigation. Its destinations are the ones the collection can actually reach: a source that publishes a filtered total gets numbered pages and a last one, a source that publishes no count gets a Next offered only while the page is full, and a pending or failed replacement claims no total at all.
+- **`DataViews.Pagination`** — the connected window navigation: the `PaginationBar`, bound to the enclosing root's provider.
+- **`DataViews.Actions`** — the connected action bar: the selection's count, the actions a caller places, and a button that clears the selection, on the design system's contrasted surface. It reads the root's selection, takes no copy of it, and is absent while nothing is selected.
+- **`PaginationBar`** — the bar beneath a collection's rows: the page size, a summary of the items on screen out of the filtered total, a page select and first, previous, next and last buttons. It takes its provider explicitly, as `DataTable` does, so a standalone table gets the same footer as a composed one. Its destinations are the ones the collection can actually reach: a source that publishes a filtered total gets a page total and a last page, a source that publishes no count gets a Next offered only while the page is full, and a pending or failed replacement claims no total at all.
 - **`DataTable`** — the row renderer: div rows over ARIA table roles, one shared column track list, sorting, selection and resizing. It takes its provider explicitly, so it behaves the same standalone and inside a `DataViews` root. A column's `sortable` is honoured only on a field the provider's source declares sortable — the same declaration `DataViews.Filters` reads — so the table never offers an ordering the source would refuse; a sortable column on a provider created without the source's capabilities throws.
 
-The remaining connected parts (Views, Summary, Actions) land in later changes.
+The remaining connected parts (Views, Summary) land in later changes. The pagination bar already carries the result summary and the action bar the selection count, so `Summary` is designed not to repeat either.
 
 ## Composition recipes
 
-### The connected parts
+The recipes, with consumer code and the live stories beside them, are the Storybook page **_work_in_progress / DataViews / Composition / Recipes** — source in [`src/lib/DataViews/DataViews.mdx`](src/lib/DataViews/DataViews.mdx):
 
-```tsx
-const machinesProvider = createDataViewsProvider({
-  schema,
-  // What the source can execute: Filters and the table's sortable columns
-  // offer nothing beyond it, and the binding refuses a provider told
-  // anything else.
-  capabilities: source.capabilities,
-});
-createSourceBinding({ host: machinesProvider, adapter: source });
+- **The connected parts** — one root, every part reading its provider; place them in any order and any wrapper.
+- **Keeping the query in the URL** — a location binding makes the URL the query's other home, and a refused link reports its reasons on `binding.issues`.
 
-<DataViews provider={machinesProvider}>
-  <DataViews.Filters labels={{ status: "Status", cpu: "Cores" }} />
-
-  <DataTable provider={machinesProvider} columns={columns} label="Machines" />
-
-  <div className="collection-footer">
-    <DataViews.Pagination label="Machines pagination" />
-  </div>
-</DataViews>
-```
-
-Both parts read the enclosing root: they take presentation choices — a name,
-visible field labels, the page sizes to offer — and never a second copy of
-the query, the window or the selection the provider already owns. Ordinary
-wrappers and custom children sit between them; moving pagination means moving
-an element, not asking for a slot.
-
-### Keeping the query in the URL
-
-```tsx
-function MachinesUrlQuery({ platform }: { platform: PlatformLocation }) {
-  // Building the binding subscribes to nothing; observing does, so it
-  // happens in an effect and a discarded render leaves nothing behind.
-  const binding = useMemo(
-    () =>
-      createLocationBinding({
-        host: machinesProvider,
-        location: createPlatformLocation(platform),
-      }),
-    [platform],
-  );
-  useEffect(() => binding.observe(), [binding]);
-  const issues = useDataViewsValue(binding.issues);
-  return issues.length === 0 ? null : (
-    <ul className="query-issues">
-      {issues.map((issue, index) => (
-        // One parameter can be refused for several reasons.
-        <li key={`${index}:${issue.parameter}`}>{issue.reason}</li>
-      ))}
-    </ul>
-  );
-}
-```
-
-`createSourceBinding`, `createLocationBinding` and `createPlatformLocation`
-come from `@canonical/dataviews-core`. Every edit the filters make writes the
-canonical query to the location, and back, forward or a pasted URL is adopted
-by the provider — one authority, no mirroring effect. A link carrying a clause
-the grammar, the schema or the source refuses is not adopted: it stays in the
-URL and its reasons are published on `binding.issues`, for the host to show
-beside the controls. The parts read the provider either way.
+The parts have recipe pages of their own: [`Filters.mdx`](src/lib/DataViews/common/Filters/Filters.mdx), [`Actions.mdx`](src/lib/DataViews/common/Actions/Actions.mdx), [`Pagination.mdx`](src/lib/DataViews/common/Pagination/Pagination.mdx) and [`PaginationBar.mdx`](src/lib/PaginationBar/PaginationBar.mdx).
 
 ## Styles
 
-`DataTable` imports its own stylesheet, so a page that renders one has the rules it needs. A page that would rather have every rule present from the first paint — before the JavaScript of a lazily loaded route arrives — links the package's entry stylesheet instead:
+Each component imports its own stylesheet, so a page that renders one has the rules it needs. A page that would rather have every rule present from the first paint — before the JavaScript of a lazily loaded route arrives — links the package's entry stylesheet instead:
 
 ```css
 @import url("@canonical/dataviews-react/index.css");
@@ -102,6 +47,8 @@ beside the controls. The parts read the provider either way.
 The table assumes the `.app` context of `@canonical/styles`, which the page loads: render it inside an element carrying the `.app` class, where the design system's primary text takes its application sizes. It is dense wherever it sits — its root carries the design system's `.dense` class — and its rows and cells take their height and padding from the density channel that class sets; it defines no density rule of its own. Its sort chevrons and checkbox marks are `@canonical/ds-assets` icons, served at `/icons` like every other design-system icon.
 
 The sheet is in the `ds.components.global` cascade layer and reads its colours, spacing, borders and type from `@canonical/design-tokens`. The one thing it cannot carry is the column track list: the solver derives that per render from the measured container, and the table publishes the data columns' tracks on itself as `--data-table-columns` (nothing at all when it has no columns), which every row consumes after the selection column's own track. That property is the table's own channel, not a customisation hook: the table writes it after any `style` it is given.
+
+The pagination bar's selects are the design system's `SelectInput`, whose input chrome is in the `@canonical/react-ds-global-form` stylesheet: a page that renders the bar loads `@canonical/react-ds-global-form/dist/esm/index.css` beside `@canonical/styles`. The bar sticks to the bottom of whatever scrolls it. The action bar sits on the design system's contrasted surface, `.contrasted`, and paints nothing of its own.
 
 ## DataTable recipes
 

--- a/packages/react/dataviews/package.json
+++ b/packages/react/dataviews/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@canonical/dataviews-react",
-  "description": "React bindings for @canonical/dataviews-core: the DataViews root with its connected Filters and Pagination parts, provider context, the four scoped observation hooks, and the DataTable renderer",
+  "description": "React bindings for @canonical/dataviews-core: the DataViews root with its connected Filters, Actions and Pagination parts, provider context, the four scoped observation hooks, the DataTable renderer and the PaginationBar",
   "version": "0.37.0",
   "type": "module",
   "module": "dist/esm/index.js",

--- a/packages/react/dataviews/src/index.ts
+++ b/packages/react/dataviews/src/index.ts
@@ -1,8 +1,8 @@
 /**
  * @canonical/dataviews-react — React bindings for collection views: the
- * DataViews root with its connected Filters and Pagination parts, provider
- * context, the four scoped observation hooks and the DataTable renderer,
- * built on @canonical/dataviews-core.
+ * DataViews root with its connected Filters, Actions and Pagination parts,
+ * provider context, the four scoped observation hooks, the DataTable renderer
+ * and the PaginationBar, built on @canonical/dataviews-core.
  *
  * @packageDocumentation
  */

--- a/packages/react/dataviews/src/index.types.test.ts
+++ b/packages/react/dataviews/src/index.types.test.ts
@@ -10,6 +10,7 @@ import type {
 } from "@canonical/dataviews-core";
 import { describe, expectTypeOf, it } from "vitest";
 import type {
+  ActionsProps,
   CellScopeValue,
   DataTableCellProps,
   DataTableColumn,
@@ -17,6 +18,7 @@ import type {
   DataTableStatus,
   DataViewsProps,
   FiltersProps,
+  PaginationBarProps,
   PaginationProps,
   UseDataViewsCellResult,
   UseDataViewsFieldResult,
@@ -27,6 +29,7 @@ type Fields = readonly SchemaFieldDefinition[];
 
 /** Every type the package root re-exports, as one enumerable tuple. */
 type EveryPublicType = [
+  ActionsProps,
   CellScopeValue,
   DataTableCellProps,
   DataTableColumn,
@@ -34,6 +37,7 @@ type EveryPublicType = [
   DataTableStatus,
   DataViewsProps<Fields>,
   FiltersProps,
+  PaginationBarProps<Fields>,
   PaginationProps,
   UseDataViewsCellResult,
   UseDataViewsFieldResult<unknown>,
@@ -43,7 +47,26 @@ type EveryPublicType = [
 describe("public surface types", () => {
   it("re-exports the full type surface from the barrel", () => {
     expectTypeOf<EveryPublicType>().not.toBeAny();
-    expectTypeOf<EveryPublicType["length"]>().toEqualTypeOf<11>();
+    expectTypeOf<EveryPublicType["length"]>().toEqualTypeOf<13>();
+  });
+});
+
+describe("the pagination bar's props", () => {
+  it("requires the provider it pages and derives its contents", () => {
+    expectTypeOf<PaginationBarProps<Fields>>()
+      .toHaveProperty("provider")
+      .not.toBeNullable();
+    expectTypeOf<PaginationBarProps<Fields>>().not.toHaveProperty("children");
+    expectTypeOf<PaginationBarProps<Fields>>().not.toHaveProperty("role");
+    expectTypeOf<PaginationBarProps<Fields>>().not.toHaveProperty("aria-label");
+  });
+
+  it("is the connected part's props with the provider", () => {
+    // The connected part is the same bar; only its provider's source differs.
+    expectTypeOf<PaginationProps>().not.toHaveProperty("provider");
+    expectTypeOf<
+      Omit<PaginationBarProps<Fields>, "provider">
+    >().toEqualTypeOf<PaginationProps>();
   });
 });
 
@@ -64,5 +87,16 @@ describe("connected part props", () => {
     expectTypeOf<PaginationProps>().not.toHaveProperty("aria-label");
     expectTypeOf<PaginationProps>().not.toHaveProperty("aria-labelledby");
     expectTypeOf<PaginationProps>().toHaveProperty("id");
+  });
+
+  it("keeps what Actions derives out of its props", () => {
+    // Its name comes from its label and the group role is its own; its
+    // children are the caller's actions.
+    expectTypeOf<ActionsProps>().not.toHaveProperty("role");
+    expectTypeOf<ActionsProps>().not.toHaveProperty("aria-label");
+    expectTypeOf<ActionsProps>().not.toHaveProperty("aria-labelledby");
+    expectTypeOf<ActionsProps>().not.toHaveProperty("selection");
+    expectTypeOf<ActionsProps>().not.toHaveProperty("ref");
+    expectTypeOf<ActionsProps>().toHaveProperty("children");
   });
 });

--- a/packages/react/dataviews/src/lib/DataTable/DataTable.stories.tsx
+++ b/packages/react/dataviews/src/lib/DataTable/DataTable.stories.tsx
@@ -6,21 +6,22 @@ import { expect, userEvent, waitFor } from "storybook/test";
 import type {
   MachineFields,
   SortableField,
-} from "../../storybook/dataTable/fixtures.js";
+} from "../../storybook/machines/fixtures.js";
 import {
   createEmptySource,
   createFailingSource,
   createPendingSource,
-} from "../../storybook/dataTable/fixtures.js";
+} from "../../storybook/machines/fixtures.js";
 import type {
   MachineProvider,
   MachineProviderOptions,
-} from "../../storybook/dataTable/story-utils.js";
+} from "../../storybook/machines/story-utils.js";
 import {
+  hostName,
   useMachineProvider,
   withAppScope,
   withFrame,
-} from "../../storybook/dataTable/story-utils.js";
+} from "../../storybook/machines/story-utils.js";
 import useDataViewsCell from "../DataViews/hooks/useDataViewsCell.js";
 import useDataViewsValue from "../DataViews/hooks/useDataViewsValue.js";
 import Component from "./DataTable.js";
@@ -56,10 +57,6 @@ type StoryTableProps = Omit<
   DataTableProps<MachineFields, RowRecord>,
   "provider" | "columns" | "rowLabel"
 >;
-
-/** Names a record for its selection checkbox: by host, else by identity. */
-const hostName = (row: RowRecord, rowId: string): string =>
-  typeof row.name === "string" ? row.name : rowId;
 
 /** The table over a provider bound to the story's own source. */
 function MachinesTable({

--- a/packages/react/dataviews/src/lib/DataViews/DataViews.mdx
+++ b/packages/react/dataviews/src/lib/DataViews/DataViews.mdx
@@ -1,0 +1,125 @@
+import { Canvas, Meta } from "@storybook/addon-docs/blocks";
+import * as Stories from "./DataViews.stories";
+
+<Meta of={Stories} name="Recipes" />
+
+# DataViews composition recipes
+
+A `DataViews` root mounts one provider for the parts inside it. The parts read the root: they take presentation choices — a name, visible field labels, the page sizes to offer — and never a second copy of the query, the window or the selection the provider already owns. Ordinary wrappers and your own components sit between them; moving pagination means moving an element, not asking for a slot.
+
+## The connected parts
+
+Build the source and the provider once, and tell the provider what the source can execute: the filters and the table's sortable columns offer nothing beyond it, and the binding refuses a provider told anything else. Then place the parts inside the root, in any order and inside any wrapper.
+
+```tsx
+import {
+  createArraySource,
+  createDataViewsProvider,
+  createSourceBinding,
+} from "@canonical/dataviews-core";
+import {
+  DataTable,
+  DataViews,
+  type DataTableColumn,
+} from "@canonical/dataviews-react";
+import { useEffect, useState } from "react";
+import { machineSchema, machines } from "./machines.js";
+
+const columns: readonly DataTableColumn[] = [
+  { id: "name", header: "Host" },
+  { id: "status", header: "Status" },
+  { id: "cores", header: "Cores" },
+  { id: "owner", header: "Owner" },
+];
+
+export function Machines() {
+  const [source] = useState(() =>
+    createArraySource({
+      rows: machines,
+      fields: ["name", "status", "region", "cores", "owner"],
+    }),
+  );
+  const [provider] = useState(() =>
+    createDataViewsProvider({
+      schema: machineSchema,
+      capabilities: source.capabilities,
+    }),
+  );
+  useEffect(() => {
+    const binding = createSourceBinding({ host: provider, adapter: source });
+    if (provider.result.get().result.status === "idle") {
+      provider.refresh();
+    }
+    return binding.dispose;
+  }, [provider, source]);
+  return (
+    <DataViews provider={provider}>
+      <DataViews.Filters labels={{ status: "Status", cores: "Cores" }} />
+      <DataTable
+        provider={provider}
+        columns={columns}
+        label="Machines"
+        selectable
+        rowLabel={(row) => String(row.name)}
+      />
+      <DataViews.Actions />
+      <DataViews.Pagination label="Machines pagination" />
+    </DataViews>
+  );
+}
+```
+
+<Canvas of={Stories.ConnectedParts} sourceState="none" />
+
+## Keeping the query in the URL
+
+A location binding makes the URL the query's other home. Every edit the filters make writes the canonical query to the location, and back, forward or a pasted URL is adopted by the provider — one authority, no mirroring effect. A link carrying a clause the grammar, the schema or the source refuses is not adopted: it stays in the URL and its reasons are published on `binding.issues`, for the host to show beside the controls. The parts read the provider either way.
+
+`createLocationBinding` and `createPlatformLocation` come from `@canonical/dataviews-core`. The platform is your router's platform surface — anything with `getLocation`, `navigate` and `subscribe`.
+
+```tsx
+import {
+  createLocationBinding,
+  createPlatformLocation,
+  type DataViewsProvider,
+  type PlatformLocation,
+} from "@canonical/dataviews-core";
+import { useDataViewsValue } from "@canonical/dataviews-react";
+import { useEffect, useMemo } from "react";
+import { machineSchema } from "./machines.js";
+
+type MachinesProvider = DataViewsProvider<typeof machineSchema.fields>;
+
+export function MachinesUrlQuery({
+  provider,
+  platform,
+}: {
+  provider: MachinesProvider;
+  platform: PlatformLocation;
+}) {
+  // Building the binding subscribes to nothing; observing does, so it
+  // happens in an effect and a discarded render leaves nothing behind.
+  const binding = useMemo(
+    () =>
+      createLocationBinding({
+        host: provider,
+        location: createPlatformLocation(platform),
+      }),
+    [provider, platform],
+  );
+  useEffect(() => binding.observe(), [binding]);
+  const issues = useDataViewsValue(binding.issues);
+  return issues.length === 0 ? null : (
+    <ul className="query-issues">
+      {issues.map((issue, index) => (
+        // One parameter can be refused for several reasons.
+        <li key={`${index}:${issue.parameter}`}>{issue.reason}</li>
+      ))}
+    </ul>
+  );
+}
+```
+
+The story below arrives on a location carrying `status=failed`. The location wins when it carries a query, so the provider adopts it, and the filters and the table show only failed machines. It uses a memory location, so the story never rewrites this page's own address.
+
+<Canvas of={Stories.QueryInTheUrl} sourceState="none" />

--- a/packages/react/dataviews/src/lib/DataViews/DataViews.stories.tsx
+++ b/packages/react/dataviews/src/lib/DataViews/DataViews.stories.tsx
@@ -1,0 +1,242 @@
+import {
+  createLocationBinding,
+  createMemoryLocation,
+} from "@canonical/dataviews-core";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import type { ReactElement } from "react";
+import { useEffect, useMemo, useState } from "react";
+import { expect, userEvent, waitFor, within } from "storybook/test";
+import { consumerCode } from "../../storybook/machines/consumerCode.js";
+import type { MachineProvider } from "../../storybook/machines/story-utils.js";
+import {
+  hostName,
+  useMachineProvider,
+  withAppScope,
+} from "../../storybook/machines/story-utils.js";
+import DataTable from "../DataTable/DataTable.js";
+import type { DataTableColumn } from "../DataTable/types.js";
+import useDataViewsValue from "./hooks/useDataViewsValue.js";
+import Component from "./Provider.js";
+
+const meta = {
+  title: "_work_in_progress/DataViews/Composition",
+  component: Component,
+  decorators: [withAppScope],
+  argTypes: {
+    provider: { control: false },
+  },
+} satisfies Meta<typeof Component>;
+
+export default meta;
+type Story = StoryObj<typeof Component>;
+
+const columns: readonly DataTableColumn[] = [
+  { id: "name", header: "Host" },
+  { id: "status", header: "Status" },
+  { id: "cores", header: "Cores" },
+  { id: "owner", header: "Owner" },
+];
+
+const columnsCode = `const columns: readonly DataTableColumn[] = [
+  { id: "name", header: "Host" },
+  { id: "status", header: "Status" },
+  { id: "cores", header: "Cores" },
+  { id: "owner", header: "Owner" },
+];`;
+
+/** The pagination bar's summary: the filters hold status regions of their own. */
+const summary = (canvas: ReturnType<typeof within>): HTMLElement =>
+  within(canvas.getByRole("navigation", { name: "Pagination" })).getByRole(
+    "status",
+  );
+
+/** The root and its parts over one provider, as an application lays them out. */
+function Collection({
+  provider,
+  children,
+}: {
+  readonly provider: MachineProvider;
+  readonly children?: ReactElement;
+}): ReactElement {
+  return (
+    <Component provider={provider}>
+      <Component.Filters labels={{ status: "Status", cores: "Cores" }} />
+      {children}
+      <DataTable
+        provider={provider}
+        columns={columns}
+        label="Machines"
+        selectable
+        rowLabel={hostName}
+      />
+      <Component.Actions />
+      <Component.Pagination sizes={[5, 10, 25]} />
+    </Component>
+  );
+}
+
+const selectTwo = (provider: MachineProvider): void => {
+  provider.selection.add(["m-02", "m-06"]);
+};
+
+/**
+ * The connected parts: one root, and every part reading it. The filters edit
+ * the query, the table shows the rows that answer it, the action bar acts on
+ * the selection, and the pagination bar pages the window. None of them takes
+ * a copy of the query, the window or the selection.
+ */
+export const ConnectedParts: Story = {
+  parameters: consumerCode({
+    parts: ["DataTable", "DataViews", "type DataTableColumn"],
+    declarations: columnsCode,
+    window: "{ page: 1, size: 5 }",
+    prepare: `provider.selection.add(["m-02", "m-06"]);`,
+    render: `<DataViews provider={provider}>
+  <DataViews.Filters labels={{ status: "Status", cores: "Cores" }} />
+  <DataTable
+    provider={provider}
+    columns={columns}
+    label="Machines"
+    selectable
+    rowLabel={(row) => String(row.name)}
+  />
+  <DataViews.Actions />
+  <DataViews.Pagination sizes={[5, 10, 25]} />
+</DataViews>`,
+  }),
+  render: function Render() {
+    const provider = useMachineProvider({
+      window: { page: 1, size: 5 },
+      prepare: selectTwo,
+    });
+    return <Collection provider={provider} />;
+  },
+  play: async ({ canvas }) => {
+    await waitFor(() =>
+      expect(summary(canvas)).toHaveTextContent("Showing 1–5 out of 12 items"),
+    );
+    await expect(
+      canvas.getByRole("group", { name: "Selection actions" }),
+    ).toHaveTextContent("2 selected");
+  },
+};
+
+/** The query the location carries, shown the way an address bar would. */
+function QueryInTheLocation({
+  provider,
+}: {
+  readonly provider: MachineProvider;
+}): ReactElement {
+  // A memory location stands in for the browser's here, so the story never
+  // rewrites the page's own address.
+  const [location] = useState(() =>
+    createMemoryLocation({ href: "/machines?status=failed" }),
+  );
+  const binding = useMemo(
+    () => createLocationBinding({ host: provider, location }),
+    [provider, location],
+  );
+  useEffect(() => binding.observe(), [binding]);
+  const [query, setQuery] = useState(() => location.read().toString());
+  useEffect(
+    () =>
+      location.subscribe(() => {
+        setQuery(location.read().toString());
+      }),
+    [location],
+  );
+  const issues = useDataViewsValue(binding.issues);
+  return (
+    <p>
+      <output aria-label="Location">{`/machines?${query}`}</output>
+      {issues.length === 0 ? null : ` — ${issues.length} refused`}
+    </p>
+  );
+}
+
+/**
+ * The query in the URL: the location arrived carrying `status=failed`, so
+ * the provider adopted it, and running machines were then added in the
+ * filters, which wrote the query back to the location. A link carrying a
+ * clause the source refuses stays in the URL with its reasons on
+ * `binding.issues`.
+ */
+export const QueryInTheUrl: Story = {
+  parameters: {
+    docs: {
+      source: {
+        language: "tsx",
+        code: `import {
+  createLocationBinding,
+  createPlatformLocation,
+  type DataViewsProvider,
+  type PlatformLocation,
+} from "@canonical/dataviews-core";
+import { useDataViewsValue } from "@canonical/dataviews-react";
+import { useEffect, useMemo } from "react";
+import { machineSchema } from "./machines.js";
+
+type MachinesProvider = DataViewsProvider<typeof machineSchema.fields>;
+
+// Render beside the parts, inside the root, with the provider the
+// collection's root mounts and your router's platform surface.
+export function MachinesUrlQuery({
+  provider,
+  platform,
+}: {
+  provider: MachinesProvider;
+  platform: PlatformLocation;
+}) {
+  // Building the binding subscribes to nothing; observing does, so it
+  // happens in an effect and a discarded render leaves nothing behind.
+  const binding = useMemo(
+    () =>
+      createLocationBinding({
+        host: provider,
+        location: createPlatformLocation(platform),
+      }),
+    [provider, platform],
+  );
+  useEffect(() => binding.observe(), [binding]);
+  const issues = useDataViewsValue(binding.issues);
+  return issues.length === 0 ? null : (
+    <ul className="query-issues">
+      {issues.map((issue, index) => (
+        // One parameter can be refused for several reasons.
+        <li key={\`\${index}:\${issue.parameter}\`}>{issue.reason}</li>
+      ))}
+    </ul>
+  );
+}`,
+      },
+    },
+  },
+  render: function Render() {
+    const provider = useMachineProvider({ window: { page: 1, size: 5 } });
+    return (
+      <Collection provider={provider}>
+        <QueryInTheLocation provider={provider} />
+      </Collection>
+    );
+  },
+  play: async ({ canvas }) => {
+    await waitFor(() =>
+      expect(canvas.getByRole("checkbox", { name: "failed" })).toBeChecked(),
+    );
+    await waitFor(() =>
+      expect(summary(canvas)).toHaveTextContent("Showing 1–3 out of 3 items"),
+    );
+    // An edit the filters make is written back to the location.
+    await userEvent.click(canvas.getByRole("checkbox", { name: "running" }));
+    await waitFor(() =>
+      expect(canvas.getByLabelText("Location")).toHaveTextContent(
+        /status=failed.*status=running|status=running.*status=failed/,
+      ),
+    );
+    await waitFor(() =>
+      // The location carried no page size, so the default page holds all
+      // nine.
+      expect(summary(canvas)).toHaveTextContent("Showing 1–9 out of 9 items"),
+    );
+  },
+};

--- a/packages/react/dataviews/src/lib/DataViews/Provider.tsx
+++ b/packages/react/dataviews/src/lib/DataViews/Provider.tsx
@@ -6,7 +6,7 @@ import type {
 import { isIdentity } from "@canonical/dataviews-core";
 import type { ReactElement } from "react";
 import DataViewsContext from "./Context.js";
-import { Filters, Pagination } from "./common/index.js";
+import { Actions, Filters, Pagination } from "./common/index.js";
 import type { DataViewsProps } from "./types.js";
 
 /**
@@ -35,6 +35,8 @@ function DataViews<
   );
 }
 
+/** The connected action bar, over the current selection. */
+DataViews.Actions = Actions;
 /** The connected query-editing part of the composition. */
 DataViews.Filters = Filters;
 /** The connected window-navigation part of the composition. */

--- a/packages/react/dataviews/src/lib/DataViews/common/Actions/Actions.anatomy.yaml
+++ b/packages/react/dataviews/src/lib/DataViews/common/Actions/Actions.anatomy.yaml
@@ -1,0 +1,119 @@
+---
+# DataTable.ActionBar — what can be done with the current selection: how much
+# is selected, the actions that apply to it, and the way to clear it.
+#
+# Anatomy DSL 0.3.0. No validator runs on this file yet: it is checked in
+# review against the DSL's JSON schema. Pinned props on a named node
+# (`props:`) are 0.3.0's; older schemas refuse them. The root carries the
+# design-system graph's IRI. It is rendered by the connected part
+# `DataViews.Actions`, which keeps the composition's name; the graph's block
+# is the design of that part's default UI.
+#
+# Names — one per part, the same in the design, the DOM and here:
+#   action bar           design "Action bar"   graph "DataTable.ActionBar"
+#                                              DOM `ds data-table-action-bar contrasted`
+#   selection indicator  design "Selection menu"   DOM `.indicator`
+#   actions              design "Actions slot"     the part's children
+#   deselect             design "Action bar icon button"   DOM `.deselect`
+#
+# Tokens are `/`-paths over `@canonical/design-tokens` 0.10.0 ids. The
+# indicator's inset reads the `@canonical/styles` density channel
+# (`density/padding-inline`, `--density-padding-inline`), and the deselect's
+# square the density line (`density/line-height-effective`); the DSL cannot
+# name a channel, so the path does and this note records it.
+#
+# The deselect button and the actions a caller places are the design system's
+# Button. The Button reads `color/text` for its label rather than the surface
+# text channel, so on this surface the bar sets the Button's own text channel
+# (`--button-color-text`) to `--surface-color-text`. A tertiary Button's ghost
+# fill already reads the surface channel. A destructive action (the design's
+# red Delete) is the Button's `destructive` anticipation, whose ghost fill and
+# text do not read the surface channel: on this surface it paints the light
+# theme's destructive ghost fill and `color/text/destructive`, where the design
+# draws the dark theme's #f53e45 text on the bar itself. Recorded against the
+# Button, not restyled here.
+#
+# The deselect button is icon-only, and an icon-only Button collapses to its
+# icon, because the Button seats its height on a label. The bar holds it to a
+# square of the density line with its icon centred, and sets its trailing
+# padding to `dimension/100` through the Button's own padding channel, as the
+# pagination bar does its buttons. The design draws a 24×24 icon button in a
+# 36×36 frame.
+#
+# Deviations the DSL cannot express, recorded here:
+#   - The contrasted surface: the root carries `.contrasted`, from the
+#     `ds.surfaces` layer of `@canonical/styles`, and the bar reads the surface
+#     channel it sets — `--surface-color-background` and `--surface-color-text`,
+#     falling back to `color/background` and `color/text`. In the light theme
+#     they resolve to `color/background/contrasted` and
+#     `color/text/contrasted`. The design binds the dark theme's values
+#     instead (`color/foreground/ghost/layer2` #131313, `color/text` #ffffff),
+#     the same polarity. The bar has no token of its own.
+#   - The bar is absent while nothing is selected; conditional display is
+#     deferred in the DSL. The design has it overlay the footer; placing it
+#     is the composition's, not the part's.
+#   - The design's selection indicator is a menu opening the persistent
+#     selection panel ("Current selection menu", hidden). The panel is a
+#     follow-up part, and a portal, which the DSL defers. Until it ships the
+#     indicator is the count; a caller may replace it.
+#   - The design's actions are ghost text buttons, the last with an icon; the
+#     graph allows at most seven. The part renders what it is given.
+#
+# States:
+#   - The indicator's count changes with the selection's size.
+#   - The deselect button's hover, active and focus states are the Button's
+#     own.
+#
+# Accessibility (DataViews component coverage):
+#   action bar, actions  "Actions/confirmation/outcome" (2.1.1, 2.4.3, 3.3.4,
+#                        4.1.2-4.1.3). The bar is a named group. Each action
+#                        reads the selection when activated, so its targets
+#                        are the ones selected at that moment. When the bar
+#                        leaves with the focus inside it, the focus returns to
+#                        the control it entered the bar from.
+#   selection indicator  "Summary" (1.3.1, 4.1.3): a polite status counting
+#                        the whole selection, across pages, not the rows on
+#                        screen. It mounts with the bar, so its first count is
+#                        not announced; the checkbox that made it announces its
+#                        own state.
+#   deselect             "Row/select-all checkboxes" (4.1.2): named with the
+#                        count it clears ("Deselect 5 items").
+node:
+  uri: apps.subcomponent.data_table-action_bar
+  styles:
+    layout.type: stack
+    layout.direction: row
+    layout.align: center
+    typography.color: color/text
+    typography.family: typography/text/primary/font-family
+    typography.size: typography/text/primary/font-size
+    typography.weight: typography/text/primary/font-weight
+    appearance.background: color/background
+  edges:
+    # The count by default; a caller's own indicator replaces it.
+    - switch:
+        "on": override
+        cases:
+          - node:
+              role: selection indicator
+              styles:
+                spacing.internal.inline: density/padding-inline
+          - uri: $custom
+      relation:
+        cardinality: "1"
+        slotName: indicator
+    - uri: global.component.button
+      relation:
+        cardinality: "0..*"
+        slotName: default
+    - node:
+        uri: global.component.button
+        props:
+          importance: tertiary
+          icon: close
+        styles:
+          size.min.width: density/line-height-effective
+          size.min.height: density/line-height-effective
+      relation:
+        cardinality: "1"
+        slotName: deselect

--- a/packages/react/dataviews/src/lib/DataViews/common/Actions/Actions.mdx
+++ b/packages/react/dataviews/src/lib/DataViews/common/Actions/Actions.mdx
@@ -1,0 +1,162 @@
+import { Canvas, Meta } from "@storybook/addon-docs/blocks";
+import * as Stories from "./Actions.stories";
+
+<Meta of={Stories} name="Recipes" />
+
+# DataViews.Actions recipes
+
+`DataViews.Actions` is the action bar: how much is selected, the actions that apply to it, and a button that clears it. It reads the enclosing root's selection and takes no copy of it, and it is absent while nothing is selected.
+
+It renders on the design system's contrasted surface — its root carries `.contrasted`, from `@canonical/styles` — so it paints no colour of its own. Place it in the collection's footer beside the pagination bar.
+
+## Actions over the selection
+
+The actions are your own components, placed as children. Each reads the selection when it is pressed, through `useDataViews`, and runs through the source binding: `binding.runAction(action, targets)` captures those targets, calls the source's `runAction`, and removes the targets that succeed from the selection. A failed target stays selected, for review and retry.
+
+A destructive action is the design system's `Button` with `anticipation="destructive"`.
+
+```tsx
+import {
+  createArraySource,
+  createDataViewsProvider,
+  createSourceBinding,
+  type DataViewsProvider,
+  type SourceBinding,
+} from "@canonical/dataviews-core";
+import {
+  DataTable,
+  DataViews,
+  type DataTableColumn,
+  useDataViews,
+} from "@canonical/dataviews-react";
+import { Button, type ButtonProps } from "@canonical/react-ds-global";
+import { useEffect, useState } from "react";
+import { archiveMachines, machineSchema, machines } from "./machines.js";
+
+type MachinesProvider = DataViewsProvider<typeof machineSchema.fields>;
+
+const columns: readonly DataTableColumn[] = [
+  { id: "name", header: "Host" },
+  { id: "status", header: "Status" },
+  { id: "owner", header: "Owner" },
+];
+
+function SelectionAction({
+  provider,
+  binding,
+  action,
+  ...button
+}: Omit<ButtonProps, "onClick"> & {
+  provider: MachinesProvider;
+  binding: SourceBinding | null;
+  action: string;
+}) {
+  const { selection } = useDataViews(provider);
+  return (
+    <Button
+      {...button}
+      type="button"
+      importance="tertiary"
+      disabled={binding === null}
+      onClick={() => {
+        void binding?.runAction(action, [...selection.state.ids]);
+      }}
+    />
+  );
+}
+
+export function Machines() {
+  const [source] = useState(() =>
+    createArraySource({
+      rows: machines,
+      fields: ["name", "status", "region", "cores", "owner"],
+      // Resolves with one outcome per target: { target, status }.
+      runAction: ({ action, targets }) => archiveMachines(action, targets),
+    }),
+  );
+  const [provider] = useState(() =>
+    createDataViewsProvider({
+      schema: machineSchema,
+      capabilities: source.capabilities,
+      window: { page: 1, size: 5 },
+    }),
+  );
+  const [binding, setBinding] = useState<SourceBinding | null>(null);
+  useEffect(() => {
+    const bound = createSourceBinding({ host: provider, adapter: source });
+    setBinding(bound);
+    if (provider.result.get().result.status === "idle") {
+      provider.refresh();
+    }
+    return () => {
+      bound.dispose();
+      setBinding(null);
+    };
+  }, [provider, source]);
+  return (
+    <DataViews provider={provider}>
+      <DataTable
+        provider={provider}
+        columns={columns}
+        label="Machines"
+        selectable
+        rowLabel={(row) => String(row.name)}
+      />
+      <DataViews.Actions>
+        <SelectionAction provider={provider} binding={binding} action="archive">
+          Archive
+        </SelectionAction>
+        <SelectionAction
+          provider={provider}
+          binding={binding}
+          action="delete"
+          anticipation="destructive"
+          icon="delete"
+        >
+          Delete
+        </SelectionAction>
+      </DataViews.Actions>
+      <DataViews.Pagination sizes={[5, 10]} />
+    </DataViews>
+  );
+}
+```
+
+<Canvas of={Stories.TwoSelected} sourceState="none" />
+
+Nothing selected, no bar:
+
+<Canvas of={Stories.NothingSelected} sourceState="none" />
+
+## The whole selection
+
+The count is the selection's, across pages — not the rows on screen — and an action acts on every selected target. The deselect button is named with what it clears ("Deselect 2 items").
+
+<Canvas of={Stories.SelectedAcrossPages} sourceState="none" />
+
+When an action succeeds for every target, the targets leave the selection, and with nothing left selected the bar goes too. If the focus was inside it, the focus returns to the control it entered the bar from — the last row checkbox, typically — rather than to the document.
+
+<Canvas of={Stories.Archived} sourceState="none" />
+
+## Your own indicator
+
+`indicator` replaces the count; `null` shows none. A replacement reads the selection itself, through `useDataViews`, and owns its own announcement: the default count is a polite status, so give yours `role="status"` if it stands in for it, and the class `indicator` to take the default's inset. When the persistent selection panel ships, its trigger takes this place.
+
+```tsx
+function MachinesSelected({ provider }: { provider: MachinesProvider }) {
+  const { selection } = useDataViews(provider);
+  const read = () => selection.state.ids.size;
+  const count = useSyncExternalStore(selection.subscribe, read, read);
+  return (
+    <span role="status" className="indicator">
+      {`${count} ${count === 1 ? "machine" : "machines"} selected`}
+    </span>
+  );
+}
+
+<DataViews.Actions indicator={<MachinesSelected provider={provider} />}>
+  {/* the actions */}
+</DataViews.Actions>;
+```
+
+<Canvas of={Stories.CustomIndicator} sourceState="none" />

--- a/packages/react/dataviews/src/lib/DataViews/common/Actions/Actions.stories.tsx
+++ b/packages/react/dataviews/src/lib/DataViews/common/Actions/Actions.stories.tsx
@@ -1,0 +1,377 @@
+import type { RowRecord, SourceBinding } from "@canonical/dataviews-core";
+import {
+  createArraySource,
+  createDataViewsProvider,
+  createSourceBinding,
+} from "@canonical/dataviews-core";
+import type { ButtonProps } from "@canonical/react-ds-global";
+import { Button } from "@canonical/react-ds-global";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import type { ReactElement, ReactNode } from "react";
+import { useEffect, useState, useSyncExternalStore } from "react";
+import { expect, userEvent, waitFor, within } from "storybook/test";
+import { consumerCode } from "../../../../storybook/machines/consumerCode.js";
+import type { MachineFields } from "../../../../storybook/machines/fixtures.js";
+import {
+  machineSchema,
+  machines,
+} from "../../../../storybook/machines/fixtures.js";
+import type { MachineProvider } from "../../../../storybook/machines/story-utils.js";
+import {
+  hostName,
+  withAppScope,
+} from "../../../../storybook/machines/story-utils.js";
+import DataTable from "../../../DataTable/DataTable.js";
+import type { DataTableColumn } from "../../../DataTable/types.js";
+import useDataViews from "../../hooks/useDataViews.js";
+import DataViews from "../../Provider.js";
+import Pagination from "../Pagination/Pagination.js";
+import Component from "./Actions.js";
+
+const meta = {
+  title: "_work_in_progress/DataViews/Actions",
+  component: Component,
+  decorators: [withAppScope],
+} satisfies Meta<typeof Component>;
+
+export default meta;
+type Story = StoryObj<typeof Component>;
+
+const columns: readonly DataTableColumn[] = [
+  { id: "name", header: "Host" },
+  { id: "status", header: "Status" },
+  { id: "owner", header: "Owner" },
+];
+
+/**
+ * One action over the selection: it reads the selection when pressed and
+ * runs through the source binding, which captures those targets and removes
+ * the ones that succeed from the selection.
+ */
+function SelectionAction({
+  provider,
+  binding,
+  action,
+  ...button
+}: Omit<ButtonProps, "onClick"> & {
+  readonly provider: MachineProvider;
+  readonly binding: SourceBinding | null;
+  readonly action: string;
+}): ReactElement {
+  const { selection } = useDataViews(provider);
+  return (
+    <Button
+      {...button}
+      type="button"
+      importance="tertiary"
+      disabled={binding === null}
+      onClick={() => {
+        void binding?.runAction(action, [...selection.state.ids]);
+      }}
+    />
+  );
+}
+
+/**
+ * The machines over a source that can archive and delete them, five to a
+ * page, with the table, the action bar and the pagination bar.
+ */
+function ManagedMachines({
+  select = [],
+  indicator,
+}: {
+  readonly select?: readonly string[];
+  readonly indicator?: (provider: MachineProvider) => ReactNode;
+}): ReactElement {
+  const [source] = useState(() => {
+    let remaining: readonly RowRecord[] = machines;
+    const managed = createArraySource({
+      rows: remaining,
+      fields: ["name", "status", "region", "cores", "owner"],
+      // Both actions take the machines out of the collection.
+      runAction: async ({ targets }) => {
+        remaining = remaining.filter(
+          (row) => !targets.includes(String(row.id)),
+        );
+        managed.setRows(remaining);
+        return targets.map((target) => ({
+          target,
+          status: "success" as const,
+        }));
+      },
+    });
+    return managed;
+  });
+  const [provider] = useState(() =>
+    createDataViewsProvider<MachineFields>({
+      schema: machineSchema,
+      capabilities: source.capabilities,
+      window: { page: 1, size: 5 },
+    }),
+  );
+  const [initial] = useState(select);
+  const [binding, setBinding] = useState<SourceBinding | null>(null);
+  useEffect(() => {
+    const bound = createSourceBinding({ host: provider, adapter: source });
+    setBinding(bound);
+    provider.selection.add(initial);
+    if (provider.result.get().result.status === "idle") {
+      provider.refresh();
+    }
+    return () => {
+      bound.dispose();
+      setBinding(null);
+    };
+  }, [provider, source, initial]);
+  return (
+    <DataViews provider={provider}>
+      <DataTable
+        provider={provider}
+        columns={columns}
+        label="Machines"
+        selectable
+        rowLabel={hostName}
+      />
+      <Component indicator={indicator?.(provider)}>
+        <SelectionAction provider={provider} binding={binding} action="archive">
+          Archive
+        </SelectionAction>
+        <SelectionAction
+          provider={provider}
+          binding={binding}
+          action="delete"
+          anticipation="destructive"
+          icon="delete"
+        >
+          Delete
+        </SelectionAction>
+      </Component>
+      <Pagination sizes={[5, 10]} />
+    </DataViews>
+  );
+}
+
+const selectionActionCode = `type MachinesProvider = DataViewsProvider<typeof machineSchema.fields>;
+
+const columns: readonly DataTableColumn[] = [
+  { id: "name", header: "Host" },
+  { id: "status", header: "Status" },
+  { id: "owner", header: "Owner" },
+];
+
+// Reads the selection when pressed; the binding captures those targets,
+// runs the source's action and removes the ones that succeed.
+function SelectionAction({
+  provider,
+  binding,
+  action,
+  ...button
+}: Omit<ButtonProps, "onClick"> & {
+  provider: MachinesProvider;
+  binding: SourceBinding | null;
+  action: string;
+}) {
+  const { selection } = useDataViews(provider);
+  return (
+    <Button
+      {...button}
+      type="button"
+      importance="tertiary"
+      disabled={binding === null}
+      onClick={() => {
+        void binding?.runAction(action, [...selection.state.ids]);
+      }}
+    />
+  );
+}`;
+
+/** A story's consumer code: the collection, its action bar and its actions. */
+const actionsCode = ({
+  prepare,
+  indicator = "",
+  declarations = "",
+  hooks = [],
+}: {
+  readonly prepare?: string;
+  readonly indicator?: string;
+  readonly declarations?: string;
+  readonly hooks?: readonly string[];
+} = {}) =>
+  consumerCode({
+    parts: ["DataTable", "DataViews", "type DataTableColumn", "useDataViews"],
+    coreTypes: ["DataViewsProvider"],
+    imports: `import { Button, type ButtonProps } from "@canonical/react-ds-global";
+import { archiveMachines, machineSchema, machines } from "./machines.js";`,
+    hooks,
+    declarations: `${selectionActionCode}${declarations}`,
+    source: `createArraySource({
+      rows: machines,
+      fields: ["name", "status", "region", "cores", "owner"],
+      // Resolves with one outcome per target: { target, status }.
+      runAction: ({ action, targets }) => archiveMachines(action, targets),
+    })`,
+    window: "{ page: 1, size: 5 }",
+    prepare,
+    keepsBinding: true,
+    render: `<DataViews provider={provider}>
+  <DataTable
+    provider={provider}
+    columns={columns}
+    label="Machines"
+    selectable
+    rowLabel={(row) => String(row.name)}
+  />
+  <DataViews.Actions${indicator}>
+    <SelectionAction provider={provider} binding={binding} action="archive">
+      Archive
+    </SelectionAction>
+    <SelectionAction
+      provider={provider}
+      binding={binding}
+      action="delete"
+      anticipation="destructive"
+      icon="delete"
+    >
+      Delete
+    </SelectionAction>
+  </DataViews.Actions>
+  <DataViews.Pagination sizes={[5, 10]} />
+</DataViews>`,
+  });
+
+const selectTwo = `provider.selection.add(["m-02", "m-06"]);`;
+
+/**
+ * Nothing selected: the table and the pagination bar, and no action bar. It
+ * appears with the first selection.
+ */
+export const NothingSelected: Story = {
+  parameters: actionsCode(),
+  render: () => <ManagedMachines />,
+  play: async ({ canvas }) => {
+    await waitFor(() =>
+      expect(canvas.getByRole("status")).toHaveTextContent(
+        "Showing 1–5 out of 12 items",
+      ),
+    );
+    await expect(canvas.queryByRole("group")).toBeNull();
+  },
+};
+
+/**
+ * Two selected: the bar counts them, offers the actions placed in it — a
+ * destructive one in the Button's destructive colour — and a deselect named
+ * with what it clears. It renders on the design system's contrasted surface.
+ */
+export const TwoSelected: Story = {
+  parameters: actionsCode({ prepare: selectTwo }),
+  render: () => <ManagedMachines select={["m-02", "m-06"]} />,
+  play: async ({ canvas }) => {
+    const bar = await canvas.findByRole("group", { name: "Selection actions" });
+    await expect(bar).toHaveTextContent("2 selected");
+    await expect(
+      canvas.getByRole("button", { name: "Deselect 2 items" }),
+    ).toBeEnabled();
+    await waitFor(() =>
+      expect(canvas.getByRole("button", { name: "Archive" })).toBeEnabled(),
+    );
+  },
+};
+
+/**
+ * Selected across pages: birch is on this page and ironwood on the second.
+ * The count is the whole selection, not the rows on screen.
+ */
+export const SelectedAcrossPages: Story = {
+  parameters: actionsCode({
+    prepare: `provider.selection.add(["m-02", "m-09"]);`,
+  }),
+  render: () => <ManagedMachines select={["m-02", "m-09"]} />,
+  play: async ({ canvas }) => {
+    await expect(
+      await canvas.findByRole("checkbox", { name: "Select birch.example.com" }),
+    ).toBeChecked();
+    await expect(
+      canvas.getByRole("group", { name: "Selection actions" }),
+    ).toHaveTextContent("2 selected");
+  },
+};
+
+/** A count that names what is selected, following the selection. */
+function MachinesSelected({
+  provider,
+}: {
+  readonly provider: MachineProvider;
+}): ReactElement {
+  const { selection } = useDataViews(provider);
+  const read = () => selection.state.ids.size;
+  const count = useSyncExternalStore(selection.subscribe, read, read);
+  return (
+    <span role="status" className="indicator">
+      {`${count} ${count === 1 ? "machine" : "machines"} selected`}
+    </span>
+  );
+}
+
+const machinesSelectedCode = `
+
+// Follows the selection, and announces it as the default count does.
+function MachinesSelected({ provider }: { provider: MachinesProvider }) {
+  const { selection } = useDataViews(provider);
+  const read = () => selection.state.ids.size;
+  const count = useSyncExternalStore(selection.subscribe, read, read);
+  return (
+    <span role="status" className="indicator">
+      {\`\${count} \${count === 1 ? "machine" : "machines"} selected\`}
+    </span>
+  );
+}`;
+
+/**
+ * A caller's indicator: a count that names what is selected. It reads the
+ * selection itself, and announces it as the default count does. When the
+ * persistent selection panel ships, its trigger takes this place.
+ */
+export const CustomIndicator: Story = {
+  parameters: actionsCode({
+    prepare: selectTwo,
+    indicator: " indicator={<MachinesSelected provider={provider} />}",
+    declarations: machinesSelectedCode,
+    hooks: ["useSyncExternalStore"],
+  }),
+  render: () => (
+    <ManagedMachines
+      select={["m-02", "m-06"]}
+      indicator={(provider) => <MachinesSelected provider={provider} />}
+    />
+  ),
+  play: async ({ canvas }) => {
+    const bar = await canvas.findByRole("group", {
+      name: "Selection actions",
+    });
+    await expect(within(bar).getByRole("status")).toHaveTextContent(
+      "2 machines selected",
+    );
+  },
+};
+
+/**
+ * Archived: two machines were selected and Archive was pressed. The source
+ * archived both, they left the collection and the selection, and with nothing
+ * left selected the bar went with them. Ten machines remain.
+ */
+export const Archived: Story = {
+  parameters: actionsCode({ prepare: selectTwo }),
+  render: () => <ManagedMachines select={["m-02", "m-06"]} />,
+  play: async ({ canvas }) => {
+    const archive = await canvas.findByRole("button", { name: "Archive" });
+    await waitFor(() => expect(archive).toBeEnabled());
+    await userEvent.click(archive);
+    await waitFor(() => expect(canvas.queryByRole("group")).toBeNull());
+    await waitFor(() =>
+      expect(canvas.getByRole("status")).toHaveTextContent(
+        "Showing 1–5 out of 10 items",
+      ),
+    );
+  },
+};

--- a/packages/react/dataviews/src/lib/DataViews/common/Actions/Actions.test.tsx
+++ b/packages/react/dataviews/src/lib/DataViews/common/Actions/Actions.test.tsx
@@ -1,0 +1,283 @@
+/**
+ * The connected action bar: it reads the root's selection, shows only while
+ * something is selected, and clears it.
+ */
+import type { DataViewsProvider } from "@canonical/dataviews-core";
+import {
+  createDataViewsProvider,
+  createSchema,
+} from "@canonical/dataviews-core";
+import { act, fireEvent, render, screen, within } from "@testing-library/react";
+import { StrictMode } from "react";
+import { describe, expect, it, vi } from "vitest";
+import DataViews from "../../Provider.js";
+import Actions from "./Actions.js";
+import type { ActionsProps } from "./types.js";
+
+const schema = createSchema([
+  { field: "status", kind: "choices", options: ["failed", "ready"] },
+]);
+
+type Fields = typeof schema.fields;
+
+const makeProvider = (): DataViewsProvider<Fields> =>
+  createDataViewsProvider<Fields>({ schema });
+
+const mount = (provider: DataViewsProvider<Fields>, props: ActionsProps = {}) =>
+  render(
+    <DataViews provider={provider}>
+      <Actions {...props} />
+    </DataViews>,
+  );
+
+const select = (provider: DataViewsProvider<Fields>, ids: string[]): void => {
+  act(() => {
+    provider.selection.add(ids);
+  });
+};
+
+const bar = () => screen.getByRole("group", { name: "Selection actions" });
+
+describe("DataViews.Actions", () => {
+  it("is reachable as the composition's Actions part", () => {
+    expect(DataViews.Actions).toBe(Actions);
+  });
+
+  it("fails clearly outside a DataViews root", () => {
+    expect(() => render(<Actions />)).toThrow(
+      "DataViews.Actions must be used inside a DataViews root",
+    );
+  });
+
+  it("is absent while nothing is selected", () => {
+    const provider = makeProvider();
+    const { container } = mount(provider);
+    expect(container).toBeEmptyDOMElement();
+    select(provider, ["m1"]);
+    expect(bar()).toBeInTheDocument();
+  });
+
+  it("counts the whole selection and names the deselect by it", () => {
+    const provider = makeProvider();
+    mount(provider);
+    // Selected rows need not be on screen: the count is the selection's.
+    select(provider, ["m1", "m9"]);
+    expect(bar()).toHaveTextContent("2 selected");
+    expect(
+      screen.getByRole("button", { name: "Deselect 2 items" }),
+    ).toBeInTheDocument();
+    act(() => {
+      provider.selection.remove(["m9"]);
+    });
+    expect(bar()).toHaveTextContent("1 selected");
+    expect(
+      screen.getByRole("button", { name: "Deselect 1 item" }),
+    ).toBeInTheDocument();
+  });
+
+  it("clears the selection, and leaves", () => {
+    const provider = makeProvider();
+    mount(provider);
+    select(provider, ["m1", "m2"]);
+    fireEvent.click(screen.getByRole("button", { name: "Deselect 2 items" }));
+    expect(provider.selection.state.ids.size).toBe(0);
+    expect(screen.queryByRole("group")).toBeNull();
+  });
+
+  it("places the caller's actions between the indicator and the deselect", () => {
+    const provider = makeProvider();
+    mount(provider, {
+      children: (
+        <button type="button" className="export">
+          Export
+        </button>
+      ),
+    });
+    select(provider, ["m1"]);
+    expect([...bar().children]).toEqual([
+      within(bar()).getByRole("status"),
+      screen.getByRole("button", { name: "Export" }),
+      screen.getByRole("button", { name: "Deselect 1 item" }),
+    ]);
+  });
+
+  it("takes a caller's indicator, or none", () => {
+    const provider = makeProvider();
+    const { rerender } = mount(provider, {
+      indicator: <button type="button">Review selection</button>,
+    });
+    select(provider, ["m1"]);
+    expect(
+      screen.getByRole("button", { name: "Review selection" }),
+    ).toBeInTheDocument();
+    expect(bar()).not.toHaveTextContent("1 selected");
+    rerender(
+      <DataViews provider={provider}>
+        <Actions indicator={null} />
+      </DataViews>,
+    );
+    expect(within(bar()).queryByRole("status")).toBeNull();
+  });
+
+  it("sits on the contrasted surface, and passes native props through", () => {
+    const provider = makeProvider();
+    mount(provider, {
+      label: "Machine actions",
+      className: "footer",
+      id: "machine-actions",
+    });
+    select(provider, ["m1"]);
+    const group = screen.getByRole("group", { name: "Machine actions" });
+    expect(group).toHaveClass(
+      "ds",
+      "data-table-action-bar",
+      "contrasted",
+      "footer",
+    );
+    expect(group).toHaveAttribute("id", "machine-actions");
+  });
+
+  it("announces the count as a status", () => {
+    const provider = makeProvider();
+    mount(provider);
+    select(provider, ["m1", "m2"]);
+    expect(within(bar()).getByRole("status")).toHaveTextContent("2 selected");
+  });
+
+  it("returns focus to where it entered the bar from when the bar leaves", () => {
+    const provider = makeProvider();
+    render(
+      <DataViews provider={provider}>
+        <button type="button">Before</button>
+        <Actions>
+          <button type="button">Archive</button>
+        </Actions>
+      </DataViews>,
+    );
+    select(provider, ["m1"]);
+    const before = screen.getByRole("button", { name: "Before" });
+    before.focus();
+    screen.getByRole("button", { name: "Archive" }).focus();
+    // Moving within the bar keeps where the focus came from.
+    const deselect = screen.getByRole("button", { name: "Deselect 1 item" });
+    deselect.focus();
+    fireEvent.click(deselect);
+    expect(before).toHaveFocus();
+  });
+
+  it("has nowhere to return focus that entered from the document", () => {
+    const provider = makeProvider();
+    mount(provider);
+    select(provider, ["m1"]);
+    const deselect = screen.getByRole("button", { name: "Deselect 1 item" });
+    deselect.focus();
+    deselect.blur();
+    deselect.focus();
+    fireEvent.click(deselect);
+    expect(document.body).toHaveFocus();
+  });
+
+  it("leaves focus alone once it has left the bar", () => {
+    const provider = makeProvider();
+    render(
+      <DataViews provider={provider}>
+        <button type="button">Before</button>
+        <button type="button">Elsewhere</button>
+        <Actions />
+      </DataViews>,
+    );
+    select(provider, ["m1"]);
+    screen.getByRole("button", { name: "Before" }).focus();
+    screen.getByRole("button", { name: "Deselect 1 item" }).focus();
+    const elsewhere = screen.getByRole("button", { name: "Elsewhere" });
+    elsewhere.focus();
+    act(() => {
+      provider.selection.clear();
+    });
+    expect(elsewhere).toHaveFocus();
+  });
+
+  it("calls the caller's focus handlers beside its own", () => {
+    const provider = makeProvider();
+    const onFocus = vi.fn();
+    const onBlur = vi.fn();
+    render(
+      <DataViews provider={provider}>
+        <button type="button">Before</button>
+        <Actions onFocus={onFocus} onBlur={onBlur}>
+          <button type="button">Export</button>
+        </Actions>
+      </DataViews>,
+    );
+    select(provider, ["m1"]);
+    const before = screen.getByRole("button", { name: "Before" });
+    before.focus();
+    screen.getByRole("button", { name: "Export" }).focus();
+    const deselect = screen.getByRole("button", { name: "Deselect 1 item" });
+    deselect.focus();
+    expect(onFocus).toHaveBeenCalledWith(
+      expect.objectContaining({ type: "focus" }),
+    );
+    expect(onBlur).toHaveBeenCalledTimes(1);
+    // Its own handler still ran: the focus still goes back.
+    fireEvent.click(deselect);
+    expect(before).toHaveFocus();
+  });
+
+  it("returns no focus once it has left for the document", () => {
+    const provider = makeProvider();
+    render(
+      <DataViews provider={provider}>
+        <button type="button">Before</button>
+        <Actions />
+      </DataViews>,
+    );
+    select(provider, ["m1"]);
+    const before = screen.getByRole("button", { name: "Before" });
+    before.focus();
+    const deselect = screen.getByRole("button", { name: "Deselect 1 item" });
+    deselect.focus();
+    deselect.blur();
+    act(() => {
+      provider.selection.clear();
+    });
+    expect(before).not.toHaveFocus();
+  });
+
+  it("forgets where focus came from once it next enters from the document", () => {
+    const provider = makeProvider();
+    render(
+      <DataViews provider={provider}>
+        <button type="button">Before</button>
+        <Actions />
+      </DataViews>,
+    );
+    select(provider, ["m1"]);
+    const before = screen.getByRole("button", { name: "Before" });
+    before.focus();
+    screen.getByRole("button", { name: "Deselect 1 item" }).focus();
+    fireEvent.click(screen.getByRole("button", { name: "Deselect 1 item" }));
+    expect(before).toHaveFocus();
+    select(provider, ["m2"]);
+    // Focus enters again from the document: the earlier origin is not reused.
+    before.blur();
+    screen.getByRole("button", { name: "Deselect 1 item" }).focus();
+    act(() => {
+      provider.selection.clear();
+    });
+    expect(document.body).toHaveFocus();
+  });
+
+  it("follows the selection under StrictMode", () => {
+    const provider = makeProvider();
+    render(
+      <StrictMode>
+        <DataViews provider={provider}>
+          <Actions />
+        </DataViews>
+      </StrictMode>,
+    );
+    select(provider, ["m1", "m2", "m3"]);
+    expect(bar()).toHaveTextContent("3 selected");
+  });
+});

--- a/packages/react/dataviews/src/lib/DataViews/common/Actions/Actions.tsx
+++ b/packages/react/dataviews/src/lib/DataViews/common/Actions/Actions.tsx
@@ -1,0 +1,99 @@
+import { Button } from "@canonical/react-ds-global";
+import type { ReactElement } from "react";
+import { useCallback, useContext, useRef } from "react";
+import DataViewsContext from "../../Context.js";
+import useDataViewsState from "../../hooks/useDataViewsState.js";
+import plural from "../../plural.js";
+import type { ActionsProps } from "./types.js";
+import "./styles.css";
+
+/**
+ * `contrasted` is the design system's contrasted surface: it sets the
+ * surface channel the stylesheet reads, so the bar needs no colour of its
+ * own.
+ */
+const componentCssClassName = "ds data-table-action-bar contrasted";
+
+/**
+ * What can be done with the current selection: how much is selected, the
+ * actions a caller places, and a button that clears it.
+ *
+ * The bar reads the enclosing root's selection and takes no copy of it. It
+ * is absent while nothing is selected. The count is the whole selection,
+ * across pages, not the rows on screen.
+ *
+ * When the bar leaves with the focus inside it — the selection cleared, or
+ * every target of an action succeeded — the focus returns to the control it
+ * entered the bar from, rather than to the document.
+ *
+ * @implements ds:apps.subcomponent.data_table-action_bar
+ */
+export default function Actions({
+  label = "Selection actions",
+  indicator,
+  children,
+  className,
+  onFocus,
+  ...rest
+}: ActionsProps): ReactElement | null {
+  const provider = useContext(DataViewsContext);
+  if (provider === null) {
+    throw new Error("DataViews.Actions must be used inside a DataViews root");
+  }
+  const { selection } = provider;
+  const count = useDataViewsState(selection).ids.size;
+
+  // Where focus entered the bar from. React releases the bar's ref before
+  // it removes the bar, so a bar leaving with the focus inside it can still
+  // find the focus there and hand it back.
+  const origin = useRef<HTMLElement | null>(null);
+  const returnFocus = useCallback(
+    (bar: HTMLDivElement) => () => {
+      if (
+        bar.contains(bar.ownerDocument.activeElement) &&
+        origin.current?.isConnected
+      ) {
+        origin.current.focus();
+      }
+    },
+    [],
+  );
+
+  if (count === 0) {
+    return null;
+  }
+  return (
+    // biome-ignore lint/a11y/useSemanticElements: a fieldset groups form controls under a legend; this groups commands under the name its label gives it
+    <div
+      {...rest}
+      ref={returnFocus}
+      role="group"
+      aria-label={label}
+      className={[componentCssClassName, className].filter(Boolean).join(" ")}
+      onFocus={(event) => {
+        const from = event.relatedTarget;
+        if (!event.currentTarget.contains(from)) {
+          origin.current = from instanceof HTMLElement ? from : null;
+        }
+        onFocus?.(event);
+      }}
+    >
+      {indicator === undefined ? (
+        <span role="status" className="indicator">{`${count} selected`}</span>
+      ) : (
+        indicator
+      )}
+      {children}
+      <Button
+        type="button"
+        importance="tertiary"
+        icon="close"
+        className="deselect"
+        aria-label={`Deselect ${count} ${plural(count, "item")}`}
+        onClick={() => {
+          selection.clear();
+        }}
+      />
+    </div>
+  );
+}

--- a/packages/react/dataviews/src/lib/DataViews/common/Actions/index.ts
+++ b/packages/react/dataviews/src/lib/DataViews/common/Actions/index.ts
@@ -1,0 +1,2 @@
+export { default as Actions } from "./Actions.js";
+export type * from "./types.js";

--- a/packages/react/dataviews/src/lib/DataViews/common/Actions/styles.css
+++ b/packages/react/dataviews/src/lib/DataViews/common/Actions/styles.css
@@ -1,0 +1,42 @@
+/* Layer: ds.components.global (@canonical/styles README, "Cascade layers"). */
+
+@layer ds.components.global {
+  /**
+   * Actions styles
+   *
+   * The specification is the anatomy beside the code, `Actions.anatomy.yaml`.
+   * Every value below is one it binds; what it could not bind is recorded
+   * there, never hardcoded here.
+   *
+   * The bar sits on the design system's contrasted surface: its root carries
+   * `.contrasted`, which sets the surface channel read here, so no colour
+   * below is the bar's own.
+   */
+  .ds.data-table-action-bar {
+    display: inline-flex;
+    align-items: center;
+    color: var(--surface-color-text, var(--color-text));
+    font-family: var(--typography-text-primary-font-family);
+    font-size: var(--typography-text-primary-font-size);
+    font-weight: var(--typography-text-primary-font-weight);
+    background-color: var(--surface-color-background, var(--color-background));
+    /* The Button reads the page's text colour for its label, not the
+       surface's; its own text channel carries the surface's to it. */
+    --button-color-text: var(--surface-color-text, var(--color-text));
+
+    & > .indicator {
+      padding-inline: var(--density-padding-inline);
+      white-space: nowrap;
+    }
+
+    /* An icon-only Button collapses without a label: held to a square one
+       row tall, its icon centred and its side padding equal. */
+    & > .ds.button.deselect {
+      --button-padding-inline-end: var(--dimension-100);
+      min-block-size: var(--density-line-height-effective);
+      min-inline-size: var(--density-line-height-effective);
+      align-items: center;
+      justify-content: center;
+    }
+  }
+}

--- a/packages/react/dataviews/src/lib/DataViews/common/Actions/styles.test.tsx
+++ b/packages/react/dataviews/src/lib/DataViews/common/Actions/styles.test.tsx
@@ -1,0 +1,177 @@
+/**
+ * The stylesheet's contract with the markup, and the anatomy's with the DOM.
+ * jsdom applies no CSS, so what is pinned is what a stylesheet change can
+ * break with every render still green: each class the sheet styles is one the
+ * bar renders, the structure its combinators assume is the one it renders,
+ * every value is a token or a channel, and the declarations whose loss no
+ * render would show are still declared.
+ *
+ * The anatomy beside the code states the DOM each part renders; the same
+ * renders pin that it still does. This reads the anatomy's notes, not its
+ * structure: it is no validator.
+ */
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  createDataViewsProvider,
+  createSchema,
+} from "@canonical/dataviews-core";
+import { act, render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import DataViews from "../../Provider.js";
+import Actions from "./Actions.js";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+
+/** A file beside this one, as text. */
+const read = (file: string): string =>
+  readFileSync(path.join(here, file), "utf8");
+
+// Comments and the layer name dropped, so neither prose nor `ds.components`
+// is ever taken for a class selector; whitespace collapsed, so a rule is
+// named by its selector list on one line.
+const sheet = read("styles.css")
+  .replace(/\/\*[\s\S]*?\*\//g, "")
+  .replace(/@layer[^{;]*/g, "")
+  .replace(/\s+/g, " ");
+
+/**
+ * The declarations of the rule whose selector list is exactly `selector`,
+ * up to its first nested rule: anchored at a rule's start, so a longer
+ * selector ending the same way never answers for it.
+ */
+const rule = (selector: string): string => {
+  const escaped = selector.replace(/[.*+?^${}()|[\]\\>]/g, "\\$&");
+  const body = sheet.match(
+    new RegExp(`(?:^|[;{}]) ?${escaped} ?\\{([^{}]*)`),
+  )?.[1];
+  if (body === undefined) {
+    throw new Error(`no rule for ${selector}`);
+  }
+  return body;
+};
+
+/**
+ * An anatomy note's DOM as a selector: a class list (`ds data-table-row
+ * status`, placeholders like `<kind>` dropped) or a selector already
+ * (`.indicator`).
+ */
+const selectorOf = (dom: string): string =>
+  dom.includes(" ")
+    ? dom
+        .split(" ")
+        .filter((name) => !name.startsWith("<"))
+        .map((name) => `.${name}`)
+        .join("")
+    : dom;
+
+/** An action bar over a selection of two. */
+const selected = (): HTMLElement => {
+  const schema = createSchema([
+    { field: "status", kind: "choices", options: ["failed", "ready"] },
+  ]);
+  const provider = createDataViewsProvider({ schema });
+  const { container } = render(
+    <DataViews provider={provider}>
+      <Actions />
+    </DataViews>,
+  );
+  act(() => {
+    provider.selection.add(["m1", "m2"]);
+  });
+  return container;
+};
+
+const bar = ".ds.data-table-action-bar";
+
+describe("Actions stylesheet", () => {
+  it("styles only classes the bar renders", () => {
+    const styled = new Set(
+      [...sheet.matchAll(/\.([a-z][\w-]*)/g)].map(([, name]) => name),
+    );
+    const rendered = new Set(
+      [...selected().querySelectorAll("[class]")].flatMap((element) => [
+        ...element.classList,
+      ]),
+    );
+    expect(styled.size).toBeGreaterThan(0);
+    expect([...styled].filter((name) => !rendered.has(name))).toEqual([]);
+  });
+
+  it("renders the structure the stylesheet's combinators assume", () => {
+    // Every class appearing somewhere is not enough: the sheet reaches each
+    // part through the bar, and a part that moves loses its rule.
+    const container = selected();
+    for (const selector of [
+      `${bar}.contrasted > .indicator`,
+      `${bar} > .ds.button.deselect`,
+    ]) {
+      expect(container.querySelector(selector), selector).not.toBeNull();
+    }
+  });
+
+  it("writes no length or colour of its own", () => {
+    // Every value is a token, a channel or a structural keyword: a missing
+    // token is recorded in the anatomy, never written here as a number.
+    expect(sheet).not.toMatch(/\d(px|rem|em)\b|#[0-9a-f]{3,8}\b|opacity/i);
+  });
+
+  it("paints the contrasted surface's channel, and hands its text to the Button", () => {
+    const root = rule(bar);
+    expect(root).toMatch(
+      /background-color: var\(--surface-color-background, var\(--color-background\)\);/,
+    );
+    expect(root).toMatch(
+      /[;{ ]color: var\(--surface-color-text, var\(--color-text\)\);/,
+    );
+    expect(root).toMatch(
+      /--button-color-text: var\(--surface-color-text, var\(--color-text\)\);/,
+    );
+  });
+
+  it("holds the icon-only deselect to a square of the density line", () => {
+    // Left to the Button, an icon-only one is shorter than the minimum target.
+    const deselect = rule("& > .ds.button.deselect");
+    expect(deselect).toMatch(
+      /min-block-size: var\(--density-line-height-effective\);/,
+    );
+    expect(deselect).toMatch(
+      /min-inline-size: var\(--density-line-height-effective\);/,
+    );
+    expect(deselect).toMatch(
+      /--button-padding-inline-end: var\(--dimension-100\);/,
+    );
+    expect(deselect).toMatch(/align-items: center;/);
+    expect(deselect).toMatch(/justify-content: center;/);
+  });
+
+  it("insets the indicator by the density channel", () => {
+    expect(rule("& > .indicator")).toMatch(
+      /padding-inline: var\(--density-padding-inline\);/,
+    );
+  });
+});
+
+describe("Actions anatomy", () => {
+  const anatomy = read("Actions.anatomy.yaml");
+
+  it("is implemented by the component beside it", () => {
+    const uri = anatomy.match(/^node:\n\s+uri: (\S+)$/m)?.[1] ?? "";
+    expect(uri).toBe("apps.subcomponent.data_table-action_bar");
+    expect(read("Actions.tsx")).toMatch(
+      /@implements ds:apps\.subcomponent\.data_table-action_bar(?![\w.-])/,
+    );
+  });
+
+  it("states only DOM the bar renders", () => {
+    const stated = [...anatomy.matchAll(/DOM `([^`]+)`/g)].map(([, dom]) =>
+      selectorOf(dom),
+    );
+    expect(stated.length).toBeGreaterThan(0);
+    const container = selected();
+    expect(
+      stated.filter((selector) => container.querySelector(selector) === null),
+    ).toEqual([]);
+  });
+});

--- a/packages/react/dataviews/src/lib/DataViews/common/Actions/types.ts
+++ b/packages/react/dataviews/src/lib/DataViews/common/Actions/types.ts
@@ -1,0 +1,31 @@
+import type { ComponentProps, ReactNode } from "react";
+
+type OwnProps = {
+  /** The group's accessible name. Defaults to "Selection actions". */
+  readonly label?: string;
+  /**
+   * The selection indicator: the count of selected items by default. A
+   * caller's own indicator — a menu opening the selection, say — replaces it;
+   * `null` shows none.
+   */
+  readonly indicator?: ReactNode;
+  /**
+   * The actions that apply to the selection. Each reads the selection when it
+   * is activated, through `useDataViews`, so the bar takes no second copy of
+   * it.
+   */
+  readonly children?: ReactNode;
+};
+
+/**
+ * Props of the connected action bar. The root is a `div` grouping the
+ * selection's commands, so it extends native div props. `role` is excluded,
+ * since the group role is the bar's own, and so are `aria-label` and
+ * `aria-labelledby`, which would override the name it takes from `label`.
+ * So is `ref`: the bar holds its root to hand the focus back when it leaves.
+ */
+export type ActionsProps = OwnProps &
+  Omit<
+    ComponentProps<"div">,
+    keyof OwnProps | "role" | "aria-label" | "aria-labelledby" | "ref"
+  >;

--- a/packages/react/dataviews/src/lib/DataViews/common/Filters/Filters.mdx
+++ b/packages/react/dataviews/src/lib/DataViews/common/Filters/Filters.mdx
@@ -1,0 +1,93 @@
+import { Canvas, Meta } from "@storybook/addon-docs/blocks";
+import * as Stories from "./Filters.stories";
+
+<Meta of={Stories} name="Recipes" />
+
+# DataViews.Filters recipes
+
+`DataViews.Filters` edits the collection's query. It takes no query and no list of fields: which fields it offers comes from the provider's schema, and which operators each accepts comes from what the provider's source declares it can execute. It never offers a restriction the source would refuse, and it has no draft to keep in step with the applied query — each edit is the applied query.
+
+The design has not drawn the filters yet, so the part renders plain form controls: a group of checkboxes for a choices field, a from and a to bound for a number or date field, and one checkbox for a flag.
+
+## Filters over a composed collection
+
+Tell the provider the source's capabilities: the filters read them, and throw when they were not given. `labels` names the fields for the reader; a field without a label is named by its field name.
+
+```tsx
+import {
+  createArraySource,
+  createDataViewsProvider,
+  createSchema,
+  createSourceBinding,
+} from "@canonical/dataviews-core";
+import {
+  DataTable,
+  DataViews,
+  type DataTableColumn,
+} from "@canonical/dataviews-react";
+import { useEffect, useState } from "react";
+import { machines } from "./machines.js";
+
+// The fields a filter can edit, and the values each takes.
+const machineSchema = createSchema([
+  { field: "status", kind: "choices", options: ["running", "failed", "pending"] },
+  { field: "cores", kind: "number", min: 1 },
+]);
+
+const columns: readonly DataTableColumn[] = [
+  { id: "name", header: "Host" },
+  { id: "status", header: "Status" },
+  { id: "cores", header: "Cores" },
+  { id: "owner", header: "Owner" },
+];
+
+export function Machines() {
+  const [source] = useState(() =>
+    createArraySource({
+      rows: machines,
+      fields: ["name", "status", "region", "cores", "owner"],
+    }),
+  );
+  const [provider] = useState(() =>
+    createDataViewsProvider({
+      schema: machineSchema,
+      capabilities: source.capabilities,
+    }),
+  );
+  useEffect(() => {
+    const binding = createSourceBinding({ host: provider, adapter: source });
+    if (provider.result.get().result.status === "idle") {
+      provider.refresh();
+    }
+    return binding.dispose;
+  }, [provider, source]);
+  return (
+    <DataViews provider={provider}>
+      <DataViews.Filters labels={{ status: "Status", cores: "Cores" }} />
+      <DataTable provider={provider} columns={columns} label="Machines" />
+    </DataViews>
+  );
+}
+```
+
+<Canvas of={Stories.Default} sourceState="none" />
+
+## The applied query, not a draft
+
+A checked status or a filled bound is the restriction in force. The provider's field handles apply the same edits from code — `provider.fields.status.eq.set(["failed"])` — and the controls follow.
+
+<Canvas of={Stories.ChoiceApplied} sourceState="none" />
+
+<Canvas of={Stories.BoundApplied} sourceState="none" />
+
+## An invalid edit keeps the restriction
+
+A bound that does not parse is refused, not applied. The restriction already in force stays in force, and the message beside the input says so, because the text on screen is no longer what filters the rows. Emptying a bound is incomplete rather than a removal; the clear button removes it.
+
+<Canvas of={Stories.InvalidEditKeepsTheRestriction} sourceState="none" />
+
+## Only what the source can run
+
+A field the source does not declare filterable gets no control. Here the source cannot filter by cores, so there is no cores bound, even though the schema names the field.
+
+<Canvas of={Stories.UndeclaredField} sourceState="none" />

--- a/packages/react/dataviews/src/lib/DataViews/common/Filters/Filters.stories.tsx
+++ b/packages/react/dataviews/src/lib/DataViews/common/Filters/Filters.stories.tsx
@@ -1,0 +1,193 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import type { ReactElement } from "react";
+import { expect, waitFor } from "storybook/test";
+import { consumerCode } from "../../../../storybook/machines/consumerCode.js";
+import { createSourceWithoutCores } from "../../../../storybook/machines/fixtures.js";
+import type {
+  MachineProvider,
+  MachineProviderOptions,
+} from "../../../../storybook/machines/story-utils.js";
+import {
+  useMachineProvider,
+  withAppScope,
+} from "../../../../storybook/machines/story-utils.js";
+import DataTable from "../../../DataTable/DataTable.js";
+import type { DataTableColumn } from "../../../DataTable/types.js";
+import DataViews from "../../Provider.js";
+import Component from "./Filters.js";
+import type { FiltersProps } from "./types.js";
+
+const meta = {
+  title: "_work_in_progress/DataViews/Filters",
+  component: Component,
+  decorators: [withAppScope],
+  args: {
+    labels: { status: "Status", cores: "Cores" },
+  },
+} satisfies Meta<typeof Component>;
+
+export default meta;
+type Story = StoryObj<typeof Component>;
+
+const columns: readonly DataTableColumn[] = [
+  { id: "name", header: "Host" },
+  { id: "status", header: "Status" },
+  { id: "cores", header: "Cores" },
+  { id: "owner", header: "Owner" },
+];
+
+const columnsCode = `const columns: readonly DataTableColumn[] = [
+  { id: "name", header: "Host" },
+  { id: "status", header: "Status" },
+  { id: "cores", header: "Cores" },
+  { id: "owner", header: "Owner" },
+];`;
+
+const composition = `<DataViews provider={provider}>
+  <DataViews.Filters labels={{ status: "Status", cores: "Cores" }} />
+  <DataTable provider={provider} columns={columns} label="Machines" />
+</DataViews>`;
+
+const parts = ["DataTable", "DataViews", "type DataTableColumn"];
+
+/** A composed collection: a root, its filters and its table. */
+function FilteredMachines({
+  options,
+  ...args
+}: FiltersProps & {
+  readonly options?: MachineProviderOptions;
+}): ReactElement {
+  const provider = useMachineProvider(options);
+  return (
+    <DataViews provider={provider}>
+      <Component {...args} />
+      <DataTable provider={provider} columns={columns} label="Machines" />
+    </DataViews>
+  );
+}
+
+const renderWith =
+  (options?: MachineProviderOptions): NonNullable<Story["render"]> =>
+  (args) => <FilteredMachines {...args} options={options} />;
+
+/** The table's record rows: every row but the header's. */
+const recordRows = (canvas: {
+  getAllByRole: (role: string) => HTMLElement[];
+}) => canvas.getAllByRole("row").length - 1;
+
+const onlyFailed = (provider: MachineProvider): void => {
+  provider.fields.status.eq.set(["failed"]);
+};
+
+const atLeastSixteenCores = (provider: MachineProvider): void => {
+  provider.fields.cores.gte.edit("16");
+};
+
+const thenAnInvalidEdit = (provider: MachineProvider): void => {
+  atLeastSixteenCores(provider);
+  provider.fields.cores.gte.edit("lots");
+};
+
+/**
+ * Default: one control per filterable field in the provider's schema — a
+ * checkbox per status, and a from and a to bound for cores. Nothing is
+ * applied, so every machine shows.
+ */
+export const Default: Story = {
+  parameters: consumerCode({
+    parts,
+    declarations: columnsCode,
+    render: composition,
+  }),
+  render: renderWith(),
+  play: async ({ canvas }) => {
+    await expect(canvas.getByRole("group", { name: "Filters" })).toBeVisible();
+    await waitFor(() => expect(recordRows(canvas)).toBe(12));
+    await expect(canvas.getByLabelText("Cores from")).toHaveValue("");
+  },
+};
+
+/**
+ * A choice applied: only failed machines. The checkbox is the applied query,
+ * not a draft of it — there is no second query to apply or keep in step.
+ */
+export const ChoiceApplied: Story = {
+  parameters: consumerCode({
+    parts,
+    declarations: columnsCode,
+    prepare: `provider.fields.status.eq.set(["failed"]);`,
+    render: composition,
+  }),
+  render: renderWith({ prepare: onlyFailed }),
+  play: async ({ canvas }) => {
+    await expect(
+      canvas.getByRole("checkbox", { name: "failed" }),
+    ).toBeChecked();
+    await waitFor(() => expect(recordRows(canvas)).toBe(3));
+  },
+};
+
+/** A bound applied: machines with at least sixteen cores. */
+export const BoundApplied: Story = {
+  parameters: consumerCode({
+    parts,
+    declarations: columnsCode,
+    prepare: `provider.fields.cores.gte.edit("16");`,
+    render: composition,
+  }),
+  render: renderWith({ prepare: atLeastSixteenCores }),
+  play: async ({ canvas }) => {
+    await expect(canvas.getByLabelText("Cores from")).toHaveValue("16");
+    await waitFor(() => expect(recordRows(canvas)).toBe(4));
+  },
+};
+
+/**
+ * An invalid edit keeps the restriction: sixteen cores was applied, then the
+ * bound was edited to text that is not a number. The edit is refused, the
+ * sixteen-core restriction stays in force, and the message beside the input
+ * says so — the text on screen is not what is filtering the rows.
+ */
+export const InvalidEditKeepsTheRestriction: Story = {
+  parameters: consumerCode({
+    parts,
+    declarations: columnsCode,
+    prepare: `provider.fields.cores.gte.edit("16");
+provider.fields.cores.gte.edit("lots");`,
+    render: composition,
+  }),
+  render: renderWith({ prepare: thenAnInvalidEdit }),
+  play: async ({ canvas }) => {
+    const bound = canvas.getByLabelText("Cores from");
+    await expect(bound).toHaveAttribute("aria-invalid", "true");
+    await expect(bound).toHaveAccessibleDescription(
+      /The previous restriction still applies\.$/,
+    );
+    await waitFor(() => expect(recordRows(canvas)).toBe(4));
+  },
+};
+
+/**
+ * A field the source cannot filter: this source declares no filter on
+ * cores, so the filters offer none. A control for a restriction the source
+ * would refuse would be a control that does nothing.
+ */
+export const UndeclaredField: Story = {
+  parameters: consumerCode({
+    parts,
+    declarations: columnsCode,
+    source: `createArraySource({
+      rows: machines,
+      // No "cores": this source can neither filter nor order by it.
+      fields: ["name", "status", "region", "owner"],
+    })`,
+    render: composition,
+  }),
+  render: renderWith({ source: createSourceWithoutCores }),
+  play: async ({ canvas }) => {
+    await expect(
+      canvas.getByRole("checkbox", { name: "failed" }),
+    ).toBeVisible();
+    await expect(canvas.queryByLabelText("Cores from")).toBeNull();
+  },
+};

--- a/packages/react/dataviews/src/lib/DataViews/common/Pagination/Pagination.mdx
+++ b/packages/react/dataviews/src/lib/DataViews/common/Pagination/Pagination.mdx
@@ -1,0 +1,72 @@
+import { Canvas, Meta } from "@storybook/addon-docs/blocks";
+import * as Stories from "./Pagination.stories";
+
+<Meta of={Stories} name="Recipes" />
+
+# DataViews.Pagination recipes
+
+`DataViews.Pagination` is the pagination bar bound to the enclosing `DataViews` root. It renders exactly what `PaginationBar` renders (its own recipes are the **PaginationBar / Recipes** page) — the page size, the summary, the page select and its four buttons — for the root's provider. The one difference is where the provider comes from: the part reads the root it is placed in, and throws outside one.
+
+Use the part inside a composition and the bar beside a standalone table. The two never mix: the part takes no provider prop, and the bar never reads a root.
+
+## In a composition
+
+The part takes presentation choices — a name, the page sizes — and never a second copy of the window the provider owns. Moving it means moving the element: it can sit anywhere inside the root.
+
+```tsx
+import {
+  createArraySource,
+  createDataViewsProvider,
+  createSourceBinding,
+} from "@canonical/dataviews-core";
+import {
+  DataTable,
+  DataViews,
+  type DataTableColumn,
+} from "@canonical/dataviews-react";
+import { useEffect, useState } from "react";
+import { machineSchema, machines } from "./machines.js";
+
+const columns: readonly DataTableColumn[] = [
+  { id: "name", header: "Host" },
+  { id: "status", header: "Status" },
+  { id: "owner", header: "Owner" },
+];
+
+export function Machines() {
+  const [source] = useState(() =>
+    createArraySource({
+      rows: machines,
+      fields: ["name", "status", "region", "cores", "owner"],
+    }),
+  );
+  const [provider] = useState(() =>
+    createDataViewsProvider({
+      schema: machineSchema,
+      capabilities: source.capabilities,
+      window: { page: 1, size: 5 },
+    }),
+  );
+  useEffect(() => {
+    const binding = createSourceBinding({ host: provider, adapter: source });
+    if (provider.result.get().result.status === "idle") {
+      provider.refresh();
+    }
+    return binding.dispose;
+  }, [provider, source]);
+  return (
+    <DataViews provider={provider}>
+      <DataTable provider={provider} columns={columns} label="Machines" />
+      <DataViews.Pagination label="Machines pagination" sizes={[5, 10, 25]} />
+    </DataViews>
+  );
+}
+```
+
+<Canvas of={Stories.InAComposition} sourceState="none" />
+
+## A filtered total
+
+The summary and the page total describe the current query. Filter the collection and both follow the source's new count; while the new count is on its way, they say nothing rather than repeat the old one.
+
+<Canvas of={Stories.AFilteredTotal} sourceState="none" />

--- a/packages/react/dataviews/src/lib/DataViews/common/Pagination/Pagination.stories.tsx
+++ b/packages/react/dataviews/src/lib/DataViews/common/Pagination/Pagination.stories.tsx
@@ -1,0 +1,121 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import type { ReactElement } from "react";
+import { expect, waitFor } from "storybook/test";
+import { consumerCode } from "../../../../storybook/machines/consumerCode.js";
+import type {
+  MachineProvider,
+  MachineProviderOptions,
+} from "../../../../storybook/machines/story-utils.js";
+import {
+  useMachineProvider,
+  withAppScope,
+} from "../../../../storybook/machines/story-utils.js";
+import DataTable from "../../../DataTable/DataTable.js";
+import type { DataTableColumn } from "../../../DataTable/types.js";
+import DataViews from "../../Provider.js";
+import Component from "./Pagination.js";
+import type { PaginationProps } from "./types.js";
+
+const meta = {
+  title: "_work_in_progress/DataViews/Pagination",
+  component: Component,
+  decorators: [withAppScope],
+  args: {
+    sizes: [5, 10, 25],
+  },
+} satisfies Meta<typeof Component>;
+
+export default meta;
+type Story = StoryObj<typeof Component>;
+
+const columns: readonly DataTableColumn[] = [
+  { id: "name", header: "Host" },
+  { id: "status", header: "Status" },
+  { id: "owner", header: "Owner" },
+];
+
+const columnsCode = `const columns: readonly DataTableColumn[] = [
+  { id: "name", header: "Host" },
+  { id: "status", header: "Status" },
+  { id: "owner", header: "Owner" },
+];`;
+
+const composition = `<DataViews provider={provider}>
+  <DataTable provider={provider} columns={columns} label="Machines" />
+  <DataViews.Pagination sizes={[5, 10, 25]} />
+</DataViews>`;
+
+/** A composed collection: a root, its table and its pagination part. */
+function ComposedMachines({
+  options,
+  ...args
+}: PaginationProps & {
+  readonly options?: MachineProviderOptions;
+}): ReactElement {
+  const provider = useMachineProvider({
+    window: { page: 1, size: 5 },
+    ...options,
+  });
+  return (
+    <DataViews provider={provider}>
+      <DataTable provider={provider} columns={columns} label="Machines" />
+      <Component {...args} />
+    </DataViews>
+  );
+}
+
+const onlyFailed = (provider: MachineProvider): void => {
+  provider.fields.status.eq.set(["failed"]);
+};
+
+/**
+ * In a composition: the part pages the root's provider and takes no provider
+ * of its own. It renders exactly what `PaginationBar` renders for that
+ * provider.
+ */
+export const InAComposition: Story = {
+  parameters: consumerCode({
+    parts: ["DataTable", "DataViews", "type DataTableColumn"],
+    declarations: columnsCode,
+    window: "{ page: 1, size: 5 }",
+    render: composition,
+  }),
+  render: (args) => <ComposedMachines {...args} />,
+  play: async ({ canvas }) => {
+    await waitFor(() =>
+      expect(canvas.getByRole("status")).toHaveTextContent(
+        "Showing 1–5 out of 12 items",
+      ),
+    );
+    await expect(canvas.getByText("of 3 pages")).toBeInTheDocument();
+  },
+};
+
+/**
+ * A filtered total: with only failed machines applied, the source counts
+ * three, and the part offers the one page they fill. The total it shows is
+ * always the current query's.
+ */
+export const AFilteredTotal: Story = {
+  parameters: consumerCode({
+    parts: ["DataTable", "DataViews", "type DataTableColumn"],
+    declarations: columnsCode,
+    window: "{ page: 1, size: 5 }",
+    prepare: `provider.fields.status.eq.set(["failed"]);`,
+    render: composition,
+  }),
+  render: (args) => (
+    <ComposedMachines {...args} options={{ prepare: onlyFailed }} />
+  ),
+  play: async ({ canvas }) => {
+    await waitFor(() =>
+      expect(canvas.getByRole("status")).toHaveTextContent(
+        "Showing 1–3 out of 3 items",
+      ),
+    );
+    await expect(canvas.getByText("of 1 page")).toBeInTheDocument();
+    await expect(
+      canvas.getByRole("button", { name: "Next page" }),
+    ).toBeDisabled();
+  },
+};

--- a/packages/react/dataviews/src/lib/DataViews/common/Pagination/Pagination.test.tsx
+++ b/packages/react/dataviews/src/lib/DataViews/common/Pagination/Pagination.test.tsx
@@ -1,7 +1,7 @@
 /**
- * The connected pagination part: destinations the collection can actually
- * reach, and counts that describe the rows on screen. Each case is
- * mutation-tested against that contract.
+ * The connected pagination part: the pagination bar, bound to the enclosing
+ * root's provider. The bar's own behaviour is pinned beside it; this pins the
+ * binding.
  */
 import type { DataViewsProvider } from "@canonical/dataviews-core";
 import {
@@ -9,7 +9,6 @@ import {
   createSchema,
 } from "@canonical/dataviews-core";
 import { act, fireEvent, render, screen } from "@testing-library/react";
-import { StrictMode } from "react";
 import { describe, expect, it } from "vitest";
 import DataViews from "../../Provider.js";
 import Pagination from "./Pagination.js";
@@ -19,46 +18,9 @@ const schema = createSchema([
 ]);
 
 type Fields = typeof schema.fields;
-type Machine = { readonly id: string };
 
-const makeProvider = (size = 2): DataViewsProvider<Fields, Machine> =>
-  createDataViewsProvider<Fields, Machine>({
-    schema,
-    window: { page: 1, size },
-  });
-
-const machines = (count: number): readonly Machine[] =>
-  Array.from({ length: count }, (_unused, index) => ({ id: `m${index}` }));
-
-/** Deliver one page for the request the provider currently wants. */
-const load = (
-  provider: DataViewsProvider<Fields, Machine>,
-  rows: readonly Machine[],
-  count: number | null,
-): void => {
-  const pending = provider.result.get().pendingRequestId ?? provider.refresh();
-  if (pending === null) {
-    throw new Error("expected a pending request");
-  }
-  act(() => {
-    provider.complete(pending, { status: "success", rows, count });
-  });
-};
-
-const mount = (
-  provider: DataViewsProvider<Fields, Machine>,
-  props: Parameters<typeof Pagination>[0] = {},
-) =>
-  render(
-    <DataViews provider={provider}>
-      <Pagination {...props} />
-    </DataViews>,
-  );
-
-/** The whole position readout: the announced page plus any total. */
-const position = () => screen.getByRole("status").parentElement;
-const previous = () => screen.getByRole("button", { name: "Previous" });
-const next = () => screen.getByRole("button", { name: "Next" });
+const makeProvider = (): DataViewsProvider<Fields> =>
+  createDataViewsProvider<Fields>({ schema, window: { page: 1, size: 2 } });
 
 describe("DataViews.Pagination", () => {
   it("is reachable as the composition's Pagination part", () => {
@@ -71,196 +33,30 @@ describe("DataViews.Pagination", () => {
     );
   });
 
-  it("names the navigation and announces the position as a status", () => {
-    mount(makeProvider());
-    expect(
-      screen.getByRole("navigation", { name: "Pagination" }),
-    ).toBeInTheDocument();
-    expect(screen.getByRole("status")).toHaveTextContent(/^Page 1$/);
-  });
-
-  it("announces the page, and leaves the total out of the announcement", () => {
-    const provider = makeProvider();
-    mount(provider);
-    load(provider, machines(2), 5);
-    expect(position()).toHaveTextContent(/^Page 1 of 3$/);
-    expect(screen.getByRole("status")).toHaveTextContent(/^Page 1$/);
-  });
-
-  it("takes its accessible name from the label", () => {
-    mount(makeProvider(), { label: "Machines pagination" });
-    expect(
-      screen.getByRole("navigation", { name: "Machines pagination" }),
-    ).toBeInTheDocument();
-  });
-
-  it("counts the pages a filtered total makes reachable", () => {
-    const provider = makeProvider();
-    mount(provider);
-    load(provider, machines(2), 5);
-    expect(position()).toHaveTextContent(/^Page 1 of 3$/);
-    expect(previous()).toBeDisabled();
-    expect(next()).toBeEnabled();
-  });
-
-  it("offers no last page when the source publishes no count", () => {
-    const provider = makeProvider();
-    mount(provider);
-    load(provider, machines(2), null);
-    expect(position()).toHaveTextContent(/^Page 1$/);
-    // A full page is evidence there may be another; a short one is not.
-    expect(next()).toBeEnabled();
-    load(provider, machines(1), null);
-    expect(next()).toBeDisabled();
-  });
-
-  it("stops at the last page a count declares", () => {
-    const provider = makeProvider();
-    mount(provider);
-    load(provider, machines(2), 4);
-    fireEvent.click(next());
-    expect(provider.result.get().window).toEqual({ page: 2, size: 2 });
-    load(provider, machines(2), 4);
-    expect(position()).toHaveTextContent(/^Page 2 of 2$/);
-    expect(next()).toBeDisabled();
-    expect(previous()).toBeEnabled();
-    fireEvent.click(previous());
-    expect(provider.result.get().window).toEqual({ page: 1, size: 2 });
-  });
-
-  it("steps one page from wherever it is", () => {
-    const provider = makeProvider();
-    mount(provider);
-    load(provider, machines(2), 6);
-    fireEvent.click(next());
-    load(provider, machines(2), 6);
-    fireEvent.click(next());
-    load(provider, machines(2), 6);
-    expect(position()).toHaveTextContent(/^Page 3 of 3$/);
-    fireEvent.click(previous());
-    expect(provider.result.get().window).toEqual({ page: 2, size: 2 });
-    load(provider, machines(2), 6);
-    fireEvent.click(next());
-    expect(provider.result.get().window).toEqual({ page: 3, size: 2 });
-  });
-
-  it("steps back from past the last page to the last one there is", () => {
-    const provider = createDataViewsProvider<Fields, Machine>({
-      schema,
-      window: { page: 9, size: 2 },
-    });
-    mount(provider);
-    load(provider, [], 4);
-    expect(position()).toHaveTextContent(/^Page 9 of 2$/);
-    fireEvent.click(previous());
-    expect(provider.result.get().window).toEqual({ page: 2, size: 2 });
-  });
-
-  it("keeps one page when the collection is empty", () => {
-    const provider = makeProvider();
-    mount(provider);
-    load(provider, [], 0);
-    expect(position()).toHaveTextContent(/^Page 1 of 1$/);
-    expect(next()).toBeDisabled();
-  });
-
-  it("claims no total while a replacement request is in flight", () => {
-    const provider = makeProvider();
-    mount(provider);
-    load(provider, machines(2), 5);
-    act(() => {
-      provider.navigateWindow(2);
-    });
-    // The previous query's total does not describe the pending one, and the
-    // rows still on screen are not the ones Next would page past.
-    expect(position()).toHaveTextContent(/^Page 2$/);
-    expect(next()).toBeDisabled();
-    load(provider, machines(2), 5);
-    expect(position()).toHaveTextContent(/^Page 2 of 3$/);
-    expect(next()).toBeEnabled();
-  });
-
-  it("resets to the first page when the page size changes", () => {
-    const provider = makeProvider();
-    mount(provider);
-    load(provider, machines(2), 40);
-    fireEvent.click(next());
-    load(provider, machines(2), 40);
-    fireEvent.change(screen.getByLabelText("Rows per page"), {
-      target: { value: "25" },
-    });
-    // The old page number counted rows of a different size.
-    expect(provider.result.get().window).toEqual({ page: 1, size: 25 });
-  });
-
-  it("always offers the applied size, in order", () => {
-    mount(makeProvider(2));
-    expect(
-      screen
-        .getAllByRole("option")
-        .map((option) => (option as HTMLOptionElement).value),
-    ).toEqual(["2", "10", "25", "50", "100"]);
-    expect(screen.getByLabelText("Rows per page")).toHaveValue("2");
-  });
-
-  it("offers each size once", () => {
-    mount(makeProvider(25), { sizes: [25, 50, 25] });
-    expect(
-      screen
-        .getAllByRole("option")
-        .map((option) => (option as HTMLOptionElement).value),
-    ).toEqual(["25", "50"]);
-  });
-
-  it("follows the window and pages under StrictMode", () => {
+  it("pages the root's provider and takes the bar's props", () => {
     const provider = makeProvider();
     render(
-      <StrictMode>
-        <DataViews provider={provider}>
-          <Pagination />
-        </DataViews>
-      </StrictMode>,
+      <DataViews provider={provider}>
+        <Pagination label="Machines pagination" className="footer" />
+      </DataViews>,
     );
-    load(provider, machines(2), 5);
-    expect(position()).toHaveTextContent(/^Page 1 of 3$/);
-    fireEvent.click(next());
-    expect(provider.result.get().window).toEqual({ page: 2, size: 2 });
-    load(provider, machines(2), 5);
-    expect(position()).toHaveTextContent(/^Page 2 of 3$/);
-  });
-
-  it("offers exactly the sizes it was given when one is applied", () => {
-    mount(makeProvider(25), { sizes: [25, 50] });
-    expect(
-      screen
-        .getAllByRole("option")
-        .map((option) => (option as HTMLOptionElement).value),
-    ).toEqual(["25", "50"]);
-  });
-
-  it("passes native nav props through and merges the class name", () => {
-    mount(makeProvider(), { className: "footer", id: "machines-pages" });
-    const nav = screen.getByRole("navigation", { name: "Pagination" });
-    expect(nav).toHaveClass("ds", "data-views-pagination", "footer");
-    expect(nav).toHaveAttribute("id", "machines-pages");
-  });
-
-  it("claims no total beside an earlier query's rows after the current one failed", () => {
-    const provider = makeProvider();
-    mount(provider);
-    load(provider, machines(2), 5);
-    act(() => {
-      provider.setSearch("m1");
-    });
-    const failed = provider.result.get().pendingRequestId;
-    if (failed === null) {
-      throw new Error("expected a pending request");
+    const requestId = provider.refresh();
+    if (requestId === null) {
+      throw new Error("expected a refresh request");
     }
     act(() => {
-      provider.complete(failed, { status: "failure", reason: "offline" });
+      provider.complete(requestId, {
+        status: "success",
+        rows: [{ id: "m1" }, { id: "m2" }],
+        count: 5,
+      });
     });
-    expect(provider.result.get().result.status).toBe("stale");
-    expect(position()).toHaveTextContent(/^Page 1$/);
-    expect(next()).toBeDisabled();
+    const nav = screen.getByRole("navigation", { name: "Machines pagination" });
+    expect(nav).toHaveClass("ds", "data-table-pagination-bar", "footer");
+    expect(screen.getByRole("status")).toHaveTextContent(
+      "Showing 1–2 out of 5 items",
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Next page" }));
+    expect(provider.result.get().window).toEqual({ page: 2, size: 2 });
   });
 });

--- a/packages/react/dataviews/src/lib/DataViews/common/Pagination/Pagination.tsx
+++ b/packages/react/dataviews/src/lib/DataViews/common/Pagination/Pagination.tsx
@@ -1,106 +1,23 @@
 import type { ReactElement } from "react";
-import { useContext, useId } from "react";
+import { useContext } from "react";
+import PaginationBar from "../../../PaginationBar/PaginationBar.js";
 import DataViewsContext from "../../Context.js";
-import useDataViewsValue from "../../hooks/useDataViewsValue.js";
 import type { PaginationProps } from "./types.js";
 
-const componentCssClassName = "ds data-views-pagination";
-
-const DEFAULT_SIZES: readonly number[] = [10, 25, 50, 100];
-
 /**
- * Window navigation for the collection.
+ * Window navigation for the collection: the pagination bar, bound to the
+ * enclosing root's provider.
  *
- * The destinations are the ones the collection can actually reach. A source
- * that publishes a filtered total gets a last page and a "page n of m"; one
- * that publishes no count gets a Next offered only while the current page is
- * full, and no invented last page. While a replacement request is in flight,
- * or after it failed and left an earlier query's rows in view, that query's
- * total is not this one's, so no total is claimed and Next waits for results
- * that answer the current query.
+ * It renders exactly what `PaginationBar` renders for that provider. The one
+ * difference is where the provider comes from: this part reads the root it
+ * is placed in, and throws outside one, rather than taking a provider prop.
  */
-export default function Pagination({
-  label = "Pagination",
-  sizes = DEFAULT_SIZES,
-  className,
-  ...rest
-}: PaginationProps): ReactElement {
+export default function Pagination(props: PaginationProps): ReactElement {
   const provider = useContext(DataViewsContext);
   if (provider === null) {
     throw new Error(
       "DataViews.Pagination must be used inside a DataViews root",
     );
   }
-  const state = useDataViewsValue(provider.result);
-  const sizeId = useId();
-  const { page, size } = state.window;
-  const current = state.resultsMatchCurrentQuery;
-  const total = current ? state.result.count : null;
-  const pages = total === null ? null : Math.max(1, Math.ceil(total / size));
-  // Without a total, a full page is the evidence there may be another one;
-  // a short page is not, and rows a superseded query produced are evidence
-  // of nothing at all.
-  const rows = state.result.rows;
-  const pageIsFull = rows !== null && rows.length === size;
-  const hasNext = pages === null ? pageIsFull && current : page < pages;
-  // A page past the last — an old link, a shrunken result — steps back to
-  // the last page there is, not one page at a time.
-  const back = pages !== null && page > pages ? pages : page - 1;
-  const given = [...new Set(sizes)];
-  const offered = given.includes(size)
-    ? given
-    : [...given, size].sort((a, b) => a - b);
-  return (
-    <nav
-      {...rest}
-      aria-label={label}
-      className={[componentCssClassName, className].filter(Boolean).join(" ")}
-    >
-      <button
-        type="button"
-        className="previous"
-        disabled={page <= 1}
-        onClick={() => {
-          provider.navigateWindow(back);
-        }}
-      >
-        Previous
-      </button>
-      <p className="position">
-        {/* Only the page the user moves to is announced; the total settles
-            with the results and would otherwise announce twice. */}
-        <span role="status">{`Page ${page}`}</span>
-        {pages === null ? null : ` of ${pages}`}
-      </p>
-      <button
-        type="button"
-        className="next"
-        disabled={!hasNext}
-        onClick={() => {
-          provider.navigateWindow(page + 1);
-        }}
-      >
-        Next
-      </button>
-      <label htmlFor={sizeId} className="size-label">
-        Rows per page
-      </label>
-      <select
-        id={sizeId}
-        className="size"
-        value={size}
-        onChange={(event) => {
-          // A new page size is a new window: the old page number counted
-          // rows of a different size, so it cannot survive the change.
-          provider.navigateWindow(1, Number(event.target.value));
-        }}
-      >
-        {offered.map((option) => (
-          <option key={option} value={option}>
-            {option}
-          </option>
-        ))}
-      </select>
-    </nav>
-  );
+  return <PaginationBar {...props} provider={provider} />;
 }

--- a/packages/react/dataviews/src/lib/DataViews/common/Pagination/types.ts
+++ b/packages/react/dataviews/src/lib/DataViews/common/Pagination/types.ts
@@ -1,24 +1,11 @@
-import type { ComponentProps } from "react";
-
-type OwnProps = {
-  /** The navigation's accessible name. Defaults to "Pagination". */
-  readonly label?: string;
-  /**
-   * The page sizes offered. The applied size is always among them, so the
-   * control can never misreport the window it is describing.
-   */
-  readonly sizes?: readonly number[];
-};
+import type { SchemaFieldDefinition } from "@canonical/dataviews-core";
+import type { PaginationBarProps } from "../../../PaginationBar/types.js";
 
 /**
- * Props of the connected pagination part. The root is a `nav`, so it
- * extends native nav props. `children` is excluded: the destinations are
- * derived from the window and what the source can count. So are `role`,
- * which would override the nav's `navigation` role, and `aria-label` and
- * `aria-labelledby`, which would override the name it takes from `label`.
+ * Props of the connected pagination part: the pagination bar's, less the
+ * provider, which comes from the enclosing root.
  */
-export type PaginationProps = OwnProps &
-  Omit<
-    ComponentProps<"nav">,
-    keyof OwnProps | "children" | "role" | "aria-label" | "aria-labelledby"
-  >;
+export type PaginationProps = Omit<
+  PaginationBarProps<readonly SchemaFieldDefinition[]>,
+  "provider"
+>;

--- a/packages/react/dataviews/src/lib/DataViews/common/index.ts
+++ b/packages/react/dataviews/src/lib/DataViews/common/index.ts
@@ -1,2 +1,3 @@
+export * from "./Actions/index.js";
 export * from "./Filters/index.js";
 export * from "./Pagination/index.js";

--- a/packages/react/dataviews/src/lib/DataViews/index.ts
+++ b/packages/react/dataviews/src/lib/DataViews/index.ts
@@ -1,4 +1,5 @@
 export type { CellScopeValue } from "./CellScopeContext.js";
+export type { ActionsProps } from "./common/Actions/index.js";
 export type { FiltersProps } from "./common/Filters/index.js";
 export type { PaginationProps } from "./common/Pagination/index.js";
 export * from "./hooks/index.js";

--- a/packages/react/dataviews/src/lib/DataViews/plural.test.ts
+++ b/packages/react/dataviews/src/lib/DataViews/plural.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, it } from "vitest";
+import plural from "./plural.js";
+
+describe("plural", () => {
+  it("is singular for one and plural for any other number", () => {
+    expect(plural(1, "item")).toBe("item");
+    expect(plural(0, "item")).toBe("items");
+    expect(plural(2, "page")).toBe("pages");
+  });
+});

--- a/packages/react/dataviews/src/lib/DataViews/plural.ts
+++ b/packages/react/dataviews/src/lib/DataViews/plural.ts
@@ -1,0 +1,4 @@
+/** A noun for a count: singular for one, plural for any other number. */
+export default function plural(count: number, noun: string): string {
+  return count === 1 ? noun : `${noun}s`;
+}

--- a/packages/react/dataviews/src/lib/PaginationBar/PaginationBar.anatomy.yaml
+++ b/packages/react/dataviews/src/lib/PaginationBar/PaginationBar.anatomy.yaml
@@ -1,0 +1,266 @@
+---
+# PaginationBar — the bar beneath a collection's rows: how many items are on
+# screen, how many a page holds, and the way to every other page.
+#
+# Anatomy DSL 0.3.0. No validator runs on this file yet: it is checked in
+# review against the DSL's JSON schema. Pinned props on a named node
+# (`props:`) are 0.3.0's; older schemas refuse them. The root carries the
+# design-system graph's IRI; its parts are role nodes, and the controls
+# reference the design system's own Button and SelectInput.
+#
+# Names — one per part, the same in the design, the DOM and here:
+#   pagination bar  design "Table pagination"   graph "DataTable.PaginationBar"
+#                                         DOM `ds data-table-pagination-bar`
+#   leading group   design "Frame 1062"   DOM `.leading`
+#   page size       design "Items per page:" + "Pagination dropdown"
+#                                         DOM `.page-size`
+#   divider         design "Rectangle 1"  DOM `.divider`
+#   result summary  design "Table pagination item indicator"
+#                                         DOM `.summary`
+#   trailing group  design "Frame 1067"   DOM `.trailing`
+#   page control    design "Pagination dropdown" + "Total page amount wrapper"
+#                                         DOM `.page`
+#   page total      design "of 2 pages"   DOM `.total`
+#   navigation      design "Frame 1066"   DOM `.navigation`
+#   first           design "Pagination button"   DOM `.first`
+#   previous        design "Pagination button"   DOM `.previous`
+#   next            design "Pagination button"   DOM `.next`
+#   last            design "Pagination button"   DOM `.last`
+# The design's layer names are frame numbers; the design owners are asked to
+# adopt the names above.
+#
+# Tokens are `/`-paths over `@canonical/design-tokens` 0.10.0 ids. The bar's
+# leading inset reads the `@canonical/styles` density channel
+# (`density/padding-inline`, `--density-padding-inline`), as the table's cells
+# do; the DSL cannot name a channel, so the path does and this note records it.
+#
+# The two selects are the design system's SelectInput, themed through the form
+# layer's own channels on the bar, never restyled:
+#   --form-input-height          density/line-height-effective
+#   --form-input-padding-block   dimension/050
+#   --form-input-padding-inline  dimension/100
+#   --form-input-background      color/foreground/ghost
+#   --form-input-border-color    none: the design draws the dropdown borderless
+# One property is overridden rather than themed: the input chrome fills its
+# container's width, and in a bar it takes its content's. Its caret is the
+# form layer's own, drawn in `color/icon`. The chrome comes from the
+# `@canonical/react-ds-global-form` stylesheet, which the page loads.
+#
+# The four buttons are the design system's Button, tertiary: a ghost fill
+# with no border, its hover, active and focus states the Button's own. An
+# icon-only Button collapses to its icon, because the Button seats its height
+# on a label, so the bar holds each to a square of the density line
+# (`density/line-height-effective`) with its icon centred in it: the one
+# place it overrides the Button's box. The design draws 36×36. The trailing
+# inline padding is set to `dimension/100` through the Button's own padding
+# channel. A disabled tertiary Button draws a border its enabled state hides;
+# the design draws no disabled state, and the Button's own is kept.
+#
+# Icons: `chevron-left` and `chevron-right` as drawn. The design's
+# `skip-to-start` and `skip-to-end` are not in `@canonical/ds-assets`; until
+# they land, first and last show `back-to-top` turned a quarter-turn towards
+# their edge — a bar with an arrow meeting it. The DSL cannot express the
+# turn; the stylesheet does, and this note records it. Icons take `1em` from
+# the Icon component; the design draws 16px, and the package has no icon-size
+# token.
+#
+# Deviations the DSL cannot express, recorded here:
+#   - `layout.position: sticky` holds the bar to the bottom edge of the
+#     scrolling container: the key is valid under the DSL's open key pattern
+#     but outside its documented vocabulary. The bar stacks above the rows
+#     scrolling beneath it at z-index 1; the package has no stacking token.
+#   - The background and text are the surface channel
+#     (`--surface-color-background`, `--surface-color-text`, falling back to
+#     `color/background` and `color/text`), so a sticky bar hides the rows
+#     beneath it on any surface. The design binds `color/foreground/ghost`,
+#     which is the same white in the light theme and transparent in no theme.
+#   - The top border is `dimension/stroke/thickness/medium` (1px). The design
+#     draws 2px; the package has no 2px stroke.
+#   - The result summary names the range on screen ("Showing 6–10 out of 12
+#     items"; one row as "Showing item 6 out of 12") where the design
+#     writes the count ("Showing 50 out of 942 items"). The count reads the
+#     same on every full page, so a page move would change nothing a screen
+#     reader hears.
+#   - The result summary is empty while the rows on screen do not answer the
+#     current query: a pending replacement, or a failed one that left an
+#     earlier query's rows in view. Conditional display is deferred in the
+#     DSL.
+#   - `spacing.internal.inline.start` and `.end` bind one side's inset: a
+#     level below the documented keys, valid under the open key pattern.
+#   - The groups wrap onto two lines when the bar is too narrow for both;
+#     the DSL has no wrapping key.
+#
+# States:
+#   - first and previous are disabled on the first page; next is disabled
+#     when no later page is known to exist; last is disabled on the last page
+#     and whenever there is no total for the current query — before results,
+#     while a replacement loads, or from a source that publishes none. Each is
+#     the Button's `@disabled`.
+#   - The page select lists every page the last settled total makes, keeping
+#     that list while a page move loads (a new query, page size or scope
+#     drops it), and lists a window past the last page after the pages there
+#     are. One option per page: a very large total makes a long list, which
+#     is carried to a later change.
+#   - The page total is absent while the source has published no total that
+#     answers the current query. The design's hidden "Skeleton loading item"
+#     on the total is not specified: one loading state belongs to the table.
+#
+# Accessibility (DataViews component coverage):
+#   bar, page size, page control, navigation
+#                       "Pagination/page size" (2.1.1, 2.4.4, 2.4.6, 3.2.2,
+#                       4.1.2). The bar is a named `nav`; the page size select
+#                       is labelled by its visible text, the page select is
+#                       named "Page" and described by its total, and each
+#                       button is named for its destination ("First page",
+#                       "Previous page", "Next page", "Last page").
+#   result summary      "Summary" (1.3.1, 4.1.3). A polite status: it changes
+#                       only when settled results change what it says, so a
+#                       background refresh with the same answer is silent.
+node:
+  uri: apps.subcomponent.data_table-pagination_bar
+  styles:
+    layout.type: stack
+    layout.direction: row
+    layout.align: center
+    layout.justify: space-between
+    layout.position: sticky
+    spacing.gap: dimension/100
+    spacing.internal.inline.start: density/padding-inline
+    typography.color: color/text
+    typography.family: typography/text/primary/font-family
+    typography.size: typography/text/primary/font-size
+    typography.weight: typography/text/primary/font-weight
+    appearance.background: color/background
+    appearance.border.top.width: dimension/stroke/thickness/medium
+    appearance.border.top.color: color/border/muted
+  edges:
+    - node:
+        role: leading group
+        styles:
+          layout.type: stack
+          layout.direction: row
+          layout.align: center
+          spacing.gap: dimension/100
+        edges:
+          - node:
+              role: page size
+              styles:
+                layout.type: stack
+                layout.direction: row
+                layout.align: center
+                spacing.gap: dimension/050
+              edges:
+                - node:
+                    role: label
+                  relation:
+                    cardinality: "1"
+                - uri: global.subcomponent.select_input
+                  relation:
+                    cardinality: "1"
+            relation:
+              cardinality: "1"
+          - node:
+              role: divider
+              styles:
+                size.width: dimension/stroke/thickness/medium
+                size.height: dimension/300
+                appearance.background: color/border/muted
+            relation:
+              cardinality: "1"
+          - node:
+              role: result summary
+              styles:
+                spacing.internal.inline.start: dimension/100
+            relation:
+              cardinality: "1"
+      relation:
+        cardinality: "1"
+    - node:
+        role: trailing group
+        styles:
+          layout.type: stack
+          layout.direction: row
+          layout.align: center
+          spacing.gap: dimension/100
+        edges:
+          - node:
+              role: page control
+              styles:
+                layout.type: stack
+                layout.direction: row
+                layout.align: center
+                spacing.gap: dimension/050
+                spacing.internal.inline.end: dimension/100
+              edges:
+                - uri: global.subcomponent.select_input
+                  relation:
+                    cardinality: "1"
+                - node:
+                    role: page total
+                  relation:
+                    cardinality: "0..1"
+            relation:
+              cardinality: "1"
+          - node:
+              role: divider
+              styles:
+                size.width: dimension/stroke/thickness/medium
+                size.height: dimension/300
+                appearance.background: color/border/muted
+            relation:
+              cardinality: "1"
+          - node:
+              role: navigation
+              styles:
+                layout.type: stack
+                layout.direction: row
+                layout.align: center
+              edges:
+                - node:
+                    uri: global.component.button
+                    props:
+                      importance: tertiary
+                      icon: back-to-top
+                    styles:
+                      size.min.width: density/line-height-effective
+                      size.min.height: density/line-height-effective
+                  relation:
+                    cardinality: "1"
+                    slotName: first
+                - node:
+                    uri: global.component.button
+                    props:
+                      importance: tertiary
+                      icon: chevron-left
+                    styles:
+                      size.min.width: density/line-height-effective
+                      size.min.height: density/line-height-effective
+                  relation:
+                    cardinality: "1"
+                    slotName: previous
+                - node:
+                    uri: global.component.button
+                    props:
+                      importance: tertiary
+                      icon: chevron-right
+                    styles:
+                      size.min.width: density/line-height-effective
+                      size.min.height: density/line-height-effective
+                  relation:
+                    cardinality: "1"
+                    slotName: next
+                - node:
+                    uri: global.component.button
+                    props:
+                      importance: tertiary
+                      icon: back-to-top
+                    styles:
+                      size.min.width: density/line-height-effective
+                      size.min.height: density/line-height-effective
+                  relation:
+                    cardinality: "1"
+                    slotName: last
+            relation:
+              cardinality: "1"
+      relation:
+        cardinality: "1"

--- a/packages/react/dataviews/src/lib/PaginationBar/PaginationBar.mdx
+++ b/packages/react/dataviews/src/lib/PaginationBar/PaginationBar.mdx
@@ -1,0 +1,97 @@
+import { Canvas, Meta } from "@storybook/addon-docs/blocks";
+import * as Stories from "./PaginationBar.stories";
+
+<Meta of={Stories} name="Recipes" />
+
+# PaginationBar recipes
+
+`PaginationBar` is the bar beneath a collection's rows: how many items a page holds, which are on screen out of how many, and the way to every other page. It pages a provider's window and nothing else — the provider owns the query, the source answers it, and the bar only asks for another window.
+
+It takes its provider explicitly, as `DataTable` does. A table used on its own gets the same footer as one composed inside a `DataViews` root, and the bar never behaves differently because some context happened to be present. Inside a root, `DataViews.Pagination` renders this same bar for the root's provider.
+
+The page size and page selects are the design system's `SelectInput`, and the buttons its `Button`. The select's chrome comes from the `@canonical/react-ds-global-form` stylesheet, so load it on the page beside `@canonical/styles`:
+
+```css
+@import url("@canonical/styles");
+@import url("@canonical/react-ds-global-form/dist/esm/index.css");
+@import url("@canonical/dataviews-react/index.css");
+```
+
+## A table and its pagination bar
+
+Build the source and the provider once, tell the provider what the source can execute, and bind them in an effect that disposes the binding. The table and the bar read the same provider: the bar asks for a window, and the table shows the rows that answer it.
+
+```tsx
+import {
+  createArraySource,
+  createDataViewsProvider,
+  createSourceBinding,
+} from "@canonical/dataviews-core";
+import {
+  DataTable,
+  PaginationBar,
+  type DataTableColumn,
+} from "@canonical/dataviews-react";
+import { useEffect, useState } from "react";
+import { machineSchema, machines } from "./machines.js";
+
+const columns: readonly DataTableColumn[] = [
+  { id: "name", header: "Host" },
+  { id: "status", header: "Status" },
+  { id: "region", header: "Region" },
+  { id: "owner", header: "Owner" },
+];
+
+export function Machines() {
+  const [source] = useState(() =>
+    createArraySource({
+      rows: machines,
+      fields: ["name", "status", "region", "cores", "owner"],
+    }),
+  );
+  const [provider] = useState(() =>
+    createDataViewsProvider({
+      schema: machineSchema,
+      capabilities: source.capabilities,
+      window: { page: 1, size: 5 },
+    }),
+  );
+  useEffect(() => {
+    const binding = createSourceBinding({ host: provider, adapter: source });
+    if (provider.result.get().result.status === "idle") {
+      provider.refresh();
+    }
+    return binding.dispose;
+  }, [provider, source]);
+  return (
+    <>
+      <DataTable provider={provider} columns={columns} label="Machines" />
+      <PaginationBar provider={provider} sizes={[5, 10, 25]} />
+    </>
+  );
+}
+```
+
+<Canvas of={Stories.FirstPage} sourceState="none" />
+
+`sizes` are the page sizes on offer: 50, 75 and 100 unless you say otherwise. The applied size is always among them, so a provider started on a size you did not list still shows it. Choosing a size returns to the first page, because the old page number counted rows of a different size.
+
+<Canvas of={Stories.LastPage} sourceState="none" />
+
+## Counts it can stand behind
+
+Every count describes the rows on screen, and every button goes somewhere the collection can reach. A source that publishes a filtered total gets a page total and a last page. A source that pages without counting — its capabilities declare `count: "none"` — gets neither: the summary counts the rows on screen, Last is unavailable, and Next is offered while the page is full, the only evidence there may be another.
+
+<Canvas of={Stories.WithoutACount} sourceState="none" />
+
+While the rows on screen do not answer the current query — nothing has arrived yet, a new page is loading, or the request failed and left an earlier query's rows in view — the summary and the page total say nothing, and Next waits. A total from an earlier query is not this one's.
+
+<Canvas of={Stories.Loading} sourceState="none" />
+
+The summary is a polite status. It names the rows on screen — "Showing 6–10 out of 12 items", or "Showing item 11 out of 12" for one — and speaks when settled results change what it says, so moving to another page or narrowing the collection is announced, and a background refresh with the same answer is not. When a navigation button that has the focus becomes unavailable — Next while its page loads, Last on arriving at the last page — the focus moves to the page select rather than to the document.
+
+## Sticky at the bottom
+
+The bar holds to the bottom edge of whatever scrolls it and paints the surface it sits on, so the rows scrolling beneath it never show through. A sticky element cannot leave its parent's box, so make the bar a direct child of the scrolling container, beside the table — not the only child of a wrapper its own height.
+
+<Canvas of={Stories.StickyInAScrollingFrame} sourceState="none" />

--- a/packages/react/dataviews/src/lib/PaginationBar/PaginationBar.ssr.test.tsx
+++ b/packages/react/dataviews/src/lib/PaginationBar/PaginationBar.ssr.test.tsx
@@ -1,0 +1,49 @@
+import {
+  createDataViewsProvider,
+  createSchema,
+} from "@canonical/dataviews-core";
+import { renderToString } from "react-dom/server";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import PaginationBar from "./PaginationBar.js";
+
+const schema = createSchema([
+  { field: "status", kind: "choices", options: ["failed", "ready"] },
+]);
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("PaginationBar SSR", () => {
+  it("renders on the server, claiming nothing before results", () => {
+    const error = vi.spyOn(console, "error").mockImplementation(() => {});
+    const html = renderToString(
+      <PaginationBar provider={createDataViewsProvider({ schema })} />,
+    );
+    expect(html).toContain('aria-label="Pagination"');
+    expect(html).toContain("Items per page:");
+    // No count yet, so no total and an empty summary.
+    expect(html).not.toContain('class="total"');
+    expect(html).toMatch(/class="summary"[^>]*><\/span>/);
+    expect(error).not.toHaveBeenCalled();
+  });
+
+  it("renders results the provider already holds", () => {
+    const provider = createDataViewsProvider({
+      schema,
+      window: { page: 1, size: 2 },
+    });
+    const requestId = provider.refresh();
+    if (requestId === null) {
+      throw new Error("expected a refresh request");
+    }
+    provider.complete(requestId, {
+      status: "success",
+      rows: [{ id: "m1" }, { id: "m2" }],
+      count: 5,
+    });
+    const html = renderToString(<PaginationBar provider={provider} />);
+    expect(html).toContain("Showing 1–2 out of 5 items");
+    expect(html).toContain("of 3 pages");
+  });
+});

--- a/packages/react/dataviews/src/lib/PaginationBar/PaginationBar.stories.tsx
+++ b/packages/react/dataviews/src/lib/PaginationBar/PaginationBar.stories.tsx
@@ -1,0 +1,264 @@
+import type { RowRecord } from "@canonical/dataviews-core";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import type { ReactElement } from "react";
+import { expect, waitFor } from "storybook/test";
+import { consumerCode } from "../../storybook/machines/consumerCode.js";
+import type { MachineFields } from "../../storybook/machines/fixtures.js";
+import {
+  createPendingSource,
+  createUncountedSource,
+} from "../../storybook/machines/fixtures.js";
+import type {
+  MachineProvider,
+  MachineProviderOptions,
+} from "../../storybook/machines/story-utils.js";
+import {
+  useMachineProvider,
+  withAppScope,
+  withScrollingFrame,
+} from "../../storybook/machines/story-utils.js";
+import DataTable from "../DataTable/DataTable.js";
+import type { DataTableColumn } from "../DataTable/types.js";
+import Component from "./PaginationBar.js";
+import type { PaginationBarProps } from "./types.js";
+
+const meta = {
+  title: "_work_in_progress/PaginationBar",
+  component: Component,
+  decorators: [withAppScope],
+  args: {
+    sizes: [5, 10, 25],
+  },
+  argTypes: {
+    provider: { control: false },
+  },
+} satisfies Meta<typeof Component>;
+
+export default meta;
+type Story = StoryObj<typeof Component>;
+
+const columns: readonly DataTableColumn[] = [
+  { id: "name", header: "Host" },
+  { id: "status", header: "Status" },
+  { id: "region", header: "Region" },
+  { id: "owner", header: "Owner" },
+];
+
+const columnsCode = `const columns: readonly DataTableColumn[] = [
+  { id: "name", header: "Host" },
+  { id: "status", header: "Status" },
+  { id: "region", header: "Region" },
+  { id: "owner", header: "Owner" },
+];`;
+
+const pageCode = `<>
+  <DataTable provider={provider} columns={columns} label="Machines" />
+  <PaginationBar provider={provider} sizes={[5, 10, 25]} />
+</>`;
+
+/** The machines five to a page, the table and its bar over one provider. */
+function MachinesPage({
+  options,
+  ...args
+}: Omit<PaginationBarProps<MachineFields, RowRecord>, "provider"> & {
+  readonly options?: MachineProviderOptions;
+}): ReactElement {
+  const provider = useMachineProvider({
+    window: { page: 1, size: 5 },
+    ...options,
+  });
+  return (
+    <>
+      <DataTable provider={provider} columns={columns} label="Machines" />
+      <Component {...args} provider={provider} />
+    </>
+  );
+}
+
+const renderWith =
+  (options?: MachineProviderOptions): NonNullable<Story["render"]> =>
+  (args) => <MachinesPage {...args} options={options} />;
+
+const goTo =
+  (page: number) =>
+  (provider: MachineProvider): void => {
+    provider.navigateWindow(page);
+  };
+
+/** The canvas a story's play function queries. */
+type StoryCanvas = Parameters<NonNullable<Story["play"]>>[0]["canvas"];
+
+/** Assert which of the bar's buttons may be pressed, first to last. */
+const expectAvailable = async (
+  canvas: StoryCanvas,
+  available: readonly boolean[],
+): Promise<void> => {
+  const names = ["First page", "Previous page", "Next page", "Last page"];
+  for (const [at, name] of names.entries()) {
+    const button = canvas.getByRole("button", { name });
+    await (available[at]
+      ? expect(button).toBeEnabled()
+      : expect(button).toBeDisabled());
+  }
+};
+
+/**
+ * First page: twelve machines, five to a page. The summary counts the rows on
+ * screen out of the filtered total, the page select offers the three pages
+ * that total makes, and there is nothing before the first page to go to.
+ */
+export const FirstPage: Story = {
+  parameters: consumerCode({
+    parts: ["DataTable", "PaginationBar", "type DataTableColumn"],
+    declarations: columnsCode,
+    window: "{ page: 1, size: 5 }",
+    render: pageCode,
+  }),
+  render: renderWith(),
+  play: async ({ canvas }) => {
+    await waitFor(() =>
+      expect(canvas.getByRole("status")).toHaveTextContent(
+        "Showing 1–5 out of 12 items",
+      ),
+    );
+    await expect(canvas.getByText("of 3 pages")).toBeInTheDocument();
+    await expectAvailable(canvas, [false, false, true, true]);
+  },
+};
+
+/** A middle page: every destination is open. */
+export const MiddlePage: Story = {
+  parameters: consumerCode({
+    parts: ["DataTable", "PaginationBar", "type DataTableColumn"],
+    declarations: columnsCode,
+    window: "{ page: 1, size: 5 }",
+    prepare: "provider.navigateWindow(2);",
+    render: pageCode,
+  }),
+  render: renderWith({ prepare: goTo(2) }),
+  play: async ({ canvas }) => {
+    await waitFor(() =>
+      expect(canvas.getByRole("status")).toHaveTextContent(
+        "Showing 6–10 out of 12 items",
+      ),
+    );
+    await expectAvailable(canvas, [true, true, true, true]);
+  },
+};
+
+/**
+ * Last page: two machines are left, and the summary says so. Nothing lies
+ * beyond the last page, so Next and Last are unavailable.
+ */
+export const LastPage: Story = {
+  parameters: consumerCode({
+    parts: ["DataTable", "PaginationBar", "type DataTableColumn"],
+    declarations: columnsCode,
+    window: "{ page: 1, size: 5 }",
+    prepare: "provider.navigateWindow(3);",
+    render: pageCode,
+  }),
+  render: renderWith({ prepare: goTo(3) }),
+  play: async ({ canvas }) => {
+    await waitFor(() =>
+      expect(canvas.getByRole("status")).toHaveTextContent(
+        "Showing 11–12 out of 12 items",
+      ),
+    );
+    await expectAvailable(canvas, [true, true, false, false]);
+  },
+};
+
+/**
+ * Without a count: a source that pages without counting publishes no total,
+ * so the bar invents none. The summary counts only the rows on screen, no
+ * page total shows, and Last is unavailable. Next is offered while the page
+ * is full, which is the only evidence there may be another.
+ */
+export const WithoutACount: Story = {
+  parameters: consumerCode({
+    parts: ["DataTable", "PaginationBar", "type DataTableColumn"],
+    imports: `import { machineSchema, machinesApi } from "./machines.js";`,
+    declarations: `${columnsCode}
+
+// A source whose capabilities declare \`count: "none"\`: each page arrives
+// with no total, as from a backend that pages without counting.`,
+    source: "machinesApi",
+    window: "{ page: 1, size: 5 }",
+    render: pageCode,
+  }),
+  render: renderWith({ source: createUncountedSource }),
+  play: async ({ canvas }) => {
+    await waitFor(() =>
+      expect(canvas.getByRole("status")).toHaveTextContent("Showing 1–5 items"),
+    );
+    await expect(canvas.queryByText(/^of /)).toBeNull();
+    await expectAvailable(canvas, [false, false, true, false]);
+  },
+};
+
+/**
+ * Loading: the source has been asked and never answers. The bar claims no
+ * count and no total it does not have, and offers no page it cannot reach.
+ */
+export const Loading: Story = {
+  parameters: consumerCode({
+    parts: ["DataTable", "PaginationBar", "type DataTableColumn"],
+    declarations: `${columnsCode}
+
+// Rendered before the bound source has answered.`,
+    window: "{ page: 1, size: 5 }",
+    render: pageCode,
+  }),
+  render: renderWith({ source: createPendingSource }),
+  play: async ({ canvas }) => {
+    await expect(await canvas.findByText("Loading…")).toBeInTheDocument();
+    await expect(canvas.getByRole("status")).toBeEmptyDOMElement();
+    await expect(
+      canvas
+        .getAllByRole("option", { name: "1" })
+        .map((option) => option.closest("select")?.getAttribute("aria-label")),
+    ).toContain("Page");
+    await expect(
+      canvas.getByRole("combobox", { name: "Page" }).querySelectorAll("option"),
+    ).toHaveLength(1);
+    await expectAvailable(canvas, [false, false, false, false]);
+  },
+};
+
+/**
+ * Sticky: every machine on one page, in a frame too short to show them all.
+ * The frame scrolls, and the bar stays at its bottom edge over the rows
+ * passing beneath it.
+ */
+export const StickyInAScrollingFrame: Story = {
+  parameters: consumerCode({
+    parts: ["DataTable", "PaginationBar", "type DataTableColumn"],
+    declarations: columnsCode,
+    render: `<div style={{ maxHeight: "16rem", overflow: "auto" }}>
+  <DataTable provider={provider} columns={columns} label="Machines" />
+  <PaginationBar provider={provider} sizes={[5, 10, 25]} />
+</div>`,
+  }),
+  decorators: [withScrollingFrame("16rem")],
+  render: renderWith({ window: { page: 1, size: 25 } }),
+  play: async ({ canvas }) => {
+    await waitFor(() =>
+      expect(canvas.getByRole("status")).toHaveTextContent(
+        "Showing 1–12 out of 12 items",
+      ),
+    );
+    const bar = canvas.getByRole("navigation", { name: "Pagination" });
+    const frame = bar.parentElement;
+    if (frame === null) {
+      throw new Error("expected the scrolling frame");
+    }
+    await expect(frame.scrollHeight).toBeGreaterThan(frame.clientHeight);
+    await expect(
+      Math.abs(
+        bar.getBoundingClientRect().bottom -
+          frame.getBoundingClientRect().bottom,
+      ),
+    ).toBeLessThanOrEqual(1);
+  },
+};

--- a/packages/react/dataviews/src/lib/PaginationBar/PaginationBar.test.tsx
+++ b/packages/react/dataviews/src/lib/PaginationBar/PaginationBar.test.tsx
@@ -1,0 +1,415 @@
+/**
+ * The pagination bar: destinations the collection can actually reach, and
+ * counts that describe the rows on screen. It takes its provider explicitly,
+ * so every case here mounts it with no DataViews root at all.
+ */
+import type { DataViewsProvider } from "@canonical/dataviews-core";
+import {
+  createDataViewsProvider,
+  createSchema,
+} from "@canonical/dataviews-core";
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { StrictMode } from "react";
+import { describe, expect, it } from "vitest";
+import DataViews from "../DataViews/Provider.js";
+import PaginationBar from "./PaginationBar.js";
+import type { PaginationBarProps } from "./types.js";
+
+const schema = createSchema([
+  { field: "status", kind: "choices", options: ["failed", "ready"] },
+]);
+
+type Fields = typeof schema.fields;
+type Machine = { readonly id: string };
+
+const makeProvider = (
+  window = { page: 1, size: 2 },
+): DataViewsProvider<Fields, Machine> =>
+  createDataViewsProvider<Fields, Machine>({ schema, window });
+
+const machines = (count: number): readonly Machine[] =>
+  Array.from({ length: count }, (_unused, index) => ({ id: `m${index}` }));
+
+/** Deliver one page for the request the provider currently wants. */
+const load = (
+  provider: DataViewsProvider<Fields, Machine>,
+  rows: readonly Machine[],
+  count: number | null,
+): void => {
+  const pending = provider.result.get().pendingRequestId ?? provider.refresh();
+  if (pending === null) {
+    throw new Error("expected a pending request");
+  }
+  act(() => {
+    provider.complete(pending, { status: "success", rows, count });
+  });
+};
+
+const mount = (
+  provider: DataViewsProvider<Fields, Machine>,
+  props: Omit<PaginationBarProps<Fields, Machine>, "provider"> = {},
+) => render(<PaginationBar {...props} provider={provider} />);
+
+const summary = () => screen.getByRole("status");
+const pageSelect = () => screen.getByRole("combobox", { name: "Page" });
+const sizeSelect = () => screen.getByLabelText("Items per page:");
+const button = (name: string) => screen.getByRole("button", { name });
+const first = () => button("First page");
+const previous = () => button("Previous page");
+const next = () => button("Next page");
+const last = () => button("Last page");
+const values = (select: HTMLElement) =>
+  [...select.querySelectorAll("option")].map((option) => option.value);
+const windowOf = (provider: DataViewsProvider<Fields, Machine>) =>
+  provider.result.get().window;
+
+describe("PaginationBar", () => {
+  it("refuses anything but a provider", () => {
+    const counterfeit = { identity: {} } as unknown as DataViewsProvider<
+      Fields,
+      Machine
+    >;
+    expect(() => render(<PaginationBar provider={counterfeit} />)).toThrow(
+      "PaginationBar requires a provider created by createDataViewsProvider",
+    );
+    expect(() =>
+      // @ts-expect-error the provider is the one input the bar cannot derive
+      render(<PaginationBar />),
+    ).toThrow(
+      "PaginationBar requires a provider created by createDataViewsProvider",
+    );
+  });
+
+  it("pages its own provider, whatever root it sits in", () => {
+    const outer = makeProvider();
+    const own = makeProvider();
+    render(
+      <DataViews provider={outer}>
+        <PaginationBar provider={own} />
+      </DataViews>,
+    );
+    load(own, machines(2), 6);
+    fireEvent.click(next());
+    expect(windowOf(own)).toEqual({ page: 2, size: 2 });
+    expect(windowOf(outer)).toEqual({ page: 1, size: 2 });
+  });
+
+  it("is a navigation named by its label, in the drawn order", () => {
+    mount(makeProvider(), { label: "Machines pagination" });
+    const nav = screen.getByRole("navigation", { name: "Machines pagination" });
+    // Page size first, then the summary; the page select, then the buttons.
+    expect([...nav.querySelectorAll("select, [role=status], button")]).toEqual([
+      sizeSelect(),
+      summary(),
+      pageSelect(),
+      first(),
+      previous(),
+      next(),
+      last(),
+    ]);
+  });
+
+  it("is named Pagination by default", () => {
+    mount(makeProvider());
+    expect(
+      screen.getByRole("navigation", { name: "Pagination" }),
+    ).toBeInTheDocument();
+  });
+
+  it("claims nothing before the first results arrive", () => {
+    mount(makeProvider());
+    expect(summary()).toBeEmptyDOMElement();
+    expect(values(pageSelect())).toEqual(["1"]);
+    expect(pageSelect()).not.toHaveAttribute("aria-describedby");
+    for (const control of [first(), previous(), next(), last()]) {
+      expect(control).toBeDisabled();
+    }
+  });
+
+  it("summarises the rows on screen out of the filtered total", () => {
+    const provider = makeProvider();
+    mount(provider);
+    load(provider, machines(2), 5);
+    expect(summary()).toHaveTextContent(/^Showing 1–2 out of 5 items$/);
+    expect(values(pageSelect())).toEqual(["1", "2", "3"]);
+    // The total describes the select it sits beside.
+    const total = screen.getByText("of 3 pages");
+    expect(pageSelect()).toHaveAttribute("aria-describedby", total.id);
+    expect(first()).toBeDisabled();
+    expect(previous()).toBeDisabled();
+    expect(next()).toBeEnabled();
+    expect(last()).toBeEnabled();
+  });
+
+  it("counts one item and one page in the singular", () => {
+    const provider = makeProvider();
+    mount(provider);
+    load(provider, machines(1), 1);
+    expect(summary()).toHaveTextContent(/^Showing item 1 out of 1$/);
+    expect(screen.getByText("of 1 page")).toBeInTheDocument();
+  });
+
+  it("offers no last page when the source publishes no count", () => {
+    const provider = makeProvider();
+    mount(provider);
+    load(provider, machines(2), null);
+    expect(summary()).toHaveTextContent(/^Showing 1–2 items$/);
+    expect(screen.queryByText(/^of /)).toBeNull();
+    expect(last()).toBeDisabled();
+    // A full page is evidence there may be another; a short one is not.
+    expect(next()).toBeEnabled();
+    fireEvent.click(next());
+    load(provider, machines(1), null);
+    expect(next()).toBeDisabled();
+    expect(summary()).toHaveTextContent(/^Showing item 3$/);
+    // Every page before this one is reachable from the select.
+    expect(values(pageSelect())).toEqual(["1", "2"]);
+    expect(pageSelect()).toHaveValue("2");
+  });
+
+  it("goes to the first and last pages a count declares", () => {
+    const provider = makeProvider();
+    mount(provider);
+    load(provider, machines(2), 6);
+    fireEvent.click(last());
+    expect(windowOf(provider)).toEqual({ page: 3, size: 2 });
+    load(provider, machines(2), 6);
+    expect(next()).toBeDisabled();
+    expect(last()).toBeDisabled();
+    fireEvent.click(first());
+    expect(windowOf(provider)).toEqual({ page: 1, size: 2 });
+  });
+
+  it("steps one page from wherever it is", () => {
+    const provider = makeProvider();
+    mount(provider);
+    load(provider, machines(2), 6);
+    fireEvent.click(next());
+    load(provider, machines(2), 6);
+    expect(pageSelect()).toHaveValue("2");
+    fireEvent.click(previous());
+    expect(windowOf(provider)).toEqual({ page: 1, size: 2 });
+    load(provider, machines(2), 6);
+    fireEvent.click(next());
+    expect(windowOf(provider)).toEqual({ page: 2, size: 2 });
+  });
+
+  it("jumps to the page the select names", () => {
+    const provider = makeProvider();
+    mount(provider);
+    load(provider, machines(2), 6);
+    fireEvent.change(pageSelect(), { target: { value: "3" } });
+    expect(windowOf(provider)).toEqual({ page: 3, size: 2 });
+  });
+
+  it("steps back from past the last page to the last one there is", () => {
+    const provider = makeProvider({ page: 9, size: 2 });
+    mount(provider);
+    load(provider, [], 4);
+    // The select still says where the window is, after the pages there are.
+    expect(pageSelect()).toHaveValue("9");
+    expect(values(pageSelect())).toEqual(["1", "2", "9"]);
+    fireEvent.click(previous());
+    expect(windowOf(provider)).toEqual({ page: 2, size: 2 });
+  });
+
+  it("steps back one page from the last", () => {
+    const provider = makeProvider({ page: 3, size: 2 });
+    mount(provider);
+    load(provider, machines(2), 6);
+    fireEvent.click(previous());
+    expect(windowOf(provider)).toEqual({ page: 2, size: 2 });
+  });
+
+  it("goes to the last page from past it", () => {
+    const provider = makeProvider({ page: 9, size: 2 });
+    mount(provider);
+    load(provider, [], 4);
+    expect(last()).toBeEnabled();
+    fireEvent.click(last());
+    expect(windowOf(provider)).toEqual({ page: 2, size: 2 });
+  });
+
+  it("keeps one page when the collection is empty", () => {
+    const provider = makeProvider();
+    mount(provider);
+    load(provider, [], 0);
+    expect(summary()).toHaveTextContent(/^Showing 0 out of 0 items$/);
+    expect(screen.getByText("of 1 page")).toBeInTheDocument();
+    expect(next()).toBeDisabled();
+  });
+
+  it("claims no total while a replacement request is in flight", () => {
+    const provider = makeProvider();
+    mount(provider);
+    load(provider, machines(2), 5);
+    act(() => {
+      provider.navigateWindow(2);
+    });
+    // The previous query's total does not describe the pending one, and the
+    // rows still on screen are not the ones Next would page past.
+    expect(summary()).toBeEmptyDOMElement();
+    expect(screen.queryByText(/^of /)).toBeNull();
+    expect(next()).toBeDisabled();
+    load(provider, machines(2), 5);
+    expect(summary()).toHaveTextContent(/^Showing 3–4 out of 5 items$/);
+    expect(next()).toBeEnabled();
+  });
+
+  it("announces the rows a new page brings", () => {
+    const provider = makeProvider();
+    mount(provider);
+    load(provider, machines(2), 5);
+    fireEvent.click(next());
+    load(provider, machines(2), 5);
+    // The same count on another page: the range is what changes.
+    expect(summary()).toHaveTextContent(/^Showing 3–4 out of 5 items$/);
+    fireEvent.click(last());
+    load(provider, machines(1), 5);
+    expect(summary()).toHaveTextContent(/^Showing item 5 out of 5$/);
+  });
+
+  it("keeps listing the settled pages while the next count is on its way", () => {
+    const provider = makeProvider();
+    mount(provider);
+    load(provider, machines(2), 6);
+    fireEvent.change(pageSelect(), { target: { value: "2" } });
+    // No total is claimed while it loads, but the list is not cut short.
+    expect(screen.queryByText(/^of /)).toBeNull();
+    expect(values(pageSelect())).toEqual(["1", "2", "3"]);
+  });
+
+  it("keeps the settled pages across a history step to another page", () => {
+    const provider = makeProvider();
+    mount(provider);
+    load(provider, machines(2), 6);
+    // Back or forward adopts an equal query under a new identity.
+    act(() => {
+      provider.adopt({ ...provider.result.get().slice }, { page: 2, size: 2 });
+    });
+    expect(values(pageSelect())).toEqual(["1", "2", "3"]);
+  });
+
+  it("drops the settled pages when the query, the page size or the scope changes", () => {
+    const provider = makeProvider();
+    mount(provider, { sizes: [2, 25] });
+    load(provider, machines(2), 6);
+    act(() => {
+      provider.setSearch("m1");
+    });
+    // A new query makes a new count: the old one's pages may not exist.
+    expect(values(pageSelect())).toEqual(["1"]);
+    load(provider, machines(2), 6);
+    act(() => {
+      provider.setSort([{ field: "status", direction: "asc" }]);
+    });
+    expect(values(pageSelect())).toEqual(["1"]);
+    load(provider, machines(2), 6);
+    fireEvent.change(sizeSelect(), { target: { value: "25" } });
+    expect(values(pageSelect())).toEqual(["1"]);
+    load(provider, machines(2), 6);
+    act(() => {
+      provider.rotateScope();
+    });
+    expect(values(pageSelect())).toEqual(["1"]);
+  });
+
+  it("claims no total beside an earlier query's rows after the current one failed", () => {
+    const provider = makeProvider();
+    mount(provider);
+    load(provider, machines(2), 5);
+    act(() => {
+      provider.setSearch("m1");
+    });
+    const failed = provider.result.get().pendingRequestId;
+    if (failed === null) {
+      throw new Error("expected a pending request");
+    }
+    act(() => {
+      provider.complete(failed, { status: "failure", reason: "offline" });
+    });
+    expect(provider.result.get().result.status).toBe("stale");
+    expect(summary()).toBeEmptyDOMElement();
+    expect(next()).toBeDisabled();
+    expect(last()).toBeDisabled();
+  });
+
+  it("resets to the first page when the page size changes", () => {
+    const provider = makeProvider();
+    mount(provider, { sizes: [2, 25] });
+    load(provider, machines(2), 40);
+    fireEvent.click(next());
+    load(provider, machines(2), 40);
+    fireEvent.change(sizeSelect(), { target: { value: "25" } });
+    // The old page number counted rows of a different size.
+    expect(windowOf(provider)).toEqual({ page: 1, size: 25 });
+  });
+
+  it("always offers the applied size, in order", () => {
+    mount(makeProvider());
+    expect(values(sizeSelect())).toEqual(["2", "50", "75", "100"]);
+    expect(sizeSelect()).toHaveValue("2");
+  });
+
+  it("offers each size once, and exactly the sizes given when one is applied", () => {
+    mount(makeProvider({ page: 1, size: 25 }), { sizes: [50, 25, 50] });
+    expect(values(sizeSelect())).toEqual(["50", "25"]);
+  });
+
+  it("moves focus to the page select when the focused button becomes unavailable", () => {
+    const provider = makeProvider();
+    mount(provider);
+    load(provider, machines(2), 4);
+    next().focus();
+    fireEvent.click(next());
+    // Next waits for the page it asked for, so it cannot keep the focus.
+    expect(next()).toBeDisabled();
+    expect(pageSelect()).toHaveFocus();
+  });
+
+  it("keeps focus on a button that stays available", () => {
+    const provider = makeProvider({ page: 3, size: 2 });
+    mount(provider);
+    load(provider, machines(2), 6);
+    previous().focus();
+    fireEvent.click(previous());
+    load(provider, machines(2), 6);
+    expect(previous()).toBeEnabled();
+    expect(previous()).toHaveFocus();
+  });
+
+  it("leaves focus alone once it has left the buttons", () => {
+    const provider = makeProvider();
+    mount(provider);
+    load(provider, machines(2), 4);
+    next().focus();
+    next().blur();
+    act(() => {
+      provider.navigateWindow(2);
+    });
+    expect(next()).toBeDisabled();
+    expect(pageSelect()).not.toHaveFocus();
+  });
+
+  it("follows the window and pages under StrictMode", () => {
+    const provider = makeProvider();
+    render(
+      <StrictMode>
+        <PaginationBar provider={provider} />
+      </StrictMode>,
+    );
+    load(provider, machines(2), 5);
+    expect(summary()).toHaveTextContent(/^Showing 1–2 out of 5 items$/);
+    fireEvent.click(next());
+    expect(windowOf(provider)).toEqual({ page: 2, size: 2 });
+    load(provider, machines(2), 5);
+    expect(pageSelect()).toHaveValue("2");
+  });
+
+  it("passes native nav props through and merges the class name", () => {
+    mount(makeProvider(), { className: "footer", id: "machines-pages" });
+    const nav = screen.getByRole("navigation", { name: "Pagination" });
+    expect(nav).toHaveClass("ds", "data-table-pagination-bar", "footer");
+    expect(nav).toHaveAttribute("id", "machines-pages");
+  });
+});

--- a/packages/react/dataviews/src/lib/PaginationBar/PaginationBar.tsx
+++ b/packages/react/dataviews/src/lib/PaginationBar/PaginationBar.tsx
@@ -1,0 +1,223 @@
+import type {
+  Identity,
+  RowRecord,
+  SchemaFieldDefinition,
+  Slice,
+} from "@canonical/dataviews-core";
+import { isIdentity, sliceEquals } from "@canonical/dataviews-core";
+import { Button } from "@canonical/react-ds-global";
+import { SelectInput } from "@canonical/react-ds-global-form";
+import type { FocusEvent, ReactElement } from "react";
+import { useId, useLayoutEffect, useRef, useState } from "react";
+import useDataViewsValue from "../DataViews/hooks/useDataViewsValue.js";
+import plural from "../DataViews/plural.js";
+import type { PaginationState } from "./paginationState.js";
+import paginationState from "./paginationState.js";
+import type { PaginationBarProps } from "./types.js";
+import "./styles.css";
+
+const componentCssClassName = "ds data-table-pagination-bar";
+
+const DEFAULT_SIZES: readonly number[] = [50, 75, 100];
+
+/**
+ * What the result summary says. Empty while the rows on screen answer an
+ * earlier query. It names the rows, not only their count, so a page change
+ * is announced.
+ */
+const summaryOf = ({ page, size, shown, total }: PaginationState): string => {
+  if (shown === null) {
+    return "";
+  }
+  const first = (page - 1) * size + 1;
+  if (shown === 1) {
+    return total === null
+      ? `Showing item ${first}`
+      : `Showing item ${first} out of ${total}`;
+  }
+  const range = shown === 0 ? "0" : `${first}–${first + shown - 1}`;
+  return total === null
+    ? `Showing ${range} items`
+    : `Showing ${range} out of ${total} ${plural(total, "item")}`;
+};
+
+/** A settled page count, and the scope, query and page size that made it. */
+type SettledPages = {
+  readonly pages: number;
+  readonly scope: Identity;
+  readonly slice: Slice;
+  readonly size: number;
+};
+
+const optionsOf = (values: readonly number[]) =>
+  values.map((value) => ({ value: String(value), label: String(value) }));
+
+/**
+ * The bar beneath a collection's rows: the page size, which items are on
+ * screen out of how many, and the way to every other page.
+ *
+ * It takes its provider explicitly, as DataTable does, so a standalone table
+ * gets the same footer as a composed one. It offers only pages the
+ * collection can reach, and a focused button that becomes unavailable hands
+ * the focus to the page select.
+ *
+ * @implements ds:apps.subcomponent.data_table-pagination_bar
+ */
+export default function PaginationBar<
+  TFields extends readonly SchemaFieldDefinition[],
+  TRow extends object = RowRecord,
+>({
+  provider,
+  label = "Pagination",
+  sizes = DEFAULT_SIZES,
+  className,
+  ...rest
+}: PaginationBarProps<TFields, TRow>): ReactElement {
+  if (!isIdentity(provider?.identity)) {
+    throw new Error(
+      "PaginationBar requires a provider created by createDataViewsProvider",
+    );
+  }
+  const snapshot = useDataViewsValue(provider.result);
+  const view = paginationState(snapshot, sizes);
+  const { page, pages } = view;
+  const baseId = useId();
+  const sizeId = `${baseId}-size`;
+  const totalId = `${baseId}-total`;
+
+  // The page select keeps the last settled page count while a page move
+  // loads, so stepping through it does not cut its own list short. A new
+  // query, page size or scope makes a new count, so it drops the old one.
+  const [settled, setSettled] = useState<SettledPages | null>(null);
+  const { scope, slice } = snapshot;
+  const matching =
+    settled !== null &&
+    settled.scope === scope &&
+    settled.size === view.size &&
+    sliceEquals(settled.slice, slice)
+      ? settled
+      : null;
+  if (pages !== null && matching?.pages !== pages) {
+    setSettled({ pages, scope, slice, size: view.size });
+  }
+  const listed = pages ?? matching?.pages ?? page;
+  // A page past the last is listed after the real pages, so the select can
+  // show it.
+  const pageOptions = optionsOf([
+    ...Array.from({ length: listed }, (_, at) => at + 1),
+    ...(page > listed ? [page] : []),
+  ]);
+
+  // The navigation button last focused, until focus leaves it. A button
+  // disabled while focused reports no blur, so this finds focus stranded.
+  const focused = useRef<HTMLButtonElement | null>(null);
+  const pageSelect = useRef<HTMLSelectElement>(null);
+  useLayoutEffect(() => {
+    if (focused.current?.disabled) {
+      focused.current = null;
+      pageSelect.current?.focus();
+    }
+  });
+  const trackFocus = {
+    onFocus: (event: FocusEvent<HTMLButtonElement>) => {
+      focused.current = event.currentTarget;
+    },
+    onBlur: () => {
+      focused.current = null;
+    },
+  };
+
+  const go = (destination: number) => () => {
+    provider.navigateWindow(destination);
+  };
+
+  return (
+    <nav
+      {...rest}
+      aria-label={label}
+      className={[componentCssClassName, className].filter(Boolean).join(" ")}
+    >
+      <div className="leading">
+        <div className="page-size">
+          <label htmlFor={sizeId}>Items per page:</label>
+          <SelectInput
+            id={sizeId}
+            value={String(view.size)}
+            options={optionsOf(view.sizes)}
+            onChange={(event) => {
+              // A new page size is a new window: the old page number counted
+              // rows of a different size, so it cannot survive the change.
+              provider.navigateWindow(1, Number(event.target.value));
+            }}
+          />
+        </div>
+        <span className="divider" />
+        <span role="status" className="summary">
+          {summaryOf(view)}
+        </span>
+      </div>
+      <div className="trailing">
+        <div className="page">
+          <SelectInput
+            ref={pageSelect}
+            aria-label="Page"
+            aria-describedby={pages === null ? undefined : totalId}
+            value={String(page)}
+            options={pageOptions}
+            onChange={(event) => {
+              provider.navigateWindow(Number(event.target.value));
+            }}
+          />
+          {pages === null ? null : (
+            <span id={totalId} className="total">
+              {`of ${pages} ${plural(pages, "page")}`}
+            </span>
+          )}
+        </div>
+        <span className="divider" />
+        <div className="navigation">
+          <Button
+            {...trackFocus}
+            type="button"
+            importance="tertiary"
+            icon="back-to-top"
+            className="first"
+            aria-label="First page"
+            disabled={page <= 1}
+            onClick={go(1)}
+          />
+          <Button
+            {...trackFocus}
+            type="button"
+            importance="tertiary"
+            icon="chevron-left"
+            className="previous"
+            aria-label="Previous page"
+            disabled={page <= 1}
+            onClick={go(view.back)}
+          />
+          <Button
+            {...trackFocus}
+            type="button"
+            importance="tertiary"
+            icon="chevron-right"
+            className="next"
+            aria-label="Next page"
+            disabled={!view.hasNext}
+            onClick={go(page + 1)}
+          />
+          <Button
+            {...trackFocus}
+            type="button"
+            importance="tertiary"
+            icon="back-to-top"
+            className="last"
+            aria-label="Last page"
+            disabled={pages === null || page === pages}
+            onClick={go(pages ?? page)}
+          />
+        </div>
+      </div>
+    </nav>
+  );
+}

--- a/packages/react/dataviews/src/lib/PaginationBar/index.ts
+++ b/packages/react/dataviews/src/lib/PaginationBar/index.ts
@@ -1,0 +1,2 @@
+export { default as PaginationBar } from "./PaginationBar.js";
+export type * from "./types.js";

--- a/packages/react/dataviews/src/lib/PaginationBar/paginationState.test.ts
+++ b/packages/react/dataviews/src/lib/PaginationBar/paginationState.test.ts
@@ -1,0 +1,126 @@
+import type {
+  CollectionCoordinatorState,
+  ResultWindow,
+} from "@canonical/dataviews-core";
+import {
+  createDataViewsProvider,
+  createSchema,
+} from "@canonical/dataviews-core";
+import { describe, expect, it } from "vitest";
+import paginationState from "./paginationState.js";
+
+const schema = createSchema([
+  { field: "status", kind: "choices", options: ["failed", "ready"] },
+]);
+
+type Settled = {
+  readonly rows: number;
+  readonly count: number | null;
+};
+
+/**
+ * A provider's snapshot on `window`: settled with `settled` when given, and
+ * with a replacement for the next page in flight when `pending` is set.
+ */
+const snapshot = (
+  window: ResultWindow,
+  settled?: Settled,
+  pending = false,
+): CollectionCoordinatorState<object> => {
+  const provider = createDataViewsProvider({ schema, window });
+  if (settled !== undefined) {
+    const requestId = provider.refresh();
+    if (requestId === null) {
+      throw new Error("expected a refresh request");
+    }
+    provider.complete(requestId, {
+      status: "success",
+      rows: Array.from({ length: settled.rows }, (_, at) => ({ id: `m${at}` })),
+      count: settled.count,
+    });
+  }
+  if (pending) {
+    provider.navigateWindow(window.page + 1);
+  }
+  return provider.result.get();
+};
+
+describe("paginationState", () => {
+  it("claims nothing before the first results", () => {
+    expect(paginationState(snapshot({ page: 1, size: 5 }), [5])).toMatchObject({
+      page: 1,
+      size: 5,
+      shown: null,
+      total: null,
+      pages: null,
+      hasNext: false,
+      sizes: [5],
+    });
+  });
+
+  it("counts the pages a filtered total makes", () => {
+    const state = paginationState(
+      snapshot({ page: 2, size: 5 }, { rows: 5, count: 12 }),
+      [5],
+    );
+    expect(state).toMatchObject({ shown: 5, total: 12, pages: 3 });
+    expect(state.hasNext).toBe(true);
+    expect(state.back).toBe(1);
+  });
+
+  it("steps back one page from the last", () => {
+    expect(
+      paginationState(
+        snapshot({ page: 3, size: 5 }, { rows: 2, count: 12 }),
+        [5],
+      ).back,
+    ).toBe(2);
+  });
+
+  it("keeps one page for an empty collection", () => {
+    expect(
+      paginationState(
+        snapshot({ page: 1, size: 5 }, { rows: 0, count: 0 }),
+        [5],
+      ).pages,
+    ).toBe(1);
+  });
+
+  it("offers Next without a count only while the page is full", () => {
+    const window = { page: 1, size: 5 };
+    expect(
+      paginationState(snapshot(window, { rows: 5, count: null }), [5]).hasNext,
+    ).toBe(true);
+    expect(
+      paginationState(snapshot(window, { rows: 4, count: null }), [5]).hasNext,
+    ).toBe(false);
+  });
+
+  it("steps back from past the last page to the last one there is", () => {
+    expect(
+      paginationState(
+        snapshot({ page: 9, size: 5 }, { rows: 0, count: 12 }),
+        [5],
+      ).back,
+    ).toBe(3);
+  });
+
+  it("claims no count or total for a replacement in flight", () => {
+    const state = paginationState(
+      snapshot({ page: 1, size: 5 }, { rows: 5, count: 12 }, true),
+      [5],
+    );
+    expect(state).toMatchObject({ page: 2, shown: null, total: null });
+    expect(state.hasNext).toBe(false);
+  });
+
+  it("offers each size once, the applied one always among them", () => {
+    const window = { page: 1, size: 25 };
+    expect(paginationState(snapshot(window), [50, 10, 50]).sizes).toEqual([
+      10, 25, 50,
+    ]);
+    expect(paginationState(snapshot(window), [25, 50, 25]).sizes).toEqual([
+      25, 50,
+    ]);
+  });
+});

--- a/packages/react/dataviews/src/lib/PaginationBar/paginationState.ts
+++ b/packages/react/dataviews/src/lib/PaginationBar/paginationState.ts
@@ -1,0 +1,63 @@
+import type { CollectionCoordinatorState } from "@canonical/dataviews-core";
+
+/** What the pagination bar shows and offers for one collection snapshot. */
+export type PaginationState = {
+  /** The window's page, counted from one. */
+  readonly page: number;
+  /** How many rows a page holds. */
+  readonly size: number;
+  /**
+   * How many rows are on screen, or null while those rows do not answer the
+   * current query: nothing has arrived yet, a replacement is in flight, or it
+   * failed and left an earlier query's rows in view.
+   */
+  readonly shown: number | null;
+  /** The filtered total, when the source publishes one for this query. */
+  readonly total: number | null;
+  /** How many pages the total makes, when there is a total. */
+  readonly pages: number | null;
+  /** Whether a later page is known to exist. */
+  readonly hasNext: boolean;
+  /**
+   * Where Previous goes. A page past the last — an old link, a shrunken
+   * result — steps back to the last page there is, not one page at a time.
+   */
+  readonly back: number;
+  /** The page sizes offered, each once, always including the applied one. */
+  readonly sizes: readonly number[];
+};
+
+/**
+ * Derive the bar's state from the provider's snapshot.
+ *
+ * The destinations are the ones the collection can actually reach. A source
+ * that publishes a filtered total gets a last page; one that publishes no
+ * count gets a Next offered only while the page is full, and no invented
+ * last page. A total that belongs to an earlier query is not this one's.
+ */
+export default function paginationState(
+  snapshot: CollectionCoordinatorState<object>,
+  sizes: readonly number[],
+): PaginationState {
+  const { page, size } = snapshot.window;
+  const current = snapshot.resultsMatchCurrentQuery;
+  const rows = snapshot.result.rows;
+  const total = current ? snapshot.result.count : null;
+  const pages = total === null ? null : Math.max(1, Math.ceil(total / size));
+  // Without a total, a full page means there may be another. Rows from an
+  // older query prove nothing.
+  const pageIsFull = rows !== null && rows.length === size;
+  const given = [...new Set(sizes)];
+  return {
+    page,
+    size,
+    shown: current && rows !== null ? rows.length : null,
+    total,
+    pages,
+    hasNext: pages === null ? pageIsFull && current : page < pages,
+    back: pages !== null && page > pages ? pages : page - 1,
+    sizes: given.includes(size)
+      ? given
+      : [...given, size].sort((a, b) => a - b),
+  };
+}

--- a/packages/react/dataviews/src/lib/PaginationBar/styles.css
+++ b/packages/react/dataviews/src/lib/PaginationBar/styles.css
@@ -1,0 +1,105 @@
+/* Layer: ds.components.global (@canonical/styles README, "Cascade layers"). */
+
+@layer ds.components.global {
+  /**
+   * PaginationBar styles
+   *
+   * The specification is the anatomy beside the code,
+   * `PaginationBar.anatomy.yaml`. Every value below is one it binds; what it
+   * could not bind is recorded there, never hardcoded here.
+   *
+   * The selects and buttons are the design system's own. The bar themes them
+   * through their channels — the form layer's input tokens and the Button's
+   * padding — and overrides only what a row of them needs: a select's width,
+   * and each icon-only button's square.
+   */
+  .ds.data-table-pagination-bar {
+    /* Held to the bottom of whatever scrolls it, over the rows beneath. */
+    position: sticky;
+    inset-block-end: 0;
+    z-index: 1;
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--dimension-100);
+    padding-inline-start: var(--density-padding-inline);
+    color: var(--surface-color-text, var(--color-text));
+    font-family: var(--typography-text-primary-font-family);
+    font-size: var(--typography-text-primary-font-size);
+    font-weight: var(--typography-text-primary-font-weight);
+    /* The surface it sits on, so the rows it covers do not show through. */
+    background-color: var(--surface-color-background, var(--color-background));
+    border-block-start: var(--dimension-stroke-thickness-medium) solid
+      var(--color-border-muted);
+
+    /* The design's compact, borderless dropdown, on the select's own tokens. */
+    --form-input-height: var(--density-line-height-effective);
+    --form-input-padding-block: var(--dimension-050);
+    --form-input-padding-inline: var(--dimension-100);
+    --form-input-background: var(--color-foreground-ghost);
+    --form-input-border-color: transparent;
+
+    & > .leading,
+    & > .trailing {
+      display: flex;
+      align-items: center;
+      gap: var(--dimension-100);
+    }
+
+    & > .leading > .page-size,
+    & > .trailing > .page {
+      display: flex;
+      align-items: center;
+      gap: var(--dimension-050);
+      white-space: nowrap;
+    }
+
+    & > .trailing > .page {
+      padding-inline-end: var(--dimension-100);
+    }
+
+    & > .leading > .summary {
+      padding-inline-start: var(--dimension-100);
+      white-space: nowrap;
+    }
+
+    & > .leading > .divider,
+    & > .trailing > .divider {
+      inline-size: var(--dimension-stroke-thickness-medium);
+      block-size: var(--dimension-300);
+      background-color: var(--color-border-muted);
+    }
+
+    /* The input chrome fills its container; in a bar it takes its content. */
+    & > .leading > .page-size > .ds.input.select,
+    & > .trailing > .page > .ds.input.select {
+      inline-size: auto;
+    }
+
+    & > .trailing > .navigation {
+      display: flex;
+      align-items: center;
+    }
+
+    /* Icon-only Buttons collapse without a label. Each is held to a square
+       one row tall, its icon centred and its side padding equal. */
+    & > .trailing > .navigation > .ds.button {
+      --button-padding-inline-end: var(--dimension-100);
+      min-block-size: var(--density-line-height-effective);
+      min-inline-size: var(--density-line-height-effective);
+      align-items: center;
+      justify-content: center;
+    }
+
+    /* Until the design's skip icons ship: a bar with an arrow meeting it,
+       turned towards the edge the button goes to. */
+    & > .trailing > .navigation > .first .ds.icon {
+      rotate: -90deg;
+    }
+
+    & > .trailing > .navigation > .last .ds.icon {
+      rotate: 90deg;
+    }
+  }
+}

--- a/packages/react/dataviews/src/lib/PaginationBar/styles.test.tsx
+++ b/packages/react/dataviews/src/lib/PaginationBar/styles.test.tsx
@@ -1,0 +1,235 @@
+/**
+ * The stylesheet's contract with the markup, and the anatomy's with the DOM.
+ * jsdom applies no CSS, so what is pinned is what a stylesheet change can
+ * break with every render still green: each class the sheet styles is one the
+ * bar renders, the structure its combinators assume is the one it renders,
+ * every value is a token or a channel, and the declarations whose loss no
+ * render would show are still declared.
+ *
+ * The anatomy beside the code states the DOM each part renders; the same
+ * renders pin that it still does. This reads the anatomy's notes, not its
+ * structure: it is no validator.
+ */
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  createDataViewsProvider,
+  createSchema,
+} from "@canonical/dataviews-core";
+import { act, render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import PaginationBar from "./PaginationBar.js";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+
+/** A file beside this one, as text. */
+const read = (file: string): string =>
+  readFileSync(path.join(here, file), "utf8");
+
+// Comments and the layer name dropped, so neither prose nor `ds.components`
+// is ever taken for a class selector; whitespace collapsed, so a rule is
+// named by its selector list on one line.
+const sheet = read("styles.css")
+  .replace(/\/\*[\s\S]*?\*\//g, "")
+  .replace(/@layer[^{;]*/g, "")
+  .replace(/\s+/g, " ");
+
+/**
+ * The declarations of the rule whose selector list is exactly `selector`,
+ * up to its first nested rule: anchored at a rule's start, so a longer
+ * selector ending the same way never answers for it.
+ */
+const rule = (selector: string): string => {
+  const escaped = selector.replace(/[.*+?^${}()|[\]\\>]/g, "\\$&");
+  const body = sheet.match(
+    new RegExp(`(?:^|[;{}]) ?${escaped} ?\\{([^{}]*)`),
+  )?.[1];
+  if (body === undefined) {
+    throw new Error(`no rule for ${selector}`);
+  }
+  return body;
+};
+
+/**
+ * An anatomy note's DOM as a selector: a class list (`ds data-table-row
+ * status`, placeholders like `<kind>` dropped) or a selector already
+ * (`.page-size`).
+ */
+const selectorOf = (dom: string): string =>
+  dom.includes(" ")
+    ? dom
+        .split(" ")
+        .filter((name) => !name.startsWith("<"))
+        .map((name) => `.${name}`)
+        .join("")
+    : dom;
+
+/** A bar over two pages of results, the page total showing. */
+const loaded = (): HTMLElement => {
+  const schema = createSchema([
+    { field: "status", kind: "choices", options: ["failed", "ready"] },
+  ]);
+  const provider = createDataViewsProvider({
+    schema,
+    window: { page: 1, size: 2 },
+  });
+  const { container } = render(<PaginationBar provider={provider} />);
+  const requestId = provider.refresh();
+  if (requestId === null) {
+    throw new Error("expected a refresh request");
+  }
+  act(() => {
+    provider.complete(requestId, {
+      status: "success",
+      rows: [{ id: "m1" }, { id: "m2" }],
+      count: 3,
+    });
+  });
+  return container;
+};
+
+const bar = ".ds.data-table-pagination-bar";
+const navigation = "& > .trailing > .navigation";
+
+describe("PaginationBar stylesheet", () => {
+  it("styles only classes the bar renders", () => {
+    const styled = new Set(
+      [...sheet.matchAll(/\.([a-z][\w-]*)/g)].map(([, name]) => name),
+    );
+    const rendered = new Set(
+      [...loaded().querySelectorAll("[class]")].flatMap((element) => [
+        ...element.classList,
+      ]),
+    );
+    expect(styled.size).toBeGreaterThan(0);
+    expect([...styled].filter((name) => !rendered.has(name))).toEqual([]);
+  });
+
+  it("renders the structure the stylesheet's combinators assume", () => {
+    // Every class appearing somewhere is not enough: the sheet reaches each
+    // part through its parent, and a part that moves loses its rule.
+    const container = loaded();
+    for (const selector of [
+      `${bar} > .leading > .page-size > .ds.input.select`,
+      `${bar} > .leading > .divider`,
+      `${bar} > .leading > .summary`,
+      `${bar} > .trailing > .page > .ds.input.select`,
+      `${bar} > .trailing > .page > .total`,
+      `${bar} > .trailing > .divider`,
+      `${bar} > .trailing > .navigation > .ds.button`,
+      `${bar} > .trailing > .navigation > .first .ds.icon`,
+      `${bar} > .trailing > .navigation > .last .ds.icon`,
+    ]) {
+      expect(container.querySelector(selector), selector).not.toBeNull();
+    }
+  });
+
+  it("writes no length or colour of its own", () => {
+    // Every value is a token, a channel or a structural keyword: a missing
+    // token is recorded in the anatomy, never written here as a number.
+    expect(sheet).not.toMatch(/\d(px|rem|em)\b|#[0-9a-f]{3,8}\b|opacity/i);
+  });
+
+  it("holds to the bottom of what scrolls it, on the surface it covers", () => {
+    const root = rule(bar);
+    expect(root).toMatch(/position: sticky;/);
+    expect(root).toMatch(/inset-block-end: 0;/);
+    expect(root).toMatch(
+      /background-color: var\(--surface-color-background, var\(--color-background\)\);/,
+    );
+    expect(root).toMatch(
+      /border-block-start: var\(--dimension-stroke-thickness-medium\) solid var\(--color-border-muted\);/,
+    );
+    expect(root).toMatch(
+      /padding-inline-start: var\(--density-padding-inline\);/,
+    );
+  });
+
+  it("themes the design system's select through its own tokens", () => {
+    const root = rule(bar);
+    for (const declaration of [
+      /--form-input-height: var\(--density-line-height-effective\);/,
+      /--form-input-padding-block: var\(--dimension-050\);/,
+      /--form-input-padding-inline: var\(--dimension-100\);/,
+      /--form-input-background: var\(--color-foreground-ghost\);/,
+      /--form-input-border-color: transparent;/,
+    ]) {
+      expect(root).toMatch(declaration);
+    }
+    // The one property overridden rather than themed.
+    expect(
+      rule(
+        "& > .leading > .page-size > .ds.input.select, & > .trailing > .page > .ds.input.select",
+      ),
+    ).toMatch(/inline-size: auto;/);
+  });
+
+  it("holds each icon-only button to a square of the density line", () => {
+    // Left to the Button, an icon-only one is shorter than the minimum target.
+    const button = rule(`${navigation} > .ds.button`);
+    expect(button).toMatch(
+      /--button-padding-inline-end: var\(--dimension-100\);/,
+    );
+    expect(button).toMatch(
+      /min-block-size: var\(--density-line-height-effective\);/,
+    );
+    expect(button).toMatch(
+      /min-inline-size: var\(--density-line-height-effective\);/,
+    );
+    expect(button).toMatch(/align-items: center;/);
+    expect(button).toMatch(/justify-content: center;/);
+  });
+
+  it("turns the interim first and last icons towards their edges", () => {
+    expect(rule(`${navigation} > .first .ds.icon`)).toMatch(/rotate: -90deg;/);
+    expect(rule(`${navigation} > .last .ds.icon`)).toMatch(/rotate: 90deg;/);
+  });
+
+  it("draws the design's dividers", () => {
+    const divider = rule("& > .leading > .divider, & > .trailing > .divider");
+    expect(divider).toMatch(
+      /inline-size: var\(--dimension-stroke-thickness-medium\);/,
+    );
+    expect(divider).toMatch(/block-size: var\(--dimension-300\);/);
+  });
+});
+
+describe("PaginationBar anatomy", () => {
+  const anatomy = read("PaginationBar.anatomy.yaml");
+
+  it("is implemented by the component beside it", () => {
+    const uri = anatomy.match(/^node:\n\s+uri: (\S+)$/m)?.[1] ?? "";
+    expect(uri).toBe("apps.subcomponent.data_table-pagination_bar");
+    expect(read("PaginationBar.tsx")).toMatch(
+      /@implements ds:apps\.subcomponent\.data_table-pagination_bar(?![\w.-])/,
+    );
+  });
+
+  it("states only DOM the bar renders", () => {
+    const stated = [...anatomy.matchAll(/DOM `([^`]+)`/g)].map(([, dom]) =>
+      selectorOf(dom),
+    );
+    expect(stated.length).toBeGreaterThan(0);
+    const container = loaded();
+    expect(
+      stated.filter((selector) => container.querySelector(selector) === null),
+    ).toEqual([]);
+  });
+
+  it("names its four buttons as the DOM classes them", () => {
+    loaded();
+    for (const [name, destination] of [
+      ["first", "First page"],
+      ["previous", "Previous page"],
+      ["next", "Next page"],
+      ["last", "Last page"],
+    ]) {
+      expect(anatomy).toMatch(new RegExp(`slotName: ${name}$`, "m"));
+      expect(anatomy).toMatch(new RegExp(`DOM \`\\.${name}\``));
+      expect(screen.getByRole("button", { name: destination })).toHaveClass(
+        name,
+      );
+    }
+  });
+});

--- a/packages/react/dataviews/src/lib/PaginationBar/types.ts
+++ b/packages/react/dataviews/src/lib/PaginationBar/types.ts
@@ -1,0 +1,42 @@
+import type {
+  DataViewsProvider,
+  RowRecord,
+  SchemaFieldDefinition,
+} from "@canonical/dataviews-core";
+import type { ComponentProps } from "react";
+
+type OwnProps<
+  TFields extends readonly SchemaFieldDefinition[],
+  TRow extends object,
+> = {
+  /** The provider created by `createDataViewsProvider` whose window the bar pages. */
+  readonly provider: DataViewsProvider<TFields, TRow>;
+  /** The navigation's accessible name. Defaults to "Pagination". */
+  readonly label?: string;
+  /**
+   * The page sizes offered; 50, 75 and 100 by default. The applied size is
+   * always among them, so the control can never misreport the window it is
+   * describing.
+   */
+  readonly sizes?: readonly number[];
+};
+
+/**
+ * Props of the pagination bar. The root is a `nav`, so it extends native nav
+ * props. `children` is excluded: the bar's contents are derived from the
+ * window and what the source can count. So are `role`, which would override
+ * the nav's `navigation` role, and `aria-label` and `aria-labelledby`, which
+ * would override the name it takes from `label`.
+ */
+export type PaginationBarProps<
+  TFields extends readonly SchemaFieldDefinition[],
+  TRow extends object = RowRecord,
+> = OwnProps<TFields, TRow> &
+  Omit<
+    ComponentProps<"nav">,
+    | keyof OwnProps<TFields, TRow>
+    | "children"
+    | "role"
+    | "aria-label"
+    | "aria-labelledby"
+  >;

--- a/packages/react/dataviews/src/lib/index.css
+++ b/packages/react/dataviews/src/lib/index.css
@@ -17,3 +17,5 @@
  */
 
 @import url("./DataTable/styles.css");
+@import url("./DataViews/common/Actions/styles.css");
+@import url("./PaginationBar/styles.css");

--- a/packages/react/dataviews/src/lib/index.ts
+++ b/packages/react/dataviews/src/lib/index.ts
@@ -1,2 +1,3 @@
 export * from "./DataTable/index.js";
 export * from "./DataViews/index.js";
+export * from "./PaginationBar/index.js";

--- a/packages/react/dataviews/src/storybook/machines/consumerCode.ts
+++ b/packages/react/dataviews/src/storybook/machines/consumerCode.ts
@@ -1,0 +1,127 @@
+/**
+ * A story's consumer code, as its "Show code" panel shows it: one component
+ * an application could paste, wired the way an application wires one — the
+ * source, a provider told what that source can execute, and the binding
+ * built and disposed in an effect. Story-only.
+ */
+
+type ConsumerCode = {
+  /** Named imports from `@canonical/dataviews-react`. */
+  readonly parts: readonly string[];
+  /** Types from `@canonical/dataviews-core` the declarations use. */
+  readonly coreTypes?: readonly string[];
+  /** Further import lines, in place of the machines module's default one. */
+  readonly imports?: string;
+  /** Module-level code: columns, custom children. */
+  readonly declarations?: string;
+  /** The source, as source text; the machines over a local array by default. */
+  readonly source?: string;
+  /** The window the provider starts on, as source text. */
+  readonly window?: string;
+  /** Commands issued once the source is bound, as source text. */
+  readonly prepare?: string;
+  /** Keep the binding in state, for children that run actions through it. */
+  readonly keepsBinding?: boolean;
+  /** React hooks the declarations use beyond `useEffect` and `useState`. */
+  readonly hooks?: readonly string[];
+  /** What the component renders, as JSX source text. */
+  readonly render: string;
+};
+
+const machineSource = `createArraySource({
+      rows: machines,
+      fields: ["name", "status", "region", "cores", "owner"],
+      searchFields: ["name", "owner"],
+    })`;
+
+const indent = (text: string, depth: number): string =>
+  text
+    .split("\n")
+    .map((line) => (line === "" ? line : `${" ".repeat(depth)}${line}`))
+    .join("\n");
+
+/** The effect binding the source, and the commands issued once it is bound. */
+const bindingEffect = (
+  prepare: string | undefined,
+  keepsBinding: boolean,
+): string => {
+  const commands = prepare === undefined ? "" : `\n${indent(prepare, 4)}`;
+  const firstPage = `
+    if (provider.result.get().result.status === "idle") {
+      provider.refresh();
+    }`;
+  return keepsBinding
+    ? `  // The binding subscribes, so it lives in an effect that disposes it;
+  // it is kept in state for the actions that run through it.
+  const [binding, setBinding] = useState<SourceBinding | null>(null);
+  useEffect(() => {
+    const bound = createSourceBinding({ host: provider, adapter: source });
+    setBinding(bound);${commands}${firstPage}
+    return () => {
+      bound.dispose();
+      setBinding(null);
+    };
+  }, [provider, source]);`
+    : `  useEffect(() => {
+    // The binding subscribes, so it lives in an effect that disposes it.
+    const binding = createSourceBinding({ host: provider, adapter: source });${commands}${firstPage}
+    return binding.dispose;
+  }, [provider, source]);`;
+};
+
+/** The story parameters that show the consumer code for one story. */
+export const consumerCode = ({
+  parts,
+  coreTypes = [],
+  imports,
+  declarations,
+  source = machineSource,
+  window,
+  prepare,
+  keepsBinding = false,
+  hooks = [],
+  render,
+}: ConsumerCode) => {
+  const core = [
+    ...(source.includes("createArraySource(") ? ["createArraySource"] : []),
+    "createDataViewsProvider",
+    "createSourceBinding",
+    ...[...coreTypes, ...(keepsBinding ? ["SourceBinding"] : [])].map(
+      (name) => `type ${name}`,
+    ),
+  ];
+  return {
+    docs: {
+      source: {
+        language: "tsx",
+        code: [
+          `import {
+${core.map((name) => `  ${name},`).join("\n")}
+} from "@canonical/dataviews-core";
+import { ${parts.join(", ")} } from "@canonical/dataviews-react";
+import { ${["useEffect", "useState", ...hooks].join(", ")} } from "react";
+${imports ?? `import { machineSchema, machines } from "./machines.js";`}`,
+          declarations,
+          `export function Machines() {
+  const [source] = useState(() =>
+    ${source},
+  );
+  const [provider] = useState(() =>
+    createDataViewsProvider({
+      schema: machineSchema,
+      // What the source can execute: the parts offer nothing beyond it.
+      capabilities: source.capabilities,${window === undefined ? "" : `\n      window: ${window},`}
+    }),
+  );
+${bindingEffect(prepare, keepsBinding)}
+  return (
+${indent(render, 4)}
+  );
+}`,
+        ]
+          .filter((block) => block !== undefined)
+          .join("\n\n"),
+      },
+    },
+  };
+};

--- a/packages/react/dataviews/src/storybook/machines/fixtures.ts
+++ b/packages/react/dataviews/src/storybook/machines/fixtures.ts
@@ -2,8 +2,9 @@ import type { RowRecord, SourceAdapter } from "@canonical/dataviews-core";
 import { createArraySource, createSchema } from "@canonical/dataviews-core";
 
 /**
- * Story fixtures for DataTable. Story-only: this folder is excluded from the
- * package build, and the tests define their own minimal fixtures inline.
+ * Story fixtures for the machine collection. Story-only: this folder is
+ * excluded from the package build, and the tests define their own minimal
+ * fixtures inline.
  *
  * The stories drive a real `createArraySource` rather than a frozen page of
  * rows, so sorting, searching and paging in a story run the same path a
@@ -23,7 +24,7 @@ type Machine = {
 };
 
 /** Twelve machines, every status represented; one story pages them by five. */
-const machines = [
+export const machines = [
   {
     id: "m-01",
     name: "alder.example.com",
@@ -170,8 +171,36 @@ export const createMachineSource = (
     searchFields: ["name", "owner"],
   });
 
+/**
+ * A source that cannot filter or order by cores: its declaration leaves the
+ * field out, so no part may offer it.
+ */
+export const createSourceWithoutCores = (): SourceAdapter =>
+  createArraySource({
+    rows: machines,
+    fields: sortableFields.filter((field) => field !== "cores"),
+    searchFields: ["name", "owner"],
+  });
+
 /** A source whose collection has nothing in it. */
 export const createEmptySource = (): SourceAdapter => createMachineSource([]);
+
+/**
+ * A source that pages without counting, as many backends do: it declares no
+ * total and publishes none, so nothing can offer a last page.
+ */
+export const createUncountedSource = (): SourceAdapter => {
+  const source = createMachineSource();
+  return {
+    capabilities: { ...source.capabilities, count: "none" },
+    execute: (request, deliver) =>
+      source.execute(request, (result) => {
+        deliver(
+          result.status === "success" ? { ...result, count: null } : result,
+        );
+      }),
+  };
+};
 
 /** A source that accepts a request and never answers it. */
 export const createPendingSource = (): SourceAdapter => ({

--- a/packages/react/dataviews/src/storybook/machines/story-utils.tsx
+++ b/packages/react/dataviews/src/storybook/machines/story-utils.tsx
@@ -1,6 +1,7 @@
 import type {
   DataViewsProvider,
   ResultWindow,
+  RowRecord,
   SourceAdapter,
 } from "@canonical/dataviews-core";
 import {
@@ -13,13 +14,14 @@ import type { MachineFields } from "./fixtures.js";
 import { createMachineSource, machineSchema } from "./fixtures.js";
 
 /**
- * Story machinery for DataTable: the provider hook every story drives and the
+ * Story machinery for the machine collection's stories — the table, its
+ * filters and its bars: the provider hook every story drives and the
  * decorators that frame it. Story-only; the records and sources live in
  * `./fixtures.ts`.
  */
 
 /**
- * The provider every DataTable story drives. Its rows are the source's own
+ * The provider every story drives. Its rows are the source's own
  * records: the binding's host contract is typed over `RowRecord`.
  */
 export type MachineProvider = DataViewsProvider<MachineFields>;
@@ -74,8 +76,9 @@ export function useMachineProvider({
 }
 
 /**
- * Render the story inside the `.app` typography scope, which the table
- * assumes: primary text there takes the application sizes.
+ * Render the story inside the `.app` scope, which the table and its bars
+ * assume: primary text there takes the application sizes, and the density
+ * channel its application values.
  */
 export const withAppScope: Decorator = (Story) => (
   <div className="app">
@@ -91,3 +94,16 @@ export const withFrame =
       <Story />
     </div>
   );
+
+/** A frame of the given height that scrolls its content, as a panel would. */
+export const withScrollingFrame =
+  (height: string): Decorator =>
+  (Story) => (
+    <div style={{ maxHeight: height, overflow: "auto" }}>
+      <Story />
+    </div>
+  );
+
+/** Names a record for its selection checkbox: by host, else by identity. */
+export const hostName = (row: RowRecord, rowId: string): string =>
+  typeof row.name === "string" ? row.name : rowId;

--- a/packages/react/ds-global-form/src/lib/index.ts
+++ b/packages/react/ds-global-form/src/lib/index.ts
@@ -12,11 +12,15 @@ export type {
   RatingInputProps,
   RatingScale,
 } from "./subcomponent/index.js";
-// CheckboxInput is exposed directly too: other design-system components
-// compose the bare checkbox — a table's row selection, say — where no Field or
-// form applies. The component only: its props type is not yet a contract this
-// package commits to.
-export { CheckboxInput, RatingInput } from "./subcomponent/index.js";
+// CheckboxInput and SelectInput are exposed directly too: other design-system
+// components compose the bare control — a table's row selection, a pagination
+// bar's page select — where no Field or form applies. The components only:
+// their props types are not yet a contract this package commits to.
+export {
+  CheckboxInput,
+  RatingInput,
+  SelectInput,
+} from "./subcomponent/index.js";
 // Value formatting. `Formatter` is the contract for an input whose displayed
 // string differs from the one it submits; `useFormattedValue` is the piece worth
 // sharing, since keeping the caret stable across a reformat is the hard part.


### PR DESCRIPTION
## Done

Adds the two parts drawn beneath a collection's rows, specified before they are styled.

**The specification.** Anatomy files for the pagination bar and the action bar sit beside the code. Every visual property binds a token or the density channel; what neither can express (a 2px stroke, the sticky position, the surface channel, missing first/last icons) is written in the file.

**`PaginationBar`** is a new export: page size, a summary of the items on screen out of the filtered total, a page select with its total, and first/previous/next/last buttons.
```ts
<PaginationBar provider={provider} label="Machines pagination" sizes={[25, 50, 100]} />
```
- It takes its provider explicitly, like `DataTable`, so a standalone table gets the same footer as a composed one.
- It sticks to the bottom of what scrolls it and is built from the design system's `Button` and `SelectInput`.
- While a request is pending, or a failure left an earlier query's rows in view, the summary and total say nothing rather than something false.
- A focused navigation button that becomes unavailable hands focus to the page select.

**`DataViews.Pagination`** is the same bar bound to the enclosing root. It now puts page size first, defaults sizes to 50, 75 and 100, uses icon buttons named for their destination, and announces page moves through the summary.

**`DataViews.Actions`** is the action bar: the selection count, the caller's actions, and a button that clears the selection. It renders on the contrasted surface only while something is selected, and returns focus to where it came from when it leaves with focus inside.

**Stories and recipes** cover Filters, Pagination, the pagination bar, the action bar and the composed collection. The README's two composition recipes move to that recipe page. Story fixtures move to `src/storybook/machines`.

**In `@canonical/react-ds-global-form`:** `SelectInput` joins `CheckboxInput` in the root exports (component only).

`DataViews.Pagination` changes shape, but no release contains it, so this is not marked breaking.

Merge order: #1233 must land first — this is based on it, so the diff here is only this change.

## QA

- `bun run check` green at the root (68 projects).
- `@canonical/dataviews-react`: 240 tests at 100% branch/function/line/statement coverage; build and Storybook build pass.
- `@canonical/dataviews-core`: unchanged, 654 tests at 100%.
- All 40 stories render under `composeStories` in StrictMode, and their 40 `play` functions pass in Chromium against the static build, with no console errors.
- To look: `bun run storybook` in `packages/react/dataviews` — the Pagination bar, Action bar and Collection stories and recipe pages.

### PR readiness check

- [x] PR title follows the Conventional Commits format.
- [x] The code follows the appropriate code standards.
- [x] The package defines `check`, `check:fix`, `test`, `build`, `build:all`.
- [x] Visual surface (pagination bar, action bar) — Chromatic runs.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0143BZrKuhi4j3YdemH5SbqD
