### PR TITLE
fix(ds-global): open the ContextualMenu story previews in their own iframes

### DIFF
--- a/packages/react/ds-global/src/lib/component/ContextualMenu/ContextualMenu.stories.tsx
+++ b/packages/react/ds-global/src/lib/component/ContextualMenu/ContextualMenu.stories.tsx
@@ -36,6 +36,16 @@ const meta = {
   parameters: {
     // Centre the trigger in the story canvas so the (portalled) menu is framed.
     layout: "centered",
+    // Docs previews render in an iframe: the open menu is portalled and
+    // `position: fixed`, so it escapes every container — inside an iframe the
+    // preview window is its own viewport and the menu stays contained in its
+    // story.
+    docs: {
+      story: {
+        inline: false,
+        iframeHeight: "480px",
+      },
+    },
   },
 } satisfies Meta<typeof Component>;
 

--- a/packages/react/ds-global/src/lib/component/ContextualMenu/ContextualMenu.stories.tsx
+++ b/packages/react/ds-global/src/lib/component/ContextualMenu/ContextualMenu.stories.tsx
@@ -1,5 +1,5 @@
 import type { Decorator, Meta, StoryObj } from "@storybook/react-vite";
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import Component from "./ContextualMenu.js";
 import type { MenuEntry } from "./types.js";
 
@@ -29,10 +29,31 @@ const stage: Decorator = (Story) => (
   </div>
 );
 
+/**
+ * Every story renders its menu open — a story is first a picture of the
+ * pattern, and a preview has nothing else to click. The open is deferred one
+ * effect after mount rather than `useState(true)`: it must land like a click,
+ * once the trigger and the portalled menu both exist — opened on the very
+ * first render, the fitment positioning runs before either ref is attached
+ * and the menu lands unpositioned. Real state rather than a static
+ * `open: true` keeps the story interactive: Escape, an outside click, or
+ * choosing an item closes the menu, and the trigger reopens it. Open
+ * previews stack safely because each docs preview is its own iframe.
+ */
+const openByDefault: Decorator = (Story, context) => {
+  const [open, setOpen] = useState(false);
+  useEffect(() => {
+    setOpen(true);
+  }, []);
+  // Args passed here REPLACE the story's args, so the story's own args must be
+  // spread back in — without them the trigger and the items vanish.
+  return <Story args={{ ...context.args, open, onOpenChange: setOpen }} />;
+};
+
 const meta = {
   title: "components/ContextualMenu",
   component: Component,
-  decorators: [stage],
+  decorators: [stage, openByDefault],
   parameters: {
     // Centre the trigger in the story canvas so the (portalled) menu is framed.
     layout: "centered",
@@ -46,6 +67,12 @@ const meta = {
         iframeHeight: "480px",
       },
     },
+  },
+  argTypes: {
+    // The `openByDefault` decorator drives the open state, so panel controls
+    // for it would only ever be overridden by it.
+    open: { control: false },
+    onOpenChange: { control: false },
   },
 } satisfies Meta<typeof Component>;
 
@@ -88,8 +115,9 @@ export const LongScrollable: Story = {
 };
 
 /**
- * A trigger opens the menu on click. In the docs canvas the menus render closed
- * (click a trigger to open one) so they do not stack on top of one another.
+ * A trigger opens the menu on click — though in the stories the menu is open
+ * from the start (the `openByDefault` decorator): a story is first a picture
+ * of the pattern.
  */
 export const Default: Story = {
   args: {


### PR DESCRIPTION
## Done

- ContextualMenu docs previews now render in iframes: the open menu is
  portalled and position: fixed, so in an iframe it stays contained in its
  own preview instead of escaping over the docs page.

- Every story now renders its menu open via an `openByDefault` decorator
  (controlled `open`/`onOpenChange`), so the docs show the pattern itself
  without anything to click. Escape, outside clicks and the trigger still
  work.

## QA

git checkout contextual-menu-iframed
bun install                  # from repo root
cd packages/react/ds-global
bun run storybook 


- Open Storybook for @canonical/react-ds-global, go to
  components/ContextualMenu:
  - each story renders its menu open on load, anchored to the trigger
  - Escape, an outside click, or picking an item closes the menu; the
    trigger reopens it
  - the docs page shows every preview in its own framed iframe
  
## Chromatic

Visual changes are expected and intentional: the ContextualMenu story
previews are now iframed and render their menus open. Any diff Chromatic
reports should only touch ContextualMenu stories — approve them in the
Chromatic review. Diffs in other stories would be unexpected.

### PR readiness check

- [x] PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format, using one of the allowed types: `feat`, `fix`, `docs`, `refactor`, `chore`, `test`, `ci`, `revert`.
  - The matching type label is applied automatically from the title — there is no type label to add by hand.
  - Breaking changes are marked with `!` in the title (e.g. `feat(router)!: …`), which adds the `breaking` label.
- [x] The code follows the appropriate [code standards](https://github.com/canonical/web-code-standards)
- [x] All packages define the required scripts in `package.json`:
  - [x] All packages: `check`, `check:fix`, and `test`.
  - [x] Packages with build steps: `build` to build the package for development or distribution, `build:all` to build **all** artifacts. See [CONTRIBUTING.md](../old/CONTRIBUTING.md#24-full-artifact-builds-buildall) for details.
- [ ] If this PR introduces a **new package**: first-time publish has been done manually from inside the package directory using `npm publish --access public` (first-time publishing is not automated). Run `bun run publish:status` from the repo root to verify. Then configure an OIDC [trusted publisher](https://docs.npmjs.com/trusted-publishers) for the package on npmjs.com (repo `canonical/pragma`, workflow `tag.yml`) and set publishing access to disallow tokens, so the automated release workflow can publish future versions.
- [ ] If this PR does not require visual testing, add the `Chromatic: skip` label to skip Chromatic.

## Screenshots

[if relevant, include a screenshot or screen capture]
