### PR TITLE
feat(dataviews): opt-in row windowing for DataTable

### DIFF
--- a/packages/react/dataviews/README.md
+++ b/packages/react/dataviews/README.md
@@ -62,3 +62,4 @@ The recipes, with consumer code and the live stories beside them, are the Storyb
 - **Resizing and its limits** — held to the declared bounds; no control on the last column; one shared `presentation` gives two tables on a provider the same arrangement.
 - **A cell that reads its own scope** — a renderer reading its row's channels.
 - **The outcomes** — loading, failed, empty, no match, and retained rows that no longer answer the current query (`stale`), with `renderStatus`.
+- **Mounting only the rows in view** — `windowing={virtualRows({ estimatedRowHeight })}`, from `@canonical/dataviews-react/virtualization`, for a result window of thousands of rows: the table becomes its own scroll viewport and every row still counts.

--- a/packages/react/dataviews/package.json
+++ b/packages/react/dataviews/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@canonical/dataviews-react",
-  "description": "React bindings for @canonical/dataviews-core: the DataViews root with its connected Filters, Actions, Pagination and Views parts, provider context, the four scoped observation hooks, the DataTable renderer and the PaginationBar",
+  "description": "React bindings for @canonical/dataviews-core: the DataViews root with its connected Filters, Actions, Pagination and Views parts, provider context, the four scoped observation hooks, the DataTable renderer with its explicitly imported row windowing, and the PaginationBar",
   "version": "0.37.0",
   "type": "module",
   "module": "dist/esm/index.js",
@@ -10,6 +10,10 @@
     ".": {
       "types": "./dist/types/index.d.ts",
       "import": "./dist/esm/index.js"
+    },
+    "./virtualization": {
+      "types": "./dist/types/lib/virtualization/index.d.ts",
+      "import": "./dist/esm/lib/virtualization/index.js"
     },
     "./index.css": "./dist/esm/lib/index.css",
     "./package.json": "./package.json"

--- a/packages/react/dataviews/src/index.ts
+++ b/packages/react/dataviews/src/index.ts
@@ -2,7 +2,8 @@
  * @canonical/dataviews-react — React bindings for collection views: the
  * DataViews root with its connected Filters, Actions, Pagination and Views
  * parts, provider context, the four scoped observation hooks, the DataTable
- * renderer and the PaginationBar, built on @canonical/dataviews-core.
+ * renderer with its explicitly imported row windowing, and the
+ * PaginationBar, built on @canonical/dataviews-core.
  *
  * @packageDocumentation
  */

--- a/packages/react/dataviews/src/index.types.test.ts
+++ b/packages/react/dataviews/src/index.types.test.ts
@@ -16,6 +16,7 @@ import type {
   DataTableColumn,
   DataTableProps,
   DataTableStatus,
+  DataTableWindowing,
   DataViewsProps,
   FiltersProps,
   PaginationBarProps,
@@ -25,6 +26,8 @@ import type {
   UseDataViewsResult,
   ViewsProps,
 } from "./index.js";
+import type { VirtualRowsOptions } from "./lib/virtualization/index.js";
+import { virtualRows } from "./lib/virtualization/index.js";
 
 type Fields = readonly SchemaFieldDefinition[];
 
@@ -36,6 +39,7 @@ type EveryPublicType = [
   DataTableColumn,
   DataTableProps<Fields, RowRecord>,
   DataTableStatus,
+  DataTableWindowing,
   DataViewsProps<Fields>,
   FiltersProps,
   PaginationBarProps<Fields>,
@@ -49,7 +53,28 @@ type EveryPublicType = [
 describe("public surface types", () => {
   it("re-exports the full type surface from the barrel", () => {
     expectTypeOf<EveryPublicType>().not.toBeAny();
-    expectTypeOf<EveryPublicType["length"]>().toEqualTypeOf<14>();
+    expectTypeOf<EveryPublicType["length"]>().toEqualTypeOf<15>();
+  });
+});
+
+describe("the windowing prop", () => {
+  it("takes the descriptor virtualRows makes, and only that", () => {
+    expectTypeOf(
+      virtualRows({ estimatedRowHeight: 40 }),
+    ).toEqualTypeOf<DataTableWindowing>();
+    expectTypeOf<
+      DataTableProps<Fields, RowRecord>["windowing"]
+    >().toEqualTypeOf<DataTableWindowing | undefined>();
+    // What a descriptor carries is keyed by a symbol no entry point
+    // exports, so a descriptor has nothing to read and cannot be written
+    // by hand.
+    expectTypeOf<DataTableWindowing>().not.toHaveProperty("estimatedRowHeight");
+    expectTypeOf<{
+      readonly estimatedRowHeight: number;
+    }>().not.toExtend<DataTableWindowing>();
+    expectTypeOf<VirtualRowsOptions>().toEqualTypeOf<{
+      readonly estimatedRowHeight: number;
+    }>();
   });
 });
 

--- a/packages/react/dataviews/src/lib/DataTable/DataTable.anatomy.yaml
+++ b/packages/react/dataviews/src/lib/DataTable/DataTable.anatomy.yaml
@@ -16,6 +16,7 @@
 #                                         DOM `ds data-table-body-cell selection`
 #   status row      DOM `ds data-table-row status`
 #   status cell     DOM `ds data-table-body-cell status <kind>`
+#   gap             DOM `ds data-table-gap`, hidden from assistive technology
 # The selection and status cells share the body cell's class for its shared
 # box, but they are role nodes here, not BodyCells: the table's `selectable`
 # prop and its outcome choose them, never a column.
@@ -42,6 +43,18 @@
 #                       (1.3.1, 1.4.1, 4.1.3). The cell is `role=cell`, not a
 #                       live region; only the stale message is `role=status`.
 #   settings cell       "ContextualMenu trigger/items", when the part ships
+#   windowed body       "DataTable windowed rows" (1.3.1, 2.1.1, 2.4.3,
+#                       4.1.2): the root reports `aria-rowcount` and every
+#                       mounted row its `aria-rowindex` in logical order, the
+#                       header row being 1, so a gap is never read as the
+#                       table's end; the row holding focus stays mounted.
+#
+# Windowed: a table given `windowing` mounts only the entries near its
+# viewport. The body row group takes the `windowed` class and holds gaps
+# in place of the entries it does not mount: before the first run of
+# mounted entries, between runs, and after the last. The root becomes the
+# scroll viewport the range is measured against. None of this changes a
+# table without `windowing`.
 #
 # Deviations the DSL cannot express, recorded here:
 #   - The surface background channel: `appearance.background` is read through
@@ -72,6 +85,16 @@
 #     the DSL's token-path grammar (`[a-z0-9-]+`) cannot spell.
 #   - The header row group's stacking above the scrolled body uses z-index 1;
 #     the package has no stacking token.
+#   - A gap's height is the range's per-render publication, the height of
+#     the entries it stands for, written on the gap itself: geometry no
+#     stylesheet can know, as `--data-table-columns` is.
+#   - The windowed root is positioned (`layout.position: relative`), so the
+#     body's offset is measured from it, and it opts out of the browser's
+#     scroll anchoring (`overflow-anchor: none`): the range anchors the
+#     scroll itself, and two corrections would move it twice. By default it
+#     is no taller than the viewport (`100svh`), so the range stays bounded
+#     wherever it sits; a caller's own maximum wins. `windowed` is a class,
+#     not a registry state, and the DSL has no key for scroll anchoring.
 #
 # Seams, inert until their parts ship:
 #   - The trailing actions track: an actions column is a body cell taking the
@@ -83,6 +106,11 @@
 #   - The per-cell loading skeleton is not specified: one status row covers
 #     the four no-rows outcomes and the first load, and a refresh keeps the
 #     retained rows visible while the table reports busy.
+#   - Group header rows: an entry of its own kind among the body's entries,
+#     spanning every track at a height of its own, which a windowed body
+#     mounts and measures as it does a row. A sticky group header stacks
+#     under the header row group, whose height it would read from
+#     `--data-table-header-height`.
 node:
   uri: apps.pattern.data_table
   styles:
@@ -192,5 +220,10 @@ node:
                     cardinality: "1"
             relation:
               cardinality: "0..1"
+          # Windowed only: the space of the entries not mounted.
+          - node:
+              role: gap
+            relation:
+              cardinality: "0..*"
       relation:
         cardinality: "1"

--- a/packages/react/dataviews/src/lib/DataTable/DataTable.mdx
+++ b/packages/react/dataviews/src/lib/DataTable/DataTable.mdx
@@ -271,3 +271,50 @@ const statusText = (status: DataTableStatus): string => {
 <Canvas of={Stories.Failed} sourceState="none" />
 
 <Canvas of={Stories.NoMatch} sourceState="none" />
+
+## Mounting only the rows in view
+
+A table renders every row of its result window, which is the right default: a page of fifty is small, and every row is in the page for the browser's own search and for a reader without JavaScript. When a result window holds thousands of rows, give the table `windowing`, and it mounts only the rows near its viewport. `virtualRows` comes from its own entry point, `@canonical/dataviews-react/virtualization`, so an application that never imports it never ships it.
+
+```tsx
+import { createDataViewsProvider } from "@canonical/dataviews-core";
+import { DataTable, type DataTableColumn } from "@canonical/dataviews-react";
+import { virtualRows } from "@canonical/dataviews-react/virtualization";
+import { machineSchema, source } from "./machines.js";
+
+const provider = createDataViewsProvider({
+  schema: machineSchema,
+  capabilities: source.capabilities,
+  window: { page: 1, size: 10_000 },
+});
+
+// One descriptor serves any number of tables: each keeps its own
+// viewport, measurements and focus.
+const windowing = virtualRows({ estimatedRowHeight: 24 });
+
+const columns: readonly DataTableColumn[] = [
+  { id: "name", header: "Host", sortable: true },
+  { id: "status", header: "Status", sortable: true },
+  { id: "owner", header: "Owner" },
+];
+
+<DataTable
+  provider={provider}
+  columns={columns}
+  label="Machines"
+  windowing={windowing}
+  style={{ maxBlockSize: "24rem" }}
+/>;
+```
+
+- **Give the table its height.** The table becomes its own scroll viewport, with the header held above its rows. It is no taller than the screen unless its style says otherwise; a table as tall as its content would mount every row.
+- **The estimate is only an estimate.** `estimatedRowHeight` places a row until it is mounted, and then the row is measured. Rows may differ in height: a cell that wraps grows its row, and the rows around it make room. When a row above the viewport turns out taller than estimated, the view stays on the rows being read.
+- **Every row still counts.** The table reports how many rows it has and each mounted row its position among them, so assistive technology knows there is more above and below. Selection, the header's select-all and sorting act on every row of the result window, mounted or not.
+- **Focus stays put.** The row holding focus stays mounted however far the table scrolls, with a neighbour on each side, and is let go when focus leaves the table.
+- **What it does not do.** Rows that are not mounted are not in the page, so the browser's own search does not find them. On the server, and without JavaScript, the table renders its whole result window, and paging is what keeps that bounded: keep real page links for readers without JavaScript. Hydrating that markup costs what hydrating a table without `windowing` costs, before the table narrows to the rows in view.
+
+<Canvas of={Stories.Windowed} sourceState="none" />
+
+<Canvas of={Stories.WindowedVariableHeights} sourceState="none" />
+
+<Canvas of={Stories.WindowedKeepsFocus} sourceState="none" />

--- a/packages/react/dataviews/src/lib/DataTable/DataTable.stories.tsx
+++ b/packages/react/dataviews/src/lib/DataTable/DataTable.stories.tsx
@@ -10,7 +10,9 @@ import type {
 import {
   createEmptySource,
   createFailingSource,
+  createMachineSource,
   createPendingSource,
+  manyMachines,
 } from "../../storybook/machines/fixtures.js";
 import type {
   MachineProvider,
@@ -24,6 +26,7 @@ import {
 } from "../../storybook/machines/story-utils.js";
 import useDataViewsCell from "../DataViews/hooks/useDataViewsCell.js";
 import useDataViewsValue from "../DataViews/hooks/useDataViewsValue.js";
+import { virtualRows } from "../virtualization/index.js";
 import Component from "./DataTable.js";
 import type {
   DataTableCellProps,
@@ -46,6 +49,7 @@ const meta = {
     presentation: { control: false },
     rowLabel: { control: false },
     renderStatus: { control: false },
+    windowing: { control: false },
   },
 } satisfies Meta<typeof Component>;
 
@@ -992,4 +996,215 @@ export const LongValues: Story = {
       sizing: { kind: "flex", weight: 1, minPx: 160 },
     },
   ]),
+};
+
+/** 24px: a dense row, the border beneath it included. */
+const windowing = virtualRows({ estimatedRowHeight: 24 });
+
+/** Ten thousand machines, all in one window. */
+const tenThousand = {
+  source: () => createMachineSource(manyMachines(10_000)),
+  window: { page: 1, size: 10_000 },
+} as const;
+
+/** A windowed story's render: its args, windowed, over ten thousand machines. */
+const renderWindowed =
+  (columns: readonly DataTableColumn[]): NonNullable<Story["render"]> =>
+  (args) => (
+    <MachinesTable
+      {...args}
+      columns={columns}
+      windowing={windowing}
+      options={tenThousand}
+    />
+  );
+
+/** A windowed story's consumer code: the table, windowed, in a capped frame. */
+const windowedConsumer = (columns: string): NonNullable<Story["parameters"]> =>
+  consumer(
+    `const windowing = virtualRows({ estimatedRowHeight: 24 });
+
+${columns}
+
+<DataTable
+  provider={provider}
+  columns={columns}
+  label="Machines"
+  selectable
+  rowLabel={(row) => String(row.name)}
+  windowing={windowing}
+  style={{ maxBlockSize: "24rem" }}
+/>;`,
+    {
+      imports: `import { virtualRows } from "@canonical/dataviews-react/virtualization";`,
+      provider: `createDataViewsProvider({
+  schema: machineSchema,
+  capabilities: source.capabilities,
+  // Ten thousand machines, all in one window.
+  window: { page: 1, size: 10_000 },
+})`,
+    },
+  );
+
+/** The logical positions of the rows mounted right now. */
+const mountedPositions = (table: HTMLElement): number[] =>
+  [...table.querySelectorAll('[role="row"]')].map((row) =>
+    Number(row.getAttribute("aria-rowindex")),
+  );
+
+/**
+ * Windowed: ten thousand machines in one window, and only the rows near the
+ * viewport are mounted — a few dozen at a time, however far the table is
+ * scrolled. The table is its own scroll viewport, here capped at 24rem, with
+ * the header held above its rows.
+ *
+ * Every row still counts. The table reports ten thousand and one rows, the
+ * header's included, and each mounted row its position among them, so a
+ * screen reader never takes the last mounted row for the last row. Sorting,
+ * selection and the header's select-all act on every row of the result
+ * window, mounted or not.
+ */
+export const Windowed: Story = {
+  parameters: windowedConsumer(`const columns: readonly DataTableColumn[] = [
+  { id: "name", header: "Host", sortable: true },
+  { id: "status", header: "Status", sortable: true },
+  { id: "region", header: "Region" },
+  { id: "cores", header: "Cores", sortable: true },
+  { id: "owner", header: "Owner" },
+];`),
+  args: { selectable: true, style: { maxBlockSize: "24rem" } },
+  render: renderWindowed(sortableColumns),
+  play: async ({ canvas }) => {
+    const table = canvas.getByRole("table");
+    await waitFor(() =>
+      expect(table).toHaveAttribute("aria-rowcount", "10001"),
+    );
+    await expect(mountedPositions(table).length).toBeLessThan(40);
+    table.scrollTop = table.scrollHeight;
+    const last = await canvas.findByText("node-09999.example.com");
+    await expect(last.closest('[role="row"]')).toHaveAttribute(
+      "aria-rowindex",
+      "10001",
+    );
+    await expect(mountedPositions(table).length).toBeLessThan(40);
+  },
+};
+
+/** A note that wraps onto as many lines as it needs. */
+function WrappingNote({ value }: DataTableCellProps): ReactElement {
+  return <span style={{ whiteSpace: "normal" }}>{String(value)}</span>;
+}
+
+/**
+ * Rows of different heights: each note wraps onto as many lines as it
+ * needs, so a row runs from one line to three. The estimate only places a
+ * row until it is mounted; then it is measured, and the space of the rows
+ * around it follows. When a row above the viewport turns out taller than
+ * its estimate, the view stays on the rows being read rather than jumping.
+ */
+export const WindowedVariableHeights: Story = {
+  parameters:
+    windowedConsumer(`function WrappingNote({ value }: DataTableCellProps) {
+  return <span style={{ whiteSpace: "normal" }}>{String(value)}</span>;
+}
+
+const columns: readonly DataTableColumn[] = [
+  { id: "name", header: "Host", sizing: { kind: "fixed", px: 224 } },
+  { id: "status", header: "Status", sizing: { kind: "fixed", px: 96 } },
+  {
+    id: "note",
+    header: "Note",
+    cell: WrappingNote,
+    sizing: { kind: "flex", weight: 1, minPx: 160 },
+  },
+];`),
+  args: { selectable: true, style: { maxBlockSize: "24rem" } },
+  decorators: [withFrame("40rem")],
+  render: renderWindowed([
+    { id: "name", header: "Host", sizing: { kind: "fixed", px: 224 } },
+    { id: "status", header: "Status", sizing: { kind: "fixed", px: 96 } },
+    {
+      id: "note",
+      header: "Note",
+      cell: WrappingNote,
+      sizing: { kind: "flex", weight: 1, minPx: 160 },
+    },
+  ]),
+  play: async ({ canvas }) => {
+    const table = canvas.getByRole("table");
+    await canvas.findByText("node-00000.example.com");
+    table.scrollTop = table.scrollHeight / 2;
+    await waitFor(() =>
+      expect(Math.min(...mountedPositions(table).slice(1))).toBeGreaterThan(
+        1000,
+      ),
+    );
+    const header = table.querySelector(".ds.data-table-row-group.header");
+    const rows = () => [
+      ...table.querySelectorAll(".ds.data-table-row-group.body > [role=row]"),
+    ];
+    const frames = async (): Promise<void> => {
+      for (let frame = 0; frame < 2; frame += 1) {
+        await new Promise((resolve) => requestAnimationFrame(resolve));
+      }
+    };
+    await frames();
+    const headerBottom = header?.getBoundingClientRect().bottom ?? 0;
+    const [first] = rows().filter(
+      (row) => row.getBoundingClientRect().bottom > headerBottom,
+    );
+    const top = first.getBoundingClientRect().top;
+    // Settled, and measured: the row being read holds still.
+    await frames();
+    await expect(first.getBoundingClientRect().top).toBe(top);
+    // The mounted rows cover the viewport, with no blank band at either end.
+    const mounted = rows();
+    await expect(mounted[0].getBoundingClientRect().top).toBeLessThanOrEqual(
+      headerBottom,
+    );
+    await expect(
+      mounted[mounted.length - 1].getBoundingClientRect().bottom,
+    ).toBeGreaterThanOrEqual(table.getBoundingClientRect().bottom - 1);
+    await expect(
+      new Set(
+        mounted.map((row) => Math.round(row.getBoundingClientRect().height)),
+      ).size,
+    ).toBeGreaterThan(1);
+  },
+};
+
+/**
+ * Keeps focus: the first machine's checkbox has focus, and the table is
+ * scrolled thousands of rows past it. Its row stays mounted, with a
+ * neighbour on each side, so focus is never dropped and Tab or Shift+Tab
+ * from it still reaches the rows beside it. Once focus leaves the table,
+ * the row is let go.
+ */
+export const WindowedKeepsFocus: Story = {
+  parameters: windowedConsumer(`const columns: readonly DataTableColumn[] = [
+  { id: "name", header: "Host" },
+  { id: "status", header: "Status" },
+  { id: "region", header: "Region" },
+  { id: "cores", header: "Cores" },
+  { id: "owner", header: "Owner" },
+];`),
+  args: { selectable: true, style: { maxBlockSize: "24rem" } },
+  render: renderWindowed(plainColumns),
+  play: async ({ canvas }) => {
+    const checkbox = await canvas.findByRole("checkbox", {
+      name: "Select node-00000.example.com",
+    });
+    checkbox.focus();
+    const table = canvas.getByRole("table");
+    table.scrollTop = table.scrollHeight / 2;
+    await waitFor(() =>
+      expect(Math.max(...mountedPositions(table))).toBeGreaterThan(4000),
+    );
+    await expect(checkbox).toBeInTheDocument();
+    await expect(checkbox).toHaveFocus();
+    await expect(checkbox.closest('[role="row"]')).toHaveAttribute(
+      "aria-rowindex",
+      "2",
+    );
+  },
 };

--- a/packages/react/dataviews/src/lib/DataTable/DataTable.test.tsx
+++ b/packages/react/dataviews/src/lib/DataTable/DataTable.test.tsx
@@ -479,6 +479,14 @@ describe("DataTable", () => {
     expect(screen.getAllByRole("row")[1]).not.toHaveAttribute("aria-selected");
   });
 
+  it("leaves row counts and positions to a windowed table", () => {
+    loadedTable([machine("m-1", "alpha")]);
+    expect(screen.getByRole("table")).not.toHaveAttribute("aria-rowcount");
+    for (const row of screen.getAllByRole("row")) {
+      expect(row).not.toHaveAttribute("aria-rowindex");
+    }
+  });
+
   it("selects and clears exactly the displayed rows from the header", () => {
     const { provider } = loadedTable(
       [machine("m-1", "alpha"), machine("m-2", "beta")],

--- a/packages/react/dataviews/src/lib/DataTable/DataTable.tsx
+++ b/packages/react/dataviews/src/lib/DataTable/DataTable.tsx
@@ -5,6 +5,7 @@ import type {
 import {
   createGridInteraction,
   createPresentation,
+  displayEntries,
   isIdentity,
 } from "@canonical/dataviews-core";
 import type { CSSProperties, ReactElement, Ref } from "react";
@@ -16,6 +17,7 @@ import {
   sameColumns,
   sizingOf,
 } from "./columnKeys.js";
+import type { TableBodyProps } from "./common/index.js";
 import { HeaderCell, SelectAllCell, TableBody } from "./common/index.js";
 import defaultStatusText from "./defaultStatusText.js";
 import {
@@ -25,8 +27,9 @@ import {
   useStableValue,
   useTableGeometry,
 } from "./hooks/index.js";
-import tableStatus from "./tableStatus.js";
-import type { DataTableProps } from "./types.js";
+import tableStatus, { sameStatus } from "./tableStatus.js";
+import type { DataTableProps, DataTableWindowing } from "./types.js";
+import windowed from "./windowed.js";
 import "./styles.css";
 
 /**
@@ -38,6 +41,21 @@ const componentCssClassName = "ds data-table dense";
 
 /** A record answers to its own identity until the caller names it better. */
 const defaultRowLabel = (_row: object, rowId: string): string => rowId;
+
+/**
+ * The body a windowing descriptor carries, given the table's body props and
+ * its published tracks, which re-wrap cells when they change.
+ */
+const windowedRows = <TRow extends object>(
+  windowing: DataTableWindowing,
+  props: TableBodyProps<TRow>,
+  tracks: string | undefined,
+): ReactElement => {
+  const { body: Body, estimatedRowHeight } = windowing[windowed];
+  return (
+    <Body {...props} estimatedRowHeight={estimatedRowHeight} tracks={tracks} />
+  );
+};
 
 /**
  * Hand the container to the caller's ref, in whichever form it arrives, and
@@ -75,6 +93,9 @@ const applyRef = (
  * The selection column is not among them: its width is the stylesheet's,
  * and the columns share what it leaves.
  *
+ * Given `windowing`, it mounts only the rows near its viewport and reports
+ * every row's logical position; without it, every row is rendered.
+ *
  * @implements ds:apps.pattern.data_table
  */
 export default function DataTable<
@@ -88,6 +109,7 @@ export default function DataTable<
   selectable = false,
   rowLabel = defaultRowLabel,
   renderStatus = defaultStatusText,
+  windowing,
   className,
   style,
   ref,
@@ -150,7 +172,20 @@ export default function DataTable<
   const geometry = useTableGeometry(activePresentation, interaction, columnIds);
   const scopes = useRowScopes(provider, fields);
   const result = useDataViewsValue(provider.result);
-  const status = tableStatus(result);
+  // Held at one reference while it says the same thing, so the entries are
+  // derived again only when a row identity or the status changes.
+  const status = useStableValue(tableStatus(result), sameStatus);
+  const ids = useDataViewsValue(scopes.ids);
+  // The status row first, then the rows: kept beside a stale status,
+  // replaced by any other.
+  const entries = useMemo(
+    () =>
+      displayEntries({
+        rowIds: status === null || status.kind === "stale" ? ids : [],
+        status,
+      }),
+    [ids, status],
+  );
   const busy =
     result.result.status === "pending" || result.result.status === "refreshing";
 
@@ -188,6 +223,19 @@ export default function DataTable<
   const nameRow = useStableCallback(rowLabel);
   const showStatus = useStableCallback(renderStatus);
 
+  const body: TableBodyProps<TRow> = {
+    provider,
+    scopes,
+    entries,
+    columns: rendered,
+    fields,
+    selectable,
+    rowLabel: nameRow,
+    // While a status shows, the caller's own function, so a new one is
+    // shown at once; otherwise the held one, which re-renders nothing.
+    renderStatus: status === null ? showStatus : renderStatus,
+  };
+
   const geometryStyle = {
     ...style,
     "--data-table-columns": geometry.template,
@@ -203,12 +251,19 @@ export default function DataTable<
       role="table"
       aria-label={label}
       aria-busy={busy}
+      // Every logical row, the header's included, so a row a windowed
+      // table has not mounted is still counted.
+      aria-rowcount={windowing === undefined ? undefined : entries.length + 1}
     >
       {/* biome-ignore lint/a11y/useSemanticElements: <thead> is only valid inside a <table>, and this grid is deliberately not one */}
       <div role="rowgroup" className="ds data-table-row-group header">
         {/* biome-ignore lint/a11y/useSemanticElements: <tr> is only valid inside a <table>, and this grid is deliberately not one */}
         {/* biome-ignore lint/a11y/useFocusableInteractive: the row is structure, not a widget — the focusable controls live in its cells */}
-        <div role="row" className="ds data-table-row">
+        <div
+          role="row"
+          className="ds data-table-row"
+          aria-rowindex={windowing === undefined ? undefined : 1}
+        >
           {selectable ? (
             <SelectAllCell
               selection={provider.selection}
@@ -240,16 +295,11 @@ export default function DataTable<
           ))}
         </div>
       </div>
-      <TableBody
-        provider={provider}
-        scopes={scopes}
-        columns={rendered}
-        fields={fields}
-        selectable={selectable}
-        rowLabel={nameRow}
-        status={status}
-        renderStatus={showStatus}
-      />
+      {windowing === undefined ? (
+        <TableBody {...body} />
+      ) : (
+        windowedRows(windowing, body, geometry.template)
+      )}
     </div>
   );
 }

--- a/packages/react/dataviews/src/lib/DataTable/common/Row/Row.tsx
+++ b/packages/react/dataviews/src/lib/DataTable/common/Row/Row.tsx
@@ -14,6 +14,8 @@ function Row<TRow extends object>({
   fields,
   selectable,
   rowLabel,
+  position,
+  ref,
 }: RowProps<TRow>): ReactElement {
   const selected = useDataViewsValue(scope.selected);
   return (
@@ -22,11 +24,13 @@ function Row<TRow extends object>({
     // biome-ignore lint/a11y/useSemanticElements: <tr> is only valid inside a <table>, and this grid is deliberately not one
     // biome-ignore lint/a11y/useFocusableInteractive: the row is structure, not a widget — the focusable controls live in its cells
     <div
+      ref={ref}
       role="row"
       className={[componentCssClassName, selected && "selected"]
         .filter(Boolean)
         .join(" ")}
       aria-selected={selectable ? selected : undefined}
+      aria-rowindex={position}
     >
       {selectable ? (
         <SelectionCell

--- a/packages/react/dataviews/src/lib/DataTable/common/Row/types.ts
+++ b/packages/react/dataviews/src/lib/DataTable/common/Row/types.ts
@@ -3,6 +3,7 @@ import type {
   RowScope,
   SchemaFieldDefinition,
 } from "@canonical/dataviews-core";
+import type { Ref } from "react";
 import type { DataTableColumn } from "../../types.js";
 
 /**
@@ -19,4 +20,8 @@ export type RowProps<TRow extends object> = {
   readonly fields: readonly string[];
   readonly selectable: boolean;
   readonly rowLabel: (row: TRow, rowId: string) => string;
+  /** The row's logical position, reported only by a windowed table. */
+  readonly position?: number;
+  /** The row element, for a windowed table to measure. */
+  readonly ref?: Ref<HTMLDivElement>;
 };

--- a/packages/react/dataviews/src/lib/DataTable/common/StatusRow/StatusRow.tsx
+++ b/packages/react/dataviews/src/lib/DataTable/common/StatusRow/StatusRow.tsx
@@ -1,0 +1,41 @@
+import type { ReactElement } from "react";
+import type { StatusRowProps } from "./types.js";
+
+const componentCssClassName = "ds data-table-row status";
+
+/**
+ * The table's status row: one cell for the whole table, saying why there
+ * are no rows or, above rows kept from an earlier query, why they no longer
+ * answer the current one.
+ */
+export default function StatusRow({
+  status,
+  renderStatus,
+  position,
+  ref,
+}: StatusRowProps): ReactElement {
+  return (
+    // biome-ignore lint/a11y/useSemanticElements: <tr> is only valid inside a <table>, and this grid is deliberately not one
+    // biome-ignore lint/a11y/useFocusableInteractive: the row is structure, not a widget — the focusable controls live in its cells
+    <div
+      ref={ref}
+      role="row"
+      className={componentCssClassName}
+      aria-rowindex={position}
+    >
+      {/* biome-ignore lint/a11y/useSemanticElements: <td> is only valid inside a <table>, and this grid is deliberately not one */}
+      <div
+        role="cell"
+        className={`ds data-table-body-cell status ${status.kind}`}
+      >
+        {status.kind === "stale" ? (
+          // A polite status message: the rows did not move, so nothing
+          // else says so.
+          <span role="status">{renderStatus(status)}</span>
+        ) : (
+          renderStatus(status)
+        )}
+      </div>
+    </div>
+  );
+}

--- a/packages/react/dataviews/src/lib/DataTable/common/StatusRow/index.ts
+++ b/packages/react/dataviews/src/lib/DataTable/common/StatusRow/index.ts
@@ -1,0 +1,2 @@
+export { default as StatusRow } from "./StatusRow.js";
+export type * from "./types.js";

--- a/packages/react/dataviews/src/lib/DataTable/common/StatusRow/types.ts
+++ b/packages/react/dataviews/src/lib/DataTable/common/StatusRow/types.ts
@@ -1,0 +1,18 @@
+import type { ReactNode, Ref } from "react";
+import type { DataTableStatus } from "../../types.js";
+
+/**
+ * Props of the table's status row.
+ *
+ * Exempt from the native-prop extension convention: an internal renderer
+ * deriving its root from the table's status, not forwarding a caller's
+ * native props.
+ */
+export type StatusRowProps = {
+  readonly status: DataTableStatus;
+  readonly renderStatus: (status: DataTableStatus) => ReactNode;
+  /** The row's logical position, reported only by a windowed table. */
+  readonly position?: number;
+  /** The row element, for a windowed table to measure. */
+  readonly ref?: Ref<HTMLDivElement>;
+};

--- a/packages/react/dataviews/src/lib/DataTable/common/TableBody/TableBody.tsx
+++ b/packages/react/dataviews/src/lib/DataTable/common/TableBody/TableBody.tsx
@@ -1,7 +1,7 @@
 import type { ReactElement } from "react";
 import { memo } from "react";
-import useDataViewsValue from "../../../DataViews/hooks/useDataViewsValue.js";
 import { Row } from "../Row/index.js";
+import { StatusRow } from "../StatusRow/index.js";
 import type { TableBodyProps } from "./types.js";
 
 const componentCssClassName = "ds data-table-row-group body";
@@ -9,60 +9,46 @@ const componentCssClassName = "ds data-table-row-group body";
 function TableBody<TRow extends object>({
   provider,
   scopes,
+  entries,
   columns,
   fields,
   selectable,
   rowLabel,
-  status,
   renderStatus,
 }: TableBodyProps<TRow>): ReactElement {
-  const ids = useDataViewsValue(scopes.ids);
   return (
     // biome-ignore lint/a11y/useSemanticElements: <tbody> is only valid inside a <table>, and this grid is deliberately not one
     <div role="rowgroup" className={componentCssClassName}>
-      {status !== null ? (
-        // biome-ignore lint/a11y/useSemanticElements: <tr> is only valid inside a <table>, and this grid is deliberately not one
-        // biome-ignore lint/a11y/useFocusableInteractive: the row is structure, not a widget — the focusable controls live in its cells
-        <div role="row" className="ds data-table-row status">
-          {/* biome-ignore lint/a11y/useSemanticElements: <td> is only valid inside a <table>, and this grid is deliberately not one */}
-          <div
-            role="cell"
-            className={`ds data-table-body-cell status ${status.kind}`}
-          >
-            {status.kind === "stale" ? (
-              // A polite status message: the rows did not move, so nothing
-              // else says so.
-              <span role="status">{renderStatus(status)}</span>
-            ) : (
-              renderStatus(status)
-            )}
-          </div>
-        </div>
-      ) : null}
-      {status === null || status.kind === "stale"
-        ? ids.map((id) => (
-            <Row
-              key={id}
-              provider={provider}
-              scope={scopes.scope(id)}
-              columns={columns}
-              fields={fields}
-              selectable={selectable}
-              rowLabel={rowLabel}
-            />
-          ))
-        : null}
+      {entries.map((entry) =>
+        entry.kind === "status" ? (
+          <StatusRow
+            key={entry.id}
+            status={entry.status}
+            renderStatus={renderStatus}
+          />
+        ) : (
+          <Row
+            key={entry.id}
+            provider={provider}
+            scope={scopes.scope(entry.rowId)}
+            columns={columns}
+            fields={fields}
+            selectable={selectable}
+            rowLabel={rowLabel}
+          />
+        ),
+      )}
     </div>
   );
 }
 
 /**
- * The body observes the row identities itself, so a republication that
- * changes only the query, the ordering or the request status re-renders the
- * header and stops there — the rows go on watching their own channels. The
- * memo holds because the table hands it stable props: a caller's rebuilt
- * column array, `rowLabel` and `renderStatus` are all held at one identity.
- * A body showing a status re-renders with the table, which costs the status
- * row and, beside stale rows, one pass over memoised rows that bail out.
+ * Every entry the table displays, in order. Memoised, and every prop is
+ * held at one reference — the entries until a row identity or the status
+ * changes, a caller's rebuilt column array and `rowLabel` always — so a
+ * republication that changes only the query or the request status
+ * re-renders the header and stops there. While a status shows, a new
+ * `renderStatus` re-renders the body, which costs the status row and,
+ * beside stale rows, one pass over memoised rows that bail out.
  */
 export default memo(TableBody) as typeof TableBody;

--- a/packages/react/dataviews/src/lib/DataTable/common/TableBody/types.ts
+++ b/packages/react/dataviews/src/lib/DataTable/common/TableBody/types.ts
@@ -1,5 +1,6 @@
 import type {
   DataViewsProvider,
+  DisplayEntry,
   RowScopes,
   SchemaFieldDefinition,
 } from "@canonical/dataviews-core";
@@ -7,25 +8,24 @@ import type { ReactNode } from "react";
 import type { DataTableColumn, DataTableStatus } from "../../types.js";
 
 /**
- * Props of the table's body row group.
+ * Props of the table's body row group, windowed or not.
  *
  * Exempt from the native-prop extension convention: an internal renderer
- * deriving its root from the row-scope registry, not forwarding a caller's
+ * deriving its root from the table's entries, not forwarding a caller's
  * native props.
  */
 export type TableBodyProps<TRow extends object> = {
   readonly provider: DataViewsProvider<readonly SchemaFieldDefinition[], TRow>;
   readonly scopes: RowScopes<TRow>;
+  /**
+   * What the body displays, in order: the status row when there is a
+   * status — why there are no rows, or why the rows shown are an earlier
+   * query's — then the rows, unless the status replaces them.
+   */
+  readonly entries: readonly DisplayEntry<DataTableStatus>[];
   readonly columns: readonly DataTableColumn[];
   readonly fields: readonly string[];
   readonly selectable: boolean;
   readonly rowLabel: (row: TRow, rowId: string) => string;
-  /**
-   * Why there are no rows, or why the rows shown are an earlier query's
-   * after the current one failed; null while the rows shown answer the
-   * current query, or while they await its replacement (which the table
-   * marks busy).
-   */
-  readonly status: DataTableStatus | null;
   readonly renderStatus: (status: DataTableStatus) => ReactNode;
 };

--- a/packages/react/dataviews/src/lib/DataTable/common/index.ts
+++ b/packages/react/dataviews/src/lib/DataTable/common/index.ts
@@ -4,4 +4,5 @@ export * from "./ResizeHandle/index.js";
 export * from "./Row/index.js";
 export * from "./SelectAllCell/index.js";
 export * from "./SelectionCell/index.js";
+export * from "./StatusRow/index.js";
 export * from "./TableBody/index.js";

--- a/packages/react/dataviews/src/lib/DataTable/styles.css
+++ b/packages/react/dataviews/src/lib/DataTable/styles.css
@@ -41,9 +41,12 @@
 
   /* Rows take their width from the track list, not from the scroll
      container, so a hovered or selected fill covers every column of a table
-     that is wider than its viewport. */
+     that is wider than its viewport. The min-content width of a track list
+     is its minimums added up, and every minimum is a length, so this reads
+     no cell: a max-content width would size every cell of every row on
+     each layout, and paint the table too wide before the solver ran. */
   .ds.data-table-row-group {
-    min-inline-size: max-content;
+    min-inline-size: min-content;
   }
 
   .ds.data-table-row-group.header {

--- a/packages/react/dataviews/src/lib/DataTable/styles.test.tsx
+++ b/packages/react/dataviews/src/lib/DataTable/styles.test.tsx
@@ -2,8 +2,9 @@
  * The stylesheet's contract with the markup. jsdom applies no CSS, so what is
  * pinned is what a stylesheet change can break with every render still
  * green: each class the sheet styles is one the table renders, nothing below
- * the table carries a style of its own, and the declarations whose loss no
- * render would show are still declared.
+ * the table carries a style of its own but a windowed table's gaps, which
+ * carry their height alone, and the declarations whose loss no render would
+ * show are still declared.
  *
  * The anatomy beside the code states the DOM each part renders; the same
  * renders pin that it still does. This reads the anatomy's notes, not its
@@ -23,6 +24,7 @@ import {
 } from "@canonical/dataviews-core";
 import { act, cleanup, render } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
+import virtualRows from "../virtualization/virtualRows.js";
 import DataTable from "./DataTable.js";
 import type { DataTableColumn } from "./types.js";
 
@@ -137,6 +139,35 @@ const loaded = (): HTMLElement =>
 const failed = (): HTMLElement =>
   settled({ status: "failure", reason: "unreachable" });
 
+/** A windowed table over more rows than it mounts, so it holds a gap. */
+const windowedTable = (): HTMLElement => {
+  const provider = createDataViewsProvider<typeof schema.fields, Machine>({
+    schema,
+    capabilities,
+  });
+  const { container } = render(
+    <DataTable
+      provider={provider}
+      columns={columns}
+      label="Machines"
+      windowing={virtualRows({ estimatedRowHeight: 32 })}
+    />,
+  );
+  const requestId = provider.refresh();
+  if (requestId === null) {
+    throw new Error("expected a refresh request");
+  }
+  const rows = Array.from({ length: 20 }, (_, position) => ({
+    id: `m-${position}`,
+    name: `host-${position}`,
+    status: "running",
+  }));
+  act(() => {
+    provider.complete(requestId, { status: "success", rows, count: 20 });
+  });
+  return container;
+};
+
 const classesOf = (container: HTMLElement): Set<string> =>
   new Set(
     [...container.querySelectorAll("[class]")].flatMap((element) => [
@@ -188,11 +219,23 @@ describe("DataTable stylesheet", () => {
 
   it("leaves every width to the stylesheet and the one published track list", () => {
     // The container's own publication is pinned in DataTable.test.tsx; no
-    // element inside it may carry a style of its own.
-    for (const mount of [loaded, failed]) {
+    // element inside it may carry a style of its own but a windowed table's
+    // gaps, each the height of the rows it stands for and nothing else.
+    for (const mount of [loaded, failed, windowedTable]) {
       const table = mount().querySelector('[role="table"]');
       expect(table).not.toBeNull();
-      expect(table?.querySelectorAll("[style]")).toHaveLength(0);
+      if (mount === windowedTable) {
+        expect(table?.querySelector(".ds.data-table-gap")).not.toBeNull();
+      }
+      for (const styled of table?.querySelectorAll<HTMLElement>("[style]") ??
+        []) {
+        expect(styled).toHaveClass("data-table-gap");
+        expect(
+          Array.from({ length: styled.style.length }, (_, position) =>
+            styled.style.item(position),
+          ),
+        ).toEqual(["block-size"]);
+      }
       cleanup();
     }
   });
@@ -336,7 +379,7 @@ describe("DataTable anatomy", () => {
       ),
     );
     expect(stated.size).toBeGreaterThan(0);
-    for (const mount of [loaded, failed]) {
+    for (const mount of [loaded, failed, windowedTable]) {
       const container = mount();
       for (const selector of [...stated]) {
         if (container.querySelector(selector) !== null) {

--- a/packages/react/dataviews/src/lib/DataTable/styles.test.tsx
+++ b/packages/react/dataviews/src/lib/DataTable/styles.test.tsx
@@ -197,6 +197,13 @@ describe("DataTable stylesheet", () => {
     }
   });
 
+  it("sizes row groups by their tracks' minimums, never by their cells", () => {
+    expect(rule(/\.ds\.data-table-row-group/)).toMatch(
+      /min-inline-size:\s*min-content;/,
+    );
+    expect(sheet).not.toMatch(/max-content/);
+  });
+
   it("writes no length or colour of its own", () => {
     // Every value is a token, a channel or a structural keyword: a missing
     // token is recorded in the anatomy, never written here as a number.

--- a/packages/react/dataviews/src/lib/DataTable/tableStatus.test.ts
+++ b/packages/react/dataviews/src/lib/DataTable/tableStatus.test.ts
@@ -10,7 +10,7 @@ import {
   createSchema,
 } from "@canonical/dataviews-core";
 import { describe, expect, it } from "vitest";
-import tableStatus from "./tableStatus.js";
+import tableStatus, { sameStatus } from "./tableStatus.js";
 
 const schema = createSchema([
   { field: "status", kind: "choices", options: ["failed", "running"] },
@@ -132,5 +132,28 @@ describe("tableStatus", () => {
 
   it("reports nothing at all while rows are displayed", () => {
     expect(tableStatus(loaded([{ id: "m-1" }]).result.get())).toBeNull();
+  });
+});
+
+describe("sameStatus", () => {
+  it("holds two statuses alike when they say the same thing", () => {
+    expect(sameStatus(null, null)).toBe(true);
+    expect(
+      sameStatus(
+        { kind: "stale", reason: "unreachable" },
+        { kind: "stale", reason: "unreachable" },
+      ),
+    ).toBe(true);
+  });
+
+  it("tells apart a different kind, a different reason and no status", () => {
+    expect(sameStatus({ kind: "loading" }, { kind: "no-data" })).toBe(false);
+    expect(
+      sameStatus(
+        { kind: "error", reason: "unreachable" },
+        { kind: "error", reason: "timed out" },
+      ),
+    ).toBe(false);
+    expect(sameStatus({ kind: "loading" }, null)).toBe(false);
   });
 });

--- a/packages/react/dataviews/src/lib/DataTable/tableStatus.ts
+++ b/packages/react/dataviews/src/lib/DataTable/tableStatus.ts
@@ -30,3 +30,18 @@ export default function tableStatus(
   const filtered = state.slice.filter.length > 0 || state.slice.search !== null;
   return { kind: filtered ? "no-results" : "no-data" };
 }
+
+/** A status's reason, where its kind has one. */
+const reasonOf = (status: DataTableStatus): string | undefined =>
+  "reason" in status ? status.reason : undefined;
+
+/** Two statuses say the same thing: the same kind, for the same reason. */
+export const sameStatus = (
+  a: DataTableStatus | null,
+  b: DataTableStatus | null,
+): boolean =>
+  a === b ||
+  (a !== null &&
+    b !== null &&
+    a.kind === b.kind &&
+    reasonOf(a) === reasonOf(b));

--- a/packages/react/dataviews/src/lib/DataTable/types.ts
+++ b/packages/react/dataviews/src/lib/DataTable/types.ts
@@ -5,6 +5,7 @@ import type {
   SchemaFieldDefinition,
 } from "@canonical/dataviews-core";
 import type { ComponentProps, ComponentType, ReactNode } from "react";
+import type { Windowed, default as windowed } from "./windowed.js";
 
 /** The props one column's cell renderer receives. */
 export type DataTableCellProps = {
@@ -73,6 +74,17 @@ export type DataTableStatus =
   | { readonly kind: "no-data" }
   | { readonly kind: "no-results" };
 
+/**
+ * A table that mounts only the rows near its viewport. Made by
+ * `virtualRows`, from `@canonical/dataviews-react/virtualization`: the one
+ * entry point that loads the implementation, so a table that never imports
+ * it never ships it.
+ */
+export type DataTableWindowing = {
+  /** The implementation, private to the package: nothing to read here. */
+  readonly [windowed]: Windowed;
+};
+
 type OwnProps<
   TFields extends readonly SchemaFieldDefinition[],
   TRow extends object,
@@ -106,6 +118,13 @@ type OwnProps<
    * re-renders the body.
    */
   readonly renderStatus?: (status: DataTableStatus) => ReactNode;
+  /**
+   * Mount only the rows near the viewport, from `virtualRows`. The table
+   * becomes its own scroll viewport, no taller than the screen unless its
+   * style says otherwise, and reports each row's logical position so that
+   * a row not mounted is still counted. Omitted, every row is rendered.
+   */
+  readonly windowing?: DataTableWindowing;
 };
 
 /**

--- a/packages/react/dataviews/src/lib/DataTable/windowed.ts
+++ b/packages/react/dataviews/src/lib/DataTable/windowed.ts
@@ -1,0 +1,35 @@
+import type { ReactNode } from "react";
+import type { TableBodyProps } from "./common/index.js";
+
+/**
+ * Props of the body a windowed table renders in place of its own: the
+ * table's own body props, the height a row is placed at until it is
+ * measured, and the table's published tracks, whose change re-wraps every
+ * row.
+ */
+export type WindowedBodyProps<TRow extends object> = TableBodyProps<TRow> & {
+  readonly estimatedRowHeight: number;
+  readonly tracks: string | undefined;
+};
+
+/** The body a windowed table renders in place of its own. */
+export type WindowedBody = <TRow extends object>(
+  props: WindowedBodyProps<TRow>,
+) => ReactNode;
+
+/** What a windowing descriptor carries: the body, and its row estimate. */
+export type Windowed = {
+  readonly body: WindowedBody;
+  readonly estimatedRowHeight: number;
+};
+
+/**
+ * The key a windowing descriptor carries its implementation under. The
+ * table reads it and the virtualization entry point writes it. Neither the
+ * key nor what it holds is exported, so no descriptor is made anywhere
+ * else, and the table's own entry point imports this key without ever
+ * importing the body.
+ */
+const windowed: unique symbol = Symbol("windowed");
+
+export default windowed;

--- a/packages/react/dataviews/src/lib/index.css
+++ b/packages/react/dataviews/src/lib/index.css
@@ -20,3 +20,4 @@
 @import url("./DataViews/common/Actions/styles.css");
 @import url("./DataViews/common/Views/styles.css");
 @import url("./PaginationBar/styles.css");
+@import url("./virtualization/common/VirtualBody/styles.css");

--- a/packages/react/dataviews/src/lib/virtualization/bundle.test.ts
+++ b/packages/react/dataviews/src/lib/virtualization/bundle.test.ts
@@ -1,0 +1,109 @@
+// @vitest-environment node
+/**
+ * Bundle isolation, read from the output module graph of two consumer
+ * bundles: one rendering DataTable without windowing ships no part of the
+ * virtualization, and one importing it ships the implementation over a
+ * single copy of the core both share. React and the design system's own
+ * packages stay external; the DataViews core is bundled, so its modules
+ * are in the graph to be counted.
+ */
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { build } from "vite";
+import { describe, expect, it } from "vitest";
+
+const lib = path.dirname(path.dirname(fileURLToPath(import.meta.url)));
+
+type Output = {
+  readonly output: readonly (
+    | { readonly type: "chunk"; readonly moduleIds: readonly string[] }
+    | {
+        readonly type: "asset";
+        readonly fileName: string;
+        readonly source: string | Uint8Array;
+      }
+  )[];
+};
+
+/** Bundle one consumer module; return its module graph and its CSS. */
+const bundle = async (
+  source: string,
+): Promise<{ readonly modules: string[]; readonly css: string }> => {
+  const result = (await build({
+    configFile: false,
+    logLevel: "silent",
+    root: path.dirname(path.dirname(lib)),
+    plugins: [
+      {
+        name: "consumer",
+        resolveId: (id) => (id === "consumer" ? "\0consumer" : null),
+        load: (id) => (id === "\0consumer" ? source : null),
+      },
+    ],
+    build: {
+      write: false,
+      minify: false,
+      rolldownOptions: {
+        input: "consumer",
+        // An application build drops its entry's exports, and with them
+        // everything but side effects: keep them, as a consumer's use would.
+        preserveEntrySignatures: "strict",
+        external: (id) =>
+          /^(react|react-dom)(\/|$)/.test(id) ||
+          /^@canonical\/(?!dataviews-core)/.test(id),
+      },
+    },
+  })) as Output | Output[];
+  const files = (Array.isArray(result) ? result : [result]).flatMap(
+    (output) => output.output,
+  );
+  return {
+    modules: files.flatMap((file) =>
+      file.type === "chunk" ? file.moduleIds : [],
+    ),
+    css: files
+      .flatMap((file) =>
+        file.type === "asset" && file.fileName.endsWith(".css")
+          ? [String(file.source)]
+          : [],
+      )
+      .join(""),
+  };
+};
+
+const from = (module: string): string => JSON.stringify(path.join(lib, module));
+
+describe("bundle isolation", () => {
+  it("ships no virtualization to a table without windowing", async () => {
+    const { modules, css } = await bundle(
+      `export { DataTable } from ${from("index.ts")};`,
+    );
+    // The table's own graph is there, down to the core modules it runs on.
+    expect(modules.some((id) => id.endsWith("DataTable.tsx"))).toBe(true);
+    expect(modules.some((id) => id.endsWith("/rows/createRowScopes.js"))).toBe(
+      true,
+    );
+    expect(modules.filter((id) => id.includes("/virtualization/"))).toEqual([]);
+    expect(css).toContain("data-table");
+    expect(css).not.toContain("windowed");
+  }, 60_000);
+
+  it("ships the implementation over one copy of the shared core", async () => {
+    const { modules, css } = await bundle(
+      `export { DataTable } from ${from("index.ts")};
+export { virtualRows } from ${from("virtualization/index.ts")};`,
+    );
+    expect(modules.some((id) => id.endsWith("VirtualBody.tsx"))).toBe(true);
+    expect(
+      modules.filter((id) => id.endsWith("/createVirtualRange.js")),
+    ).toHaveLength(1);
+    expect(
+      modules.filter((id) => id.endsWith("/observable/createChannel.js")),
+    ).toHaveLength(1);
+    // The core arrives one way only: as its built package.
+    expect(
+      modules.filter((id) => id.includes("/runtime/dataviews/src/")),
+    ).toEqual([]);
+    expect(css).toContain("windowed");
+  }, 60_000);
+});

--- a/packages/react/dataviews/src/lib/virtualization/common/VirtualBody/VirtualBody.ssr.test.tsx
+++ b/packages/react/dataviews/src/lib/virtualization/common/VirtualBody/VirtualBody.ssr.test.tsx
@@ -1,0 +1,45 @@
+/**
+ * On the server there is no viewport, so a windowed table renders its whole
+ * current window: the markup a reader without JavaScript gets is complete,
+ * and the range narrows it once the client measures.
+ */
+import {
+  createDataViewsProvider,
+  createSchema,
+} from "@canonical/dataviews-core";
+import { renderToString } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+import DataTable from "../../../DataTable/DataTable.js";
+import virtualRows from "../../virtualRows.js";
+
+const schema = createSchema([
+  { field: "status", kind: "choices", options: ["failed", "running"] },
+]);
+
+describe("windowed DataTable SSR", () => {
+  it("renders every row of the window, each at its logical position", () => {
+    const provider = createDataViewsProvider({ schema });
+    const requestId = provider.refresh();
+    if (requestId === null) {
+      throw new Error("expected a refresh request");
+    }
+    const rows = Array.from({ length: 30 }, (_, position) => ({
+      id: `m-${position}`,
+      name: `host-${position}`,
+    }));
+    provider.complete(requestId, { status: "success", rows, count: 30 });
+    const html = renderToString(
+      <DataTable
+        provider={provider}
+        label="Machines"
+        columns={[{ id: "name", header: "Name" }]}
+        windowing={virtualRows({ estimatedRowHeight: 32 })}
+      />,
+    );
+    expect(html).toContain('aria-rowcount="31"');
+    expect(html.match(/role="row"/g)).toHaveLength(31);
+    expect(html).toContain('aria-rowindex="31"');
+    expect(html).toContain("host-29");
+    expect(html).not.toContain("data-table-gap");
+  });
+});

--- a/packages/react/dataviews/src/lib/virtualization/common/VirtualBody/VirtualBody.test.tsx
+++ b/packages/react/dataviews/src/lib/virtualization/common/VirtualBody/VirtualBody.test.tsx
@@ -1,0 +1,853 @@
+/**
+ * The windowed body's contract: a bounded range of rows mounted from the
+ * whole window, logical positions and counts across the gaps, the row
+ * holding focus kept mounted, and a scroll that corrects itself when rows
+ * above the viewport change height.
+ *
+ * jsdom lays nothing out, so the viewport's height, its scroll position
+ * and every row's measured size are the test's to set.
+ */
+import type {
+  DataViewsProvider,
+  SourceCapabilities,
+} from "@canonical/dataviews-core";
+import {
+  createDataViewsProvider,
+  createSchema,
+} from "@canonical/dataviews-core";
+import { act, fireEvent, render, screen, within } from "@testing-library/react";
+import type { ReactElement } from "react";
+import { StrictMode } from "react";
+import { hydrateRoot } from "react-dom/client";
+import { renderToString } from "react-dom/server";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import DataTable from "../../../DataTable/DataTable.js";
+import type {
+  DataTableCellProps,
+  DataTableColumn,
+  DataTableProps,
+} from "../../../DataTable/types.js";
+import virtualRows from "../../virtualRows.js";
+
+const schema = createSchema([
+  { field: "status", kind: "choices", options: ["failed", "running"] },
+]);
+
+type Fields = typeof schema.fields;
+type Machine = {
+  readonly id: string;
+  readonly name: string;
+  readonly status: string;
+};
+
+const capabilities: SourceCapabilities = {
+  filter: { status: ["eq"] },
+  search: ["name"],
+  sort: ["name"],
+  sortTerms: 1,
+  group: [],
+  count: "filtered",
+};
+
+/** `count` machines from `m-<from>`, each named `host-<n>`. */
+const machines = (count: number, from = 0): Machine[] =>
+  Array.from({ length: count }, (_, position) => ({
+    id: `m-${from + position}`,
+    name: `host-${from + position}`,
+    status: "running",
+  }));
+
+const columns: readonly DataTableColumn[] = [
+  { id: "name", header: "Name", resizable: true },
+  { id: "status", header: "Status" },
+];
+
+/** Rows placed at 10px until measured; the viewport shows 100px. */
+const windowing = virtualRows({ estimatedRowHeight: 10 });
+
+/** A ResizeObserver the test drives: it keeps what it observes. */
+class FakeResizeObserver {
+  static live: FakeResizeObserver[] = [];
+  readonly observed = new Set<Element>();
+  readonly #callback: ResizeObserverCallback;
+  constructor(callback: ResizeObserverCallback) {
+    this.#callback = callback;
+    FakeResizeObserver.live.push(this);
+  }
+  observe(target: Element): void {
+    this.observed.add(target);
+  }
+  unobserve(target: Element): void {
+    this.observed.delete(target);
+  }
+  disconnect(): void {
+    this.observed.clear();
+  }
+  /** Report each element's border-box height, all at one width. */
+  report(sizes: readonly (readonly [Element, number])[], width: number): void {
+    for (const [target] of sizes) {
+      if (!this.observed.has(target)) {
+        throw new Error("reported an element nobody observes");
+      }
+    }
+    this.#callback(
+      sizes.map(([target, height]) => ({
+        target,
+        borderBoxSize: [{ blockSize: height, inlineSize: width }],
+      })) as unknown as ResizeObserverEntry[],
+      this as unknown as ResizeObserver,
+    );
+  }
+}
+
+/** The observer measuring the rows. */
+const rowObserver = (): FakeResizeObserver => {
+  const observer = FakeResizeObserver.live.find((candidate) =>
+    [...candidate.observed].some(
+      (element) => element.getAttribute("role") === "row",
+    ),
+  );
+  if (observer === undefined) {
+    throw new Error("no observer is measuring rows");
+  }
+  return observer;
+};
+
+/** Every height reported, for a page to add up as the browser would. */
+const reported = new WeakMap<Element, number>();
+
+/** Report sizes through the observer measuring the rows. */
+const report = (
+  sizes: readonly (readonly [Element, number])[],
+  width = 400,
+): void => {
+  for (const [element, height] of sizes) {
+    reported.set(element, height);
+  }
+  const observer = rowObserver();
+  act(() => {
+    observer.report(sizes, width);
+  });
+};
+
+/** Settle a fresh request on the provider with these rows. */
+const load = (
+  provider: DataViewsProvider<Fields, Machine>,
+  rows: readonly Machine[],
+): void => {
+  const requestId = provider.refresh();
+  if (requestId === null) {
+    throw new Error("expected a refresh request");
+  }
+  act(() => {
+    provider.complete(requestId, {
+      status: "success",
+      rows,
+      count: rows.length,
+    });
+  });
+};
+
+/** Give a table a scroll position the test can set, starting at the top. */
+const scrollable = (table: HTMLElement): HTMLElement => {
+  Object.defineProperty(table, "scrollTop", {
+    value: 0,
+    writable: true,
+    configurable: true,
+  });
+  return table;
+};
+
+const makeProvider = (): DataViewsProvider<Fields, Machine> =>
+  createDataViewsProvider<Fields, Machine>({ schema, capabilities });
+
+/** A windowed table over `rows`, scrolled to the top. */
+const windowedTable = (
+  rows: readonly Machine[] = machines(1000),
+  props: Partial<DataTableProps<Fields, Machine>> = {},
+  wrap: (table: ReactElement) => ReactElement = (table) => table,
+) => {
+  const provider = makeProvider();
+  const view = render(
+    wrap(
+      <DataTable
+        provider={provider}
+        columns={columns}
+        label="Machines"
+        windowing={windowing}
+        {...props}
+      />,
+    ),
+  );
+  load(provider, rows);
+  return { provider, view, table: scrollable(screen.getByRole("table")) };
+};
+
+/**
+ * Hold a table's scroll within its page, as a browser does, however the
+ * page changes under it: its gaps and its mounted rows, each at the height
+ * last reported for it, or 10px.
+ */
+const pageBound = (table: HTMLElement): void => {
+  let top = 0;
+  const bound = (value: number): number => {
+    const page =
+      [...table.querySelectorAll<HTMLElement>(".ds.data-table-gap")]
+        .map((gap) => Number.parseFloat(gap.style.blockSize))
+        .reduce((total, height) => total + height, 0) +
+      [
+        ...table.querySelectorAll(
+          '.ds.data-table-row-group.body > [role="row"]',
+        ),
+      ]
+        .map((row) => reported.get(row) ?? 10)
+        .reduce((total, height) => total + height, 0);
+    return Math.max(0, Math.min(value, page - 100));
+  };
+  Object.defineProperty(table, "scrollTop", {
+    configurable: true,
+    get: () => bound(top),
+    set: (value: number) => {
+      top = bound(value);
+    },
+  });
+};
+
+const scrollTo = (table: HTMLElement, top: number): void => {
+  act(() => {
+    table.scrollTop = top;
+    fireEvent.scroll(table);
+  });
+};
+
+/** The hosts of the mounted rows, in order. */
+const mountedHosts = (scope: HTMLElement = document.body): string[] =>
+  within(scope)
+    .getAllByRole("row")
+    .slice(1)
+    .map(
+      (row) =>
+        row.querySelector(".ds.data-table-body-cell:not(.selection)")
+          ?.textContent ?? "",
+    );
+
+/** The heights of the gaps, in order. */
+const gapHeights = (table: HTMLElement): string[] =>
+  [...table.querySelectorAll<HTMLElement>(".ds.data-table-gap")].map(
+    (gap) => gap.style.blockSize,
+  );
+
+/** The row showing one host. */
+const rowOf = (host: string): HTMLElement => {
+  const row = screen.getByText(host).closest<HTMLElement>('[role="row"]');
+  if (row === null) {
+    throw new Error(`no row shows ${host}`);
+  }
+  return row;
+};
+
+beforeEach(() => {
+  FakeResizeObserver.live = [];
+  vi.stubGlobal("ResizeObserver", FakeResizeObserver);
+  // The table's viewport shows 100px; nothing else has a height.
+  vi.spyOn(HTMLElement.prototype, "clientHeight", "get").mockImplementation(
+    function (this: HTMLElement) {
+      return this.getAttribute("role") === "table" ? 100 : 0;
+    },
+  );
+  vi.spyOn(document, "hasFocus").mockReturnValue(true);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe("windowed DataTable", () => {
+  it("mounts the rows in view and a few past each edge, not the whole window", () => {
+    const { table } = windowedTable();
+    expect(mountedHosts()).toEqual(machines(15).map((row) => row.name));
+    expect(gapHeights(table)).toEqual(["9850px"]);
+  });
+
+  it("counts every row and places each mounted one in logical order", () => {
+    const { table } = windowedTable();
+    expect(table).toHaveAttribute("aria-rowcount", "1001");
+    const [header, first] = screen.getAllByRole("row");
+    expect(header).toHaveAttribute("aria-rowindex", "1");
+    expect(first).toHaveAttribute("aria-rowindex", "2");
+    scrollTo(table, 5000);
+    expect(rowOf("host-500")).toHaveAttribute("aria-rowindex", "502");
+  });
+
+  it("moves the mounted rows with the scroll", () => {
+    const { table } = windowedTable();
+    scrollTo(table, 5000);
+    expect(mountedHosts()).toEqual(machines(19, 496).map((row) => row.name));
+    expect(gapHeights(table)).toEqual(["4960px", "4850px"]);
+  });
+
+  it("shows its rows beneath the header, which the viewport keeps in view", () => {
+    // A 24px header above a 100px body: the rows in view are the same.
+    vi.spyOn(HTMLElement.prototype, "clientHeight", "get").mockImplementation(
+      function (this: HTMLElement) {
+        return this.getAttribute("role") === "table" ? 124 : 0;
+      },
+    );
+    vi.spyOn(HTMLElement.prototype, "offsetTop", "get").mockImplementation(
+      function (this: HTMLElement) {
+        return this.classList.contains("body") ? 24 : 0;
+      },
+    );
+    const { table } = windowedTable();
+    expect(mountedHosts()).toEqual(machines(15).map((row) => row.name));
+    scrollTo(table, 5000);
+    expect(mountedHosts()).toEqual(machines(19, 496).map((row) => row.name));
+  });
+
+  it("ends on the last row, with no gap after it", () => {
+    const { table } = windowedTable();
+    scrollTo(table, 9900);
+    expect(rowOf("host-999")).toHaveAttribute("aria-rowindex", "1001");
+    expect(gapHeights(table)).toEqual(["9860px"]);
+    expect(
+      table.querySelector(".ds.data-table-row-group.body")?.lastElementChild,
+    ).toBe(rowOf("host-999"));
+  });
+
+  it("renders nothing for a scroll that keeps the same rows mounted", () => {
+    let renders = 0;
+    const Counted = ({ value }: DataTableCellProps) => {
+      renders += 1;
+      return <>{String(value)}</>;
+    };
+    const { table } = windowedTable(machines(1000), {
+      columns: [{ id: "name", header: "Name", cell: Counted }],
+    });
+    scrollTo(table, 5000);
+    renders = 0;
+    scrollTo(table, 5003);
+    expect(renders).toBe(0);
+    // Ten rows further on, ten rows enter and only they render.
+    scrollTo(table, 5100);
+    expect(renders).toBe(10);
+  });
+
+  describe("focus", () => {
+    it("keeps the row holding focus mounted, with its neighbours, wherever the viewport goes", () => {
+      const { table } = windowedTable(machines(1000), { selectable: true });
+      const checkbox = screen.getByRole("checkbox", { name: "Select m-3" });
+      act(() => {
+        checkbox.focus();
+      });
+      scrollTo(table, 5000);
+      expect(checkbox).toBeInTheDocument();
+      expect(document.activeElement).toBe(checkbox);
+      expect(mountedHosts().slice(0, 3)).toEqual([
+        "host-2",
+        "host-3",
+        "host-4",
+      ]);
+      expect(rowOf("host-3")).toHaveAttribute("aria-rowindex", "5");
+      expect(gapHeights(table)).toEqual(["20px", "4910px", "4850px"]);
+    });
+
+    it("follows focus from one row to the next", () => {
+      const { table } = windowedTable(machines(1000), { selectable: true });
+      act(() => {
+        screen.getByRole("checkbox", { name: "Select m-3" }).focus();
+      });
+      act(() => {
+        screen.getByRole("checkbox", { name: "Select m-4" }).focus();
+      });
+      scrollTo(table, 5000);
+      expect(mountedHosts().slice(0, 3)).toEqual([
+        "host-3",
+        "host-4",
+        "host-5",
+      ]);
+    });
+
+    it("keeps a row that already holds focus when a new range mounts it", () => {
+      const { provider, table, view } = windowedTable(machines(1000), {
+        selectable: true,
+      });
+      act(() => {
+        screen.getByRole("checkbox", { name: "Select m-3" }).focus();
+      });
+      view.rerender(
+        <DataTable
+          provider={provider}
+          columns={columns}
+          label="Machines"
+          selectable
+          windowing={virtualRows({ estimatedRowHeight: 20 })}
+        />,
+      );
+      scrollTo(table, 10_000);
+      expect(
+        screen.getByRole("checkbox", { name: "Select m-3" }),
+      ).toBeInTheDocument();
+    });
+
+    it("ignores focus that lands on no row", () => {
+      const { table } = windowedTable(machines(1000), { selectable: true });
+      const group = table.querySelector<HTMLElement>(
+        ".ds.data-table-row-group.body",
+      );
+      if (group === null) {
+        throw new Error("no body row group");
+      }
+      fireEvent.focus(group);
+      scrollTo(table, 5000);
+      expect(mountedHosts()).toEqual(machines(19, 496).map((row) => row.name));
+    });
+
+    it("lets the row go once focus leaves the table", () => {
+      const { table } = windowedTable(machines(1000), { selectable: true });
+      const outside = document.createElement("button");
+      document.body.append(outside);
+      act(() => {
+        screen.getByRole("checkbox", { name: "Select m-3" }).focus();
+      });
+      scrollTo(table, 5000);
+      act(() => {
+        outside.focus();
+      });
+      expect(screen.queryByRole("checkbox", { name: "Select m-3" })).toBeNull();
+      outside.remove();
+    });
+
+    it("keeps the row while focus is only away with the window", () => {
+      const { table } = windowedTable(machines(1000), { selectable: true });
+      const checkbox = screen.getByRole("checkbox", { name: "Select m-3" });
+      act(() => {
+        checkbox.focus();
+      });
+      scrollTo(table, 5000);
+      vi.mocked(document.hasFocus).mockReturnValue(false);
+      act(() => {
+        checkbox.blur();
+      });
+      expect(checkbox).toBeInTheDocument();
+    });
+  });
+
+  describe("measurement", () => {
+    it("scrolls by what a row above the viewport grew, so the view holds still", () => {
+      const { table } = windowedTable();
+      scrollTo(table, 5000);
+      report([
+        [rowOf("host-497"), 30],
+        [rowOf("host-505"), 30],
+        [table, 100],
+      ]);
+      expect(table.scrollTop).toBe(5020);
+    });
+
+    it("forgets the heights of rows not mounted when the rows' width changes", () => {
+      const { table } = windowedTable();
+      report(machines(5).map((row) => [rowOf(row.name), 20] as const));
+      scrollTo(table, 5000);
+      report(
+        mountedHosts().map((host) => [rowOf(host), 10] as const),
+        500,
+      );
+      // The five rows at the top are back to their estimate: the view
+      // moves up by the 50px they had grown.
+      expect(table.scrollTop).toBe(4950);
+      expect(gapHeights(table)[0]).toBe("4910px");
+    });
+
+    it("mounts more rows when the viewport grows", () => {
+      const { table } = windowedTable();
+      vi.spyOn(HTMLElement.prototype, "clientHeight", "get").mockImplementation(
+        function (this: HTMLElement) {
+          return this.getAttribute("role") === "table" ? 200 : 0;
+        },
+      );
+      report([[table, 200]]);
+      expect(mountedHosts()).toHaveLength(25);
+    });
+
+    it("observes only the rows it has mounted, however far it scrolls", () => {
+      const { table } = windowedTable();
+      for (let top = 0; top <= 9000; top += 1000) {
+        scrollTo(table, top);
+      }
+      // The mounted rows and the viewport itself, nothing that has left.
+      expect(rowObserver().observed.size).toBe(mountedHosts().length + 1);
+    });
+
+    it("forgets the heights of rows not mounted when a column is resized", () => {
+      const { table } = windowedTable();
+      report(machines(5).map((row) => [rowOf(row.name), 20] as const));
+      scrollTo(table, 5000);
+      // New tracks re-wrap cells, whatever the rows' own width does.
+      fireEvent.keyDown(screen.getByRole("separator"), { key: "ArrowRight" });
+      expect(table.scrollTop).toBe(4950);
+    });
+
+    it("holds the view at the bottom when forgotten heights grow the page", () => {
+      const { table } = windowedTable();
+      pageBound(table);
+      report(machines(5).map((row) => [rowOf(row.name), 5] as const));
+      // The very end of the page: 10,000px less 25, less the viewport.
+      scrollTo(table, 9875);
+      // A new width forgets the five short rows, far above: the page grows
+      // by 25px and the view moves with its rows, past the page's old end.
+      report(
+        mountedHosts().map((host) => [rowOf(host), 10] as const),
+        500,
+      );
+      expect(table.scrollTop).toBe(9900);
+    });
+
+    it("holds the view at the bottom when forgotten heights shrink the page", () => {
+      const { table } = windowedTable();
+      pageBound(table);
+      report(machines(5).map((row) => [rowOf(row.name), 20] as const));
+      // The very end of the page: 10,000px and 50, less the viewport.
+      scrollTo(table, 9950);
+      report(
+        mountedHosts().map((host) => [rowOf(host), 10] as const),
+        500,
+      );
+      // 50px up with its rows, which is the new end: not 50px past it.
+      expect(table.scrollTop).toBe(9900);
+    });
+
+    it("holds the view at the bottom when forgotten heights grow some rows and shrink others", () => {
+      const { table } = windowedTable();
+      pageBound(table);
+      // Forgetting them: two rows 10px shorter, three 5px taller, net -5.
+      report([
+        [rowOf("host-0"), 20],
+        [rowOf("host-1"), 20],
+        [rowOf("host-2"), 5],
+        [rowOf("host-3"), 5],
+        [rowOf("host-4"), 5],
+      ]);
+      scrollTo(table, 9905);
+      report(
+        mountedHosts().map((host) => [rowOf(host), 10] as const),
+        500,
+      );
+      expect(table.scrollTop).toBe(9900);
+    });
+
+    it("holds the view when a row grows in the batch that forgets heights", () => {
+      const { table } = windowedTable();
+      pageBound(table);
+      report(machines(5).map((row) => [rowOf(row.name), 5] as const));
+      scrollTo(table, 9875);
+      // The five short rows forgotten (+25) and host-987 above the anchor
+      // measured 10px taller (+10), in one report.
+      report(
+        mountedHosts().map(
+          (host) => [rowOf(host), host === "host-987" ? 20 : 10] as const,
+        ),
+        500,
+      );
+      expect(table.scrollTop).toBe(9910);
+    });
+
+    it("holds the view at the bottom when a mounted row above it shrinks", () => {
+      const { table } = windowedTable();
+      pageBound(table);
+      scrollTo(table, 9900);
+      report([[rowOf("host-987"), 5]]);
+      expect(table.scrollTop).toBe(9895);
+    });
+
+    it("holds the view at the bottom when rows above it leave", () => {
+      const rows = machines(1000);
+      const { provider, table } = windowedTable(rows);
+      pageBound(table);
+      scrollTo(table, 9900);
+      load(provider, rows.slice(5));
+      expect(table.scrollTop).toBe(9850);
+    });
+
+    it("places a viewport that grew in the batch that forgot heights", () => {
+      const { table } = windowedTable();
+      report(machines(5).map((row) => [rowOf(row.name), 5] as const));
+      scrollTo(table, 5000);
+      vi.spyOn(HTMLElement.prototype, "clientHeight", "get").mockImplementation(
+        function (this: HTMLElement) {
+          return this.getAttribute("role") === "table" ? 200 : 0;
+        },
+      );
+      report(
+        [
+          ...mountedHosts().map((host) => [rowOf(host), 10] as const),
+          [table, 200],
+        ],
+        500,
+      );
+      // Twenty rows in view, one partly, and four past each edge.
+      expect(table.scrollTop).toBe(5025);
+      expect(mountedHosts()).toHaveLength(29);
+    });
+
+    it("holds the view at the bottom when a column resize grows the page", () => {
+      const { table } = windowedTable();
+      pageBound(table);
+      report(machines(5).map((row) => [rowOf(row.name), 5] as const));
+      scrollTo(table, 9875);
+      fireEvent.keyDown(screen.getByRole("separator"), { key: "ArrowRight" });
+      expect(table.scrollTop).toBe(9900);
+    });
+
+    it("forgets the height of a row whose record was replaced", () => {
+      const rows = machines(1000);
+      const { provider, table } = windowedTable(rows);
+      report(machines(5).map((row) => [rowOf(row.name), 20] as const));
+      scrollTo(table, 5000);
+      load(
+        provider,
+        rows.map((row) =>
+          row.id === "m-2" ? { ...row, name: "renamed" } : row,
+        ),
+      );
+      expect(table.scrollTop).toBe(4990);
+    });
+  });
+
+  describe("new entries", () => {
+    it("keeps the view on its rows when rows arrive above them", () => {
+      const rows = machines(1000);
+      const { provider, table } = windowedTable(rows);
+      scrollTo(table, 5000);
+      load(provider, [...machines(5, 1000), ...rows]);
+      expect(table.scrollTop).toBe(5050);
+      expect(rowOf("host-500")).toHaveAttribute("aria-rowindex", "507");
+      // The correction is made once: the same rows again move nothing.
+      load(provider, [...machines(5, 1000), ...rows]);
+      expect(table.scrollTop).toBe(5050);
+    });
+
+    it("shows rows arriving at the very top rather than scrolling past them", () => {
+      const rows = machines(1000);
+      const { provider, table } = windowedTable(rows);
+      load(provider, [...machines(5, 1000), ...rows]);
+      expect(table.scrollTop).toBe(0);
+      expect(mountedHosts()[0]).toBe("host-1000");
+    });
+
+    it("counts and places a stale status among the rows it stands above", () => {
+      const { provider, table } = windowedTable();
+      act(() => {
+        provider.setSearch("host-1");
+      });
+      const requestId = provider.result.get().pendingRequestId;
+      if (requestId === null) {
+        throw new Error("expected the search to issue a request");
+      }
+      act(() => {
+        provider.complete(requestId, {
+          status: "failure",
+          reason: "unreachable",
+        });
+      });
+      expect(table).toHaveAttribute("aria-rowcount", "1002");
+      const [, status, first] = screen.getAllByRole("row");
+      expect(status).toHaveAttribute("aria-rowindex", "2");
+      expect(first).toHaveAttribute("aria-rowindex", "3");
+    });
+
+    it("renders an unchanged status once, however often the table renders", () => {
+      const renderStatus = vi.fn(() => "Not current");
+      const { provider, table, view } = windowedTable(machines(1000), {
+        renderStatus,
+      });
+      act(() => {
+        provider.setSearch("host-1");
+      });
+      const requestId = provider.result.get().pendingRequestId;
+      if (requestId === null) {
+        throw new Error("expected the search to issue a request");
+      }
+      act(() => {
+        provider.complete(requestId, {
+          status: "failure",
+          reason: "unreachable",
+        });
+      });
+      const calls = renderStatus.mock.calls.length;
+      view.rerender(
+        <DataTable
+          provider={provider}
+          columns={columns}
+          label="Machines"
+          windowing={windowing}
+          renderStatus={renderStatus}
+        />,
+      );
+      scrollTo(table, 3);
+      expect(renderStatus).toHaveBeenCalledTimes(calls);
+    });
+  });
+
+  it("selects every displayed row from the header, mounted or not", () => {
+    const { provider } = windowedTable(machines(1000), { selectable: true });
+    fireEvent.click(
+      screen.getByRole("checkbox", { name: "Select all displayed rows" }),
+    );
+    expect(provider.selection.state.ids.size).toBe(1000);
+  });
+
+  it("resizes a column across the rows it mounts", () => {
+    const { table } = windowedTable();
+    const tracks = table.style.getPropertyValue("--data-table-columns");
+    fireEvent.keyDown(screen.getByRole("separator"), { key: "ArrowRight" });
+    expect(table.style.getPropertyValue("--data-table-columns")).not.toBe(
+      tracks,
+    );
+  });
+
+  it("keeps each table's own range, whatever descriptor they share", () => {
+    const first = makeProvider();
+    const second = makeProvider();
+    render(
+      <>
+        <DataTable
+          provider={first}
+          columns={columns}
+          label="First"
+          windowing={windowing}
+        />
+        <DataTable
+          provider={second}
+          columns={columns}
+          label="Second"
+          windowing={windowing}
+        />
+      </>,
+    );
+    load(first, machines(1000));
+    load(second, machines(1000));
+    const [one, two] = screen.getAllByRole("table").map(scrollable);
+    scrollTo(one, 5000);
+    expect(mountedHosts(one)).toContain("host-500");
+    expect(mountedHosts(two)[0]).toBe("host-0");
+  });
+
+  it("windows by its estimates where nothing can measure", () => {
+    vi.stubGlobal("ResizeObserver", undefined);
+    windowedTable();
+    expect(mountedHosts()).toHaveLength(15);
+  });
+
+  it("keeps its range, focus and anchor through StrictMode's double mount", () => {
+    const { table } = windowedTable(
+      machines(1000),
+      { selectable: true },
+      (element) => <StrictMode>{element}</StrictMode>,
+    );
+    expect(mountedHosts()).toHaveLength(15);
+    act(() => {
+      screen.getByRole("checkbox", { name: "Select m-3" }).focus();
+    });
+    scrollTo(table, 5000);
+    expect(document.activeElement).toBe(
+      screen.getByRole("checkbox", { name: "Select m-3" }),
+    );
+    report([[rowOf("host-497"), 30]]);
+    expect(table.scrollTop).toBe(5020);
+  });
+
+  it("measures the rows it mounted before a double mount remounted it", () => {
+    const provider = makeProvider();
+    load(provider, machines(1000));
+    render(
+      <StrictMode>
+        <DataTable
+          provider={provider}
+          columns={columns}
+          label="Machines"
+          windowing={windowing}
+        />
+      </StrictMode>,
+    );
+    const table = scrollable(screen.getByRole("table"));
+    report([[rowOf("host-2"), 30]]);
+    scrollTo(table, 5000);
+    // host-2 measured 20px taller, so the rows in view start two rows
+    // earlier than the estimates alone would put them.
+    expect(mountedHosts()[0]).toBe("host-494");
+  });
+
+  it("starts a new range when the estimate changes", () => {
+    const { provider, view } = windowedTable();
+    view.rerender(
+      <DataTable
+        provider={provider}
+        columns={columns}
+        label="Machines"
+        windowing={virtualRows({ estimatedRowHeight: 20 })}
+      />,
+    );
+    expect(mountedHosts()).toHaveLength(10);
+  });
+
+  it("leaves nothing observing or listening once unmounted", () => {
+    const added = vi.spyOn(EventTarget.prototype, "addEventListener");
+    const removed = vi.spyOn(EventTarget.prototype, "removeEventListener");
+    const { table, view } = windowedTable();
+    const ours = added.mock.calls.flatMap(([type, listener], call) => {
+      const target = added.mock.contexts[call];
+      return type === "scroll" &&
+        target instanceof Node &&
+        (target === table || table.contains(target))
+        ? [{ target, type, listener }]
+        : [];
+    });
+    expect(ours.length).toBeGreaterThan(0);
+    view.unmount();
+    for (const { target, type, listener } of ours) {
+      expect(
+        removed.mock.calls.some(
+          ([removedType, removedListener], call) =>
+            removed.mock.contexts[call] === target &&
+            removedType === type &&
+            removedListener === listener,
+        ),
+      ).toBe(true);
+    }
+    expect(
+      FakeResizeObserver.live.every((observer) => observer.observed.size === 0),
+    ).toBe(true);
+  });
+
+  it("hydrates the server's whole window without a mismatch, then narrows it", async () => {
+    const errors = vi.spyOn(console, "error");
+    const provider = makeProvider();
+    load(provider, machines(100));
+    const table = (
+      <DataTable
+        provider={provider}
+        columns={columns}
+        label="Machines"
+        windowing={windowing}
+      />
+    );
+    const container = document.createElement("div");
+    container.innerHTML = renderToString(table);
+    document.body.append(container);
+    expect(container.querySelectorAll('[role="row"]')).toHaveLength(101);
+    const root = await act(async () => hydrateRoot(container, table));
+    expect(errors).not.toHaveBeenCalled();
+    expect(container.querySelectorAll('[role="row"]')).toHaveLength(16);
+    // A row hydrated from the server's markup is measured like any other.
+    const hydrated = container.querySelector('[aria-rowindex="4"]');
+    if (hydrated === null) {
+      throw new Error("no hydrated row");
+    }
+    report([[hydrated, 30]]);
+    act(() => {
+      root.unmount();
+    });
+    container.remove();
+  });
+});

--- a/packages/react/dataviews/src/lib/virtualization/common/VirtualBody/VirtualBody.tsx
+++ b/packages/react/dataviews/src/lib/virtualization/common/VirtualBody/VirtualBody.tsx
@@ -1,0 +1,98 @@
+import type { ReactElement } from "react";
+import { memo } from "react";
+import { Row, StatusRow } from "../../../DataTable/common/index.js";
+import useDataViewsValue from "../../../DataViews/hooks/useDataViewsValue.js";
+import { useVirtualRows } from "../../hooks/index.js";
+import type { VirtualBodyProps } from "./types.js";
+import "./styles.css";
+
+const componentCssClassName = "ds data-table-row-group body windowed";
+
+/** The space of entries not mounted: hidden, since it holds no rows. */
+const gap = (key: string, size: number): ReactElement => (
+  <div
+    key={key}
+    className="ds data-table-gap"
+    aria-hidden="true"
+    style={{ blockSize: size }}
+  />
+);
+
+function VirtualBody<TRow extends object>({
+  provider,
+  scopes,
+  entries,
+  columns,
+  fields,
+  selectable,
+  rowLabel,
+  renderStatus,
+  estimatedRowHeight,
+  tracks,
+}: VirtualBodyProps<TRow>): ReactElement {
+  const model = useDataViewsValue(provider.rows);
+  const { mounted, body, refFor, onFocus, onBlur } = useVirtualRows({
+    entries,
+    estimatedRowHeight,
+    model,
+    tracks,
+  });
+  // One flat list, keyed by entry id, so a row keeps its element as it
+  // moves between runs.
+  const rows: ReactElement[] = [];
+  for (const [position, run] of mounted.runs.entries()) {
+    if (run.before > 0) {
+      rows.push(gap(`gap-${position}`, run.before));
+    }
+    for (const entry of entries.slice(run.start, run.end)) {
+      rows.push(
+        entry.kind === "status" ? (
+          <StatusRow
+            key={entry.id}
+            ref={refFor(entry.id)}
+            position={entry.index}
+            status={entry.status}
+            renderStatus={renderStatus}
+          />
+        ) : (
+          <Row
+            key={entry.id}
+            ref={refFor(entry.id)}
+            position={entry.index}
+            provider={provider}
+            scope={scopes.scope(entry.rowId)}
+            columns={columns}
+            fields={fields}
+            selectable={selectable}
+            rowLabel={rowLabel}
+          />
+        ),
+      );
+    }
+  }
+  if (mounted.after > 0) {
+    rows.push(gap("gap-after", mounted.after));
+  }
+  return (
+    // biome-ignore lint/a11y/useSemanticElements: <tbody> is only valid inside a <table>, and this grid is deliberately not one
+    <div
+      ref={body}
+      role="rowgroup"
+      className={componentCssClassName}
+      onFocus={onFocus}
+      onBlur={onBlur}
+    >
+      {rows}
+    </div>
+  );
+}
+
+/**
+ * The table's body, windowed: the entries near the viewport, each at its
+ * logical row position, with a gap for the space of the rest. A scroll
+ * that does not change the mounted entries renders nothing, and the rows
+ * are memoised as they are in the table's own body, so one that stays
+ * mounted is not rendered again. New tracks render the body once, to
+ * forget the heights they outdate; its rows bail out.
+ */
+export default memo(VirtualBody) as typeof VirtualBody;

--- a/packages/react/dataviews/src/lib/virtualization/common/VirtualBody/index.ts
+++ b/packages/react/dataviews/src/lib/virtualization/common/VirtualBody/index.ts
@@ -1,0 +1,2 @@
+export type * from "./types.js";
+export { default as VirtualBody } from "./VirtualBody.js";

--- a/packages/react/dataviews/src/lib/virtualization/common/VirtualBody/styles.css
+++ b/packages/react/dataviews/src/lib/virtualization/common/VirtualBody/styles.css
@@ -1,0 +1,28 @@
+/* Layer: ds.components.global (@canonical/styles README, "Cascade layers"). */
+
+@layer ds.components.global {
+  /**
+   * VirtualBody styles
+   *
+   * The specification is `DataTable.anatomy.yaml`: every value below is one
+   * it binds, and what it could not bind is recorded there, never hardcoded
+   * here. A windowed body mounts the entries near the viewport and holds a
+   * gap, sized inline, for the rest. The body imports these rules itself,
+   * so an application that never windows a table loads them only if it
+   * links `index.css`.
+   */
+  .ds.data-table:has(> .ds.data-table-row-group.body.windowed) {
+    /* The body's offset, which places the viewport among the entries, is
+       measured from the root. */
+    position: relative;
+    /* The range keeps the entry at the viewport's start in place when a
+       row above it is measured; the browser's own anchoring would correct
+       the same shift a second time. */
+    overflow-anchor: none;
+    /* The table is its own scroll viewport, and a viewport as tall as its
+       content would mount every row: by default it is no taller than the
+       screen, measured with the browser's bars shown so the cap holds
+       still while the page scrolls. A caller's own maximum wins. */
+    max-block-size: 100svh;
+  }
+}

--- a/packages/react/dataviews/src/lib/virtualization/common/VirtualBody/styles.test.tsx
+++ b/packages/react/dataviews/src/lib/virtualization/common/VirtualBody/styles.test.tsx
@@ -1,0 +1,48 @@
+/**
+ * The windowed stylesheet's contract with the markup: the table it styles
+ * is the one a windowed body renders, and it declares what the range needs
+ * of its viewport. jsdom applies no CSS, so the declarations are read.
+ */
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  createDataViewsProvider,
+  createSchema,
+} from "@canonical/dataviews-core";
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import DataTable from "../../../DataTable/DataTable.js";
+import virtualRows from "../../virtualRows.js";
+
+const sheet = readFileSync(
+  path.join(path.dirname(fileURLToPath(import.meta.url)), "styles.css"),
+  "utf8",
+).replace(/\/\*[\s\S]*?\*\//g, "");
+
+describe("windowed DataTable stylesheet", () => {
+  it("styles the table a windowed body renders", () => {
+    const provider = createDataViewsProvider({
+      schema: createSchema([{ field: "owner", kind: "flag" }]),
+    });
+    const { container } = render(
+      <DataTable
+        provider={provider}
+        label="Machines"
+        columns={[{ id: "name", header: "Name" }]}
+        windowing={virtualRows({ estimatedRowHeight: 32 })}
+      />,
+    );
+    const selector = sheet.match(/\.ds\.data-table:has\(> ([^)]+)\)/)?.[1];
+    expect(selector).toBe(".ds.data-table-row-group.body.windowed");
+    expect(
+      container.querySelector(`.ds.data-table > ${selector}`),
+    ).not.toBeNull();
+  });
+
+  it("makes the table its own bounded viewport, anchored by the range", () => {
+    expect(sheet).toMatch(/position:\s*relative;/);
+    expect(sheet).toMatch(/overflow-anchor:\s*none;/);
+    expect(sheet).toMatch(/max-block-size:\s*100svh;/);
+  });
+});

--- a/packages/react/dataviews/src/lib/virtualization/common/VirtualBody/types.ts
+++ b/packages/react/dataviews/src/lib/virtualization/common/VirtualBody/types.ts
@@ -1,0 +1,10 @@
+import type { WindowedBodyProps } from "../../../DataTable/windowed.js";
+
+/**
+ * Props of the windowed body row group.
+ *
+ * Exempt from the native-prop extension convention: an internal renderer
+ * deriving its root from the table's entries, not forwarding a caller's
+ * native props.
+ */
+export type VirtualBodyProps<TRow extends object> = WindowedBodyProps<TRow>;

--- a/packages/react/dataviews/src/lib/virtualization/common/index.ts
+++ b/packages/react/dataviews/src/lib/virtualization/common/index.ts
@@ -1,0 +1,1 @@
+export * from "./VirtualBody/index.js";

--- a/packages/react/dataviews/src/lib/virtualization/hooks/index.ts
+++ b/packages/react/dataviews/src/lib/virtualization/hooks/index.ts
@@ -1,0 +1,2 @@
+export type { UseVirtualRowsProps, UseVirtualRowsResult } from "./types.js";
+export { default as useVirtualRows } from "./useVirtualRows.js";

--- a/packages/react/dataviews/src/lib/virtualization/hooks/types.ts
+++ b/packages/react/dataviews/src/lib/virtualization/hooks/types.ts
@@ -1,0 +1,37 @@
+/**
+ * Hook domain types for the virtualization domain. Each hook declares its
+ * result type here.
+ */
+
+import type { DisplayEntry, RowModel } from "@canonical/dataviews-core";
+import type { MountedRange } from "@canonical/dataviews-core/virtualization";
+import type { FocusEvent, RefObject } from "react";
+
+/** One windowed body's range, and the handles its elements attach by. */
+export type UseVirtualRowsResult = {
+  /** The entries to mount, as runs, and the space of the rest. */
+  readonly mounted: MountedRange;
+  /** The body row group; its parent is the scroll viewport. */
+  readonly body: RefObject<HTMLDivElement | null>;
+  /**
+   * The ref one entry's row attaches by, to be measured and to keep focus.
+   * The same function for as long as the row is mounted.
+   */
+  readonly refFor: (id: string) => (node: HTMLDivElement) => () => void;
+  /** Keeps the row focus enters mounted, wherever the viewport goes. */
+  readonly onFocus: (event: FocusEvent<HTMLDivElement>) => void;
+  /** Lets it go when focus leaves the body, not when it leaves the window. */
+  readonly onBlur: (event: FocusEvent<HTMLDivElement>) => void;
+};
+
+/** What one windowed body displays, and what its rows' heights hang on. */
+export type UseVirtualRowsProps = {
+  /** The entries, in display order. */
+  readonly entries: readonly DisplayEntry[];
+  /** The height a row is placed at until it is measured, in pixels. */
+  readonly estimatedRowHeight: number;
+  /** The row model, whose replaced records may have new heights. */
+  readonly model: RowModel<object>;
+  /** The published tracks, whose change re-wraps every row. */
+  readonly tracks: string | undefined;
+};

--- a/packages/react/dataviews/src/lib/virtualization/hooks/useVirtualRows.ts
+++ b/packages/react/dataviews/src/lib/virtualization/hooks/useVirtualRows.ts
@@ -1,0 +1,269 @@
+import type { RowModel } from "@canonical/dataviews-core";
+import type { MountedRange } from "@canonical/dataviews-core/virtualization";
+import { createVirtualRange } from "@canonical/dataviews-core/virtualization";
+import type { FocusEvent } from "react";
+import {
+  useCallback,
+  useLayoutEffect,
+  useMemo,
+  useReducer,
+  useRef,
+  useState,
+  useSyncExternalStore,
+} from "react";
+import type { UseVirtualRowsProps, UseVirtualRowsResult } from "./types.js";
+
+/** What the rows' heights were last measured against. */
+type Snapshot = Pick<UseVirtualRowsProps, "entries" | "model" | "tracks">;
+
+/** A row both models hold, as different records: its height may differ. */
+const wasReplaced = (
+  before: RowModel<object>,
+  after: RowModel<object>,
+  rowId: string,
+): boolean => {
+  const record = before.byId(rowId);
+  return record !== undefined && record !== after.byId(rowId);
+};
+
+/**
+ * The rows showing a replaced record under the id they kept, whose height
+ * may have changed with it. A changed status needs no such check: the
+ * table's status row leaves while the next request is pending, and its
+ * measurement leaves with it.
+ */
+const replaced = (before: Snapshot, after: Snapshot): string[] =>
+  after.entries.flatMap((entry) =>
+    entry.kind === "record" &&
+    wasReplaced(before.model, after.model, entry.rowId)
+      ? [entry.id]
+      : [],
+  );
+
+/** The viewport a body measures against: the table root, its parent. */
+const viewportOf = (body: HTMLDivElement | null): HTMLElement =>
+  // A layout effect runs with the body mounted, and the body is always
+  // rendered inside the table's root.
+  (body as HTMLDivElement).parentElement as HTMLElement;
+
+/**
+ * Mount one table's entries near its viewport: the range deciding which,
+ * and the browser work feeding it.
+ *
+ * The table's root is the viewport. A scroll places the viewport among the
+ * entries; one resize observer reports the viewport's size and every
+ * mounted row's. New tracks, or a new row width, outdate every measurement
+ * of a row not mounted; a replaced record outdates its own. The row holding
+ * focus stays mounted wherever the viewport goes, and the scroll corrects
+ * itself when rows above the viewport are measured, replaced or added.
+ *
+ * On the server, and while hydrating, every entry is mounted: the full
+ * current window is the markup a reader without JavaScript gets, and the
+ * range narrows it once the viewport is measured.
+ */
+export default function useVirtualRows({
+  entries,
+  estimatedRowHeight,
+  model,
+  tracks,
+}: UseVirtualRowsProps): UseVirtualRowsResult {
+  const range = useMemo(
+    () =>
+      createVirtualRange({
+        estimates: { record: estimatedRowHeight, status: estimatedRowHeight },
+      }),
+    [estimatedRowHeight],
+  );
+  const body = useRef<HTMLDivElement>(null);
+  // The entry id of every mounted row element.
+  const [measured] = useState(() => new Map<Element, string>());
+  const observer = useRef<ResizeObserver | null>(null);
+  const shift = useRef(0);
+  const previous = useRef<Snapshot>({ entries, model, tracks });
+  // Where the viewport starts as far as the range knows: set by every
+  // placement and moved by every correction. A correction is made from
+  // here, never from the viewport's scroll, which the browser may already
+  // have held to the end of a page that shrank.
+  const expected = useRef(0);
+  // A correction for forgotten heights, made again once their gaps are
+  // rendered: until then a page that grows may be too short to hold it.
+  const reassert = useRef(false);
+  const [, refresh] = useReducer((count: number) => count + 1, 0);
+
+  // Set while rendering, so the runs always index the entries rendered;
+  // the range notifies nobody for it, and the scroll it asks for is made
+  // once the rows are committed.
+  shift.current += range.setEntries(entries);
+
+  const complete = useMemo<MountedRange>(
+    () => ({ runs: [{ start: 0, end: entries.length, before: 0 }], after: 0 }),
+    [entries.length],
+  );
+  const mounted = useSyncExternalStore(
+    range.subscribe,
+    range.get,
+    () => complete,
+  );
+
+  // The header sticks to the viewport's top and the rows show beneath it:
+  // the entries in view start where the scroll does, in a viewport one
+  // header shorter.
+  const place = useCallback((): void => {
+    const group = body.current as HTMLDivElement;
+    const viewport = viewportOf(group);
+    expected.current = viewport.scrollTop;
+    range.setViewport(
+      expected.current,
+      viewport.clientHeight - group.offsetTop,
+    );
+  }, [range]);
+
+  const correct = useCallback((moved: number): void => {
+    if (moved !== 0) {
+      expected.current += moved;
+      viewportOf(body.current).scrollTop = expected.current;
+    }
+  }, []);
+
+  // One ref per mounted entry, held for as long as its row is mounted so a
+  // memoised row is never rendered again for a new one.
+  const refFor = useMemo(() => {
+    const refs = new Map<string, (node: HTMLDivElement) => () => void>();
+    return (id: string): ((node: HTMLDivElement) => () => void) => {
+      const known = refs.get(id);
+      if (known !== undefined) {
+        return known;
+      }
+      const attach = (node: HTMLDivElement): (() => void) => {
+        refs.set(id, attach);
+        measured.set(node, id);
+        observer.current?.observe(node);
+        // A row can hold focus before it is attached: a control focused
+        // while hydrating, or a row a new range mounts again.
+        if (node.contains(node.ownerDocument.activeElement)) {
+          range.retain(id);
+        }
+        return () => {
+          observer.current?.unobserve(node);
+          measured.delete(node);
+          refs.delete(id);
+        };
+      };
+      return attach;
+    };
+  }, [range, measured]);
+
+  const onFocus = useCallback(
+    (event: FocusEvent<HTMLDivElement>): void => {
+      const row = (event.target as Element).closest('[role="row"]');
+      const id = row === null ? undefined : measured.get(row);
+      if (id !== undefined) {
+        range.retain(id);
+      }
+    },
+    [range, measured],
+  );
+
+  // Focus that leaves the body lets its row go. Focus that leaves the
+  // window has not left the body, and the row waits for its return.
+  const onBlur = useCallback(
+    (event: FocusEvent<HTMLDivElement>): void => {
+      const group = event.currentTarget;
+      if (
+        !group.contains(event.relatedTarget) &&
+        group.ownerDocument.hasFocus()
+      ) {
+        range.retain(null);
+      }
+    },
+    [range],
+  );
+
+  useLayoutEffect(() => {
+    const viewport = viewportOf(body.current);
+    reassert.current = false;
+    let width: number | undefined;
+    const resizes =
+      typeof ResizeObserver === "undefined"
+        ? null
+        : new ResizeObserver((records) => {
+            const sizes: [string, number][] = [];
+            let rowWidth = width;
+            for (const record of records) {
+              const id = measured.get(record.target);
+              if (id !== undefined) {
+                const [box] = record.borderBoxSize;
+                sizes.push([id, box.blockSize]);
+                rowWidth = box.inlineSize;
+              }
+            }
+            // The rows share one width: a new one outdates every row not
+            // mounted, whose height may have changed with it.
+            const outdated =
+              width !== undefined && rowWidth !== width
+                ? range.invalidate("all")
+                : 0;
+            width = rowWidth;
+            correct(outdated + range.measure(sizes));
+            if (outdated !== 0) {
+              reassert.current = true;
+            }
+            // Until a correction is made again, the viewport's scroll may
+            // be one the browser held short of it: nothing to place from.
+            if (!reassert.current) {
+              place();
+            }
+          });
+    observer.current = resizes;
+    resizes?.observe(viewport);
+    for (const element of measured.keys()) {
+      resizes?.observe(element);
+    }
+    // The first placement comes before the store's own subscription, which
+    // React takes after paint: render it now, so the first paint is right.
+    const unplaced = range.get();
+    place();
+    if (range.get() !== unplaced) {
+      refresh();
+    }
+    viewport.addEventListener("scroll", place);
+    return () => {
+      viewport.removeEventListener("scroll", place);
+      resizes?.disconnect();
+      observer.current = null;
+    };
+  }, [range, measured, place, correct]);
+
+  // After the rows commit: make the scroll the entries asked for, and
+  // forget the heights the change outdated — every row's not mounted when
+  // the tracks re-wrap cells, otherwise those whose content was replaced.
+  useLayoutEffect(() => {
+    const before = previous.current;
+    const after = { entries, model, tracks };
+    previous.current = after;
+    const outdated =
+      before.tracks !== tracks
+        ? range.invalidate("all")
+        : before.model === model
+          ? 0
+          : range.invalidate(replaced(before, after));
+    correct(shift.current + outdated);
+    shift.current = 0;
+    if (outdated !== 0) {
+      reassert.current = true;
+    }
+  }, [range, entries, model, tracks, correct]);
+
+  // Once the committed range is the range's own, its gaps have the heights
+  // a correction for forgotten heights was worked out against: make it
+  // again, where the page now holds it, and place the viewport from there.
+  useLayoutEffect(() => {
+    if (reassert.current && mounted === range.get()) {
+      reassert.current = false;
+      viewportOf(body.current).scrollTop = expected.current;
+      place();
+    }
+  });
+
+  return { mounted, body, refFor, onFocus, onBlur };
+}

--- a/packages/react/dataviews/src/lib/virtualization/index.ts
+++ b/packages/react/dataviews/src/lib/virtualization/index.ts
@@ -1,0 +1,2 @@
+export type * from "./types.js";
+export { default as virtualRows } from "./virtualRows.js";

--- a/packages/react/dataviews/src/lib/virtualization/types.ts
+++ b/packages/react/dataviews/src/lib/virtualization/types.ts
@@ -1,0 +1,8 @@
+/** How `virtualRows` windows a table's rows. */
+export type VirtualRowsOptions = {
+  /**
+   * The height a row is placed at until it is measured, in pixels. An
+   * estimate, never a clip: a taller row grows, and the table measures it.
+   */
+  readonly estimatedRowHeight: number;
+};

--- a/packages/react/dataviews/src/lib/virtualization/virtualRows.performance.test.tsx
+++ b/packages/react/dataviews/src/lib/virtualization/virtualRows.performance.test.tsx
@@ -1,0 +1,254 @@
+/**
+ * The windowed table's share of the representative performance suite, as
+ * far as jsdom takes it: bounded DOM at every scroll position of a large
+ * local window, work in proportion to the rows entering the range, no row
+ * work for a selection or a resize, variable-height rows, and repeated
+ * mounting that leaves nothing subscribed. Layout, paint and latency need
+ * a browser and are not measured here.
+ */
+import type { DataViewsProvider } from "@canonical/dataviews-core";
+import {
+  createDataViewsProvider,
+  createSchema,
+} from "@canonical/dataviews-core";
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import DataTable from "../DataTable/DataTable.js";
+import type {
+  DataTableCellProps,
+  DataTableColumn,
+} from "../DataTable/types.js";
+import virtualRows from "./virtualRows.js";
+
+const schema = createSchema([
+  { field: "status", kind: "choices", options: ["failed", "running"] },
+]);
+
+type Fields = typeof schema.fields;
+type Machine = {
+  readonly id: string;
+  readonly name: string;
+  readonly status: string;
+};
+
+const rows: readonly Machine[] = Array.from(
+  { length: 10_000 },
+  (_, position) => ({
+    id: `m-${position}`,
+    name: `host-${position}`,
+    status: "running",
+  }),
+);
+
+/** 32px rows in a 640px viewport: twenty in view, four more past each edge. */
+const rowHeight = 32;
+const inView = 640 / rowHeight;
+const mountedAtMost = inView + 1 + 2 * 4;
+
+let cellRenders = 0;
+
+/** A cell that counts its renders: every mounted row renders one. */
+function CountedCell({ value }: DataTableCellProps) {
+  cellRenders += 1;
+  return <>{String(value)}</>;
+}
+
+const columns: readonly DataTableColumn[] = [
+  { id: "name", header: "Name", cell: CountedCell, resizable: true },
+  { id: "status", header: "Status" },
+];
+
+/** A ResizeObserver the test drives. */
+class FakeResizeObserver {
+  static live: FakeResizeObserver[] = [];
+  readonly observed = new Set<Element>();
+  readonly #callback: ResizeObserverCallback;
+  constructor(callback: ResizeObserverCallback) {
+    this.#callback = callback;
+    FakeResizeObserver.live.push(this);
+  }
+  observe(target: Element): void {
+    this.observed.add(target);
+  }
+  unobserve(target: Element): void {
+    this.observed.delete(target);
+  }
+  disconnect(): void {
+    this.observed.clear();
+  }
+  report(sizes: readonly (readonly [Element, number])[]): void {
+    this.#callback(
+      sizes.map(([target, height]) => ({
+        target,
+        borderBoxSize: [{ blockSize: height, inlineSize: 800 }],
+      })) as unknown as ResizeObserverEntry[],
+      this as unknown as ResizeObserver,
+    );
+  }
+}
+
+/** A windowed table over all ten thousand rows, scrolled to the top. */
+const largeTable = (selectable = false) => {
+  const provider: DataViewsProvider<Fields, Machine> = createDataViewsProvider<
+    Fields,
+    Machine
+  >({ schema });
+  const view = render(
+    <DataTable
+      provider={provider}
+      columns={columns}
+      label="Machines"
+      selectable={selectable}
+      windowing={virtualRows({ estimatedRowHeight: rowHeight })}
+    />,
+  );
+  const requestId = provider.refresh();
+  if (requestId === null) {
+    throw new Error("expected a refresh request");
+  }
+  act(() => {
+    provider.complete(requestId, {
+      status: "success",
+      rows,
+      count: rows.length,
+    });
+  });
+  const table = screen.getByRole("table");
+  Object.defineProperty(table, "scrollTop", {
+    value: 0,
+    writable: true,
+    configurable: true,
+  });
+  return { provider, view, table };
+};
+
+const scrollTo = (table: HTMLElement, top: number): void => {
+  act(() => {
+    table.scrollTop = top;
+    fireEvent.scroll(table);
+  });
+};
+
+/** The body rows mounted right now. */
+const mountedRows = (table: HTMLElement): HTMLElement[] => [
+  ...table.querySelectorAll<HTMLElement>(
+    '.ds.data-table-row-group.body > [role="row"]',
+  ),
+];
+
+beforeEach(() => {
+  cellRenders = 0;
+  FakeResizeObserver.live = [];
+  vi.stubGlobal("ResizeObserver", FakeResizeObserver);
+  vi.spyOn(HTMLElement.prototype, "clientHeight", "get").mockImplementation(
+    function (this: HTMLElement) {
+      return this.getAttribute("role") === "table" ? 640 : 0;
+    },
+  );
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe("windowed DataTable, bounded work", () => {
+  it("mounts a bounded range of a 10,000-row window at every scroll position", () => {
+    const { table } = largeTable();
+    for (let top = 0; top < rows.length * rowHeight; top += 3_200) {
+      scrollTo(table, top);
+      const mounted = mountedRows(table);
+      expect(mounted.length).toBeLessThanOrEqual(mountedAtMost);
+      expect(mounted.length).toBeGreaterThanOrEqual(inView);
+      // The row at the viewport's top is among them, at its position.
+      expect(
+        mounted.some(
+          (row) =>
+            row.getAttribute("aria-rowindex") === String(top / rowHeight + 2),
+        ),
+      ).toBe(true);
+    }
+    // Every element under the table, gaps and cells included, stays
+    // bounded by the mounted rows rather than the window.
+    expect(table.querySelectorAll("*").length).toBeLessThan(200);
+  });
+
+  it("renders only the rows entering the range as it scrolls", () => {
+    const { table } = largeTable();
+    scrollTo(table, 16_000);
+    for (let step = 1; step <= 20; step += 1) {
+      cellRenders = 0;
+      scrollTo(table, 16_000 + step * 10 * rowHeight);
+      expect(cellRenders).toBe(10);
+    }
+  });
+
+  it("renders no cell for a scroll inside the range, a selection or a resize", () => {
+    const { provider, table } = largeTable(true);
+    scrollTo(table, 16_000);
+    cellRenders = 0;
+    scrollTo(table, 16_005);
+    act(() => {
+      provider.selection.toggle("m-505");
+    });
+    fireEvent.click(
+      screen.getByRole("checkbox", { name: "Select all displayed rows" }),
+    );
+    fireEvent.keyDown(screen.getByRole("separator"), { key: "ArrowRight" });
+    expect(cellRenders).toBe(0);
+    expect(provider.selection.state.ids.size).toBe(rows.length);
+  });
+
+  it("keeps its gaps equal to the rows they stand for, however tall each is", () => {
+    const { table } = largeTable();
+    const measured = mountedRows(table).map(
+      (row, position) => [row, position % 2 === 0 ? 32 : 64] as const,
+    );
+    const [observer] = FakeResizeObserver.live.filter((candidate) =>
+      candidate.observed.has(measured[0][0]),
+    );
+    act(() => {
+      observer.report(measured);
+    });
+    scrollTo(table, 160_000);
+    const [before] = table.querySelectorAll<HTMLElement>(".ds.data-table-gap");
+    const first = Number(mountedRows(table)[0].getAttribute("aria-rowindex"));
+    // Every row before the first mounted one: the measured ones at their
+    // measured heights, the rest at the estimate.
+    const grown = measured.reduce((total, [, height]) => total + height, 0);
+    expect(before.style.blockSize).toBe(
+      `${grown + (first - 2 - measured.length) * rowHeight}px`,
+    );
+  });
+
+  it("leaves nothing subscribed or observed after repeated mounting", () => {
+    const provider = createDataViewsProvider<Fields, Machine>({ schema });
+    let live = 0;
+    for (const channel of [provider.rows, provider.result]) {
+      const subscribe = channel.subscribe;
+      vi.spyOn(channel, "subscribe").mockImplementation((listener) => {
+        live += 1;
+        const unsubscribe = subscribe(listener);
+        return () => {
+          live -= 1;
+          unsubscribe();
+        };
+      });
+    }
+    for (let cycle = 0; cycle < 25; cycle += 1) {
+      const { unmount } = render(
+        <DataTable
+          provider={provider}
+          columns={columns}
+          label="Machines"
+          windowing={virtualRows({ estimatedRowHeight: rowHeight })}
+        />,
+      );
+      unmount();
+    }
+    expect(live).toBe(0);
+    expect(
+      FakeResizeObserver.live.every((observer) => observer.observed.size === 0),
+    ).toBe(true);
+  });
+});

--- a/packages/react/dataviews/src/lib/virtualization/virtualRows.test.ts
+++ b/packages/react/dataviews/src/lib/virtualization/virtualRows.test.ts
@@ -1,0 +1,49 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import * as root from "../../index.js";
+import windowed from "../DataTable/windowed.js";
+import { VirtualBody } from "./common/index.js";
+import * as entry from "./index.js";
+import virtualRows from "./virtualRows.js";
+
+describe("virtualRows", () => {
+  it("describes the windowing, carrying the body it renders", () => {
+    const windowing = virtualRows({ estimatedRowHeight: 40 });
+    expect(windowing[windowed]).toEqual({
+      body: VirtualBody,
+      estimatedRowHeight: 40,
+    });
+    expect(Object.isFrozen(windowing)).toBe(true);
+    expect(Object.isFrozen(windowing[windowed])).toBe(true);
+    // Nothing but the private key: the descriptor has no field to read.
+    expect(Object.keys(windowing)).toEqual([]);
+  });
+
+  it("refuses an estimate that is not a positive number of pixels", () => {
+    for (const estimatedRowHeight of [0, -1, Number.NaN, Infinity]) {
+      expect(() => virtualRows({ estimatedRowHeight })).toThrow(
+        "virtualRows requires a positive estimatedRowHeight, in pixels",
+      );
+    }
+  });
+
+  it("is reached only through its own entry point", () => {
+    expect(Object.keys(entry)).toEqual(["virtualRows"]);
+    expect(root).not.toHaveProperty("virtualRows");
+    const manifest = JSON.parse(
+      readFileSync(
+        path.join(
+          path.dirname(fileURLToPath(import.meta.url)),
+          "../../../package.json",
+        ),
+        "utf8",
+      ),
+    );
+    expect(manifest.exports["./virtualization"]).toEqual({
+      types: "./dist/types/lib/virtualization/index.d.ts",
+      import: "./dist/esm/lib/virtualization/index.js",
+    });
+  });
+});

--- a/packages/react/dataviews/src/lib/virtualization/virtualRows.ts
+++ b/packages/react/dataviews/src/lib/virtualization/virtualRows.ts
@@ -1,0 +1,31 @@
+import type { DataTableWindowing } from "../DataTable/types.js";
+import windowed from "../DataTable/windowed.js";
+import { VirtualBody } from "./common/index.js";
+import type { VirtualRowsOptions } from "./types.js";
+
+/**
+ * Mount only the rows near a DataTable's viewport, however many rows its
+ * result window holds.
+ *
+ * ```tsx
+ * const windowing = virtualRows({ estimatedRowHeight: 24 });
+ *
+ * <DataTable provider={provider} columns={columns} label="Machines" windowing={windowing} />;
+ * ```
+ *
+ * The result is an immutable descriptor, not a running virtualizer: every
+ * table given it keeps its own viewport, measurements and focus, so one
+ * descriptor serves any number of tables.
+ */
+export default function virtualRows({
+  estimatedRowHeight,
+}: VirtualRowsOptions): DataTableWindowing {
+  if (!Number.isFinite(estimatedRowHeight) || estimatedRowHeight <= 0) {
+    throw new Error(
+      "virtualRows requires a positive estimatedRowHeight, in pixels",
+    );
+  }
+  return Object.freeze({
+    [windowed]: Object.freeze({ body: VirtualBody, estimatedRowHeight }),
+  });
+}

--- a/packages/react/dataviews/src/storybook/machines/fixtures.ts
+++ b/packages/react/dataviews/src/storybook/machines/fixtures.ts
@@ -161,6 +161,17 @@ const sortableFields = ["name", "status", "region", "cores", "owner"] as const;
 /** A field the source can order by — the only kind a story may sort. */
 export type SortableField = (typeof sortableFields)[number];
 
+/**
+ * `count` machines for the windowed stories, made from the twelve above in
+ * turn — their statuses, regions, owners and notes — each host numbered.
+ */
+export const manyMachines = (count: number): readonly RowRecord[] =>
+  Array.from({ length: count }, (_, position) => ({
+    ...machines[position % machines.length],
+    id: `n-${position}`,
+    name: `node-${String(position).padStart(5, "0")}.example.com`,
+  }));
+
 /** A local-array source over the machines, or over a caller's own rows. */
 export const createMachineSource = (
   rows: readonly RowRecord[] = machines,

--- a/packages/runtime/dataviews/README.md
+++ b/packages/runtime/dataviews/README.md
@@ -59,3 +59,13 @@ The scope — database, collection and partition — is fixed at construction; s
 - **Across tabs** — `subscribe` hears this tab's writes and, through a `BroadcastChannel` where the platform has one, other tabs'; it says only that something changed, and IndexedDB stays the authority to read again.
 
 A REST-backed store is the application's own: it implements the same `ViewStore` contract, the revision preconditions and per-key patches included, and no REST adapter ships here.
+
+## Windowed tables
+
+A table that mounts only the rows near its viewport decides which through `createVirtualRange`, imported from its own entry point, so an application that never windows a table bundles none of it:
+
+```ts
+import { createVirtualRange } from "@canonical/dataviews-core/virtualization";
+```
+
+The range works over `displayEntries`, from the package root: the entries a table body displays, in order — its status row, then a row per record — each with an id unique across kinds and its logical row position, the header row being 1. It is arithmetic over estimated and measured entry sizes, keyed by entry id: a binding reports the viewport and the measurements, and scrolls by the corrections the range returns. React applications use `virtualRows` from `@canonical/dataviews-react/virtualization` rather than the range itself.

--- a/packages/runtime/dataviews/package.json
+++ b/packages/runtime/dataviews/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@canonical/dataviews-core",
-  "description": "Framework-agnostic collection-views core for Canonical apps: query grammar, schema-enforced field validation, observation channels, selection and window projection, lifecycle transition records, the request-lifecycle coordinator, the provider assembling them, the Location port with the flat URL query grammar and the authority loop that keeps them in step, and the source adapter contract with its local-array, observable-query-client and Relay forward-connection adapters, the provider's saved views over a store it is given, and an explicitly imported local-first IndexedDB saved-view store",
+  "description": "Framework-agnostic collection-views core for Canonical apps: query grammar, schema-enforced field validation, observation channels, selection and window projection, lifecycle transition records, the request-lifecycle coordinator, the provider assembling them, the Location port with the flat URL query grammar and the authority loop that keeps them in step, and the source adapter contract with its local-array, observable-query-client and Relay forward-connection adapters, the provider's saved views over a store it is given, an explicitly imported local-first IndexedDB saved-view store, and the explicitly imported virtual range a windowed table mounts its rows by",
   "version": "0.37.0",
   "type": "module",
   "module": "dist/esm/index.js",
@@ -14,6 +14,10 @@
     "./views": {
       "types": "./dist/types/lib/views/index.d.ts",
       "import": "./dist/esm/lib/views/index.js"
+    },
+    "./virtualization": {
+      "types": "./dist/types/lib/virtualization/index.d.ts",
+      "import": "./dist/esm/lib/virtualization/index.js"
     }
   },
   "files": [

--- a/packages/runtime/dataviews/src/index.test.ts
+++ b/packages/runtime/dataviews/src/index.test.ts
@@ -28,6 +28,7 @@ describe("public surface", () => {
       "createSelection",
       "createSourceBinding",
       "decodeQuery",
+      "displayEntries",
       "encodeQuery",
       "executeSlice",
       "isIdentity",
@@ -110,6 +111,20 @@ describe("public surface", () => {
         params: new URLSearchParams("status=failed&page=3"),
       }).window,
     ).toEqual({ page: 3, size: 50 });
+  });
+
+  it("keeps the virtual range out of the root, behind its own entry point", async () => {
+    expect(dataviews).not.toHaveProperty("createVirtualRange");
+    const virtualization = await import("./lib/virtualization/index.js");
+    expect(Object.keys(virtualization)).toEqual(["createVirtualRange"]);
+    const { readFileSync } = await import("node:fs");
+    const manifest = JSON.parse(
+      readFileSync(new URL("../package.json", import.meta.url), "utf8"),
+    );
+    expect(manifest.exports["./virtualization"]).toEqual({
+      types: "./dist/types/lib/virtualization/index.d.ts",
+      import: "./dist/esm/lib/virtualization/index.js",
+    });
   });
 
   it("keeps saved-view storage out of the root, behind its own entry point", async () => {

--- a/packages/runtime/dataviews/src/index.types.test.ts
+++ b/packages/runtime/dataviews/src/index.types.test.ts
@@ -27,6 +27,9 @@ import type {
   DecodedQuery,
   DecodeQueryConfig,
   DispatchResult,
+  DisplayEntriesConfig,
+  DisplayEntry,
+  DisplayEntryKind,
   EmptyOr,
   EncodeQueryConfig,
   ExecuteSliceOptions,
@@ -134,6 +137,12 @@ import type {
   ViewStore,
   ViewUpdateResult,
 } from "./lib/views/index.js";
+import type {
+  MountedRange,
+  MountedRun,
+  VirtualRange,
+  VirtualRangeConfig,
+} from "./lib/virtualization/index.js";
 
 /** Every type the saved-view entry point exports, as one enumerable tuple. */
 type EveryViewsType = [
@@ -175,6 +184,9 @@ type EveryPublicType = [
   DateField,
   DecodedQuery,
   DecodeQueryConfig,
+  DisplayEntriesConfig<unknown>,
+  DisplayEntry,
+  DisplayEntryKind,
   DispatchResult,
   EmptyOr<unknown>,
   EncodeQueryConfig,
@@ -268,7 +280,7 @@ type EveryPublicType = [
 describe("public surface types", () => {
   it("re-exports the full type surface from the barrel", () => {
     expectTypeOf<EveryPublicType>().not.toBeAny();
-    expectTypeOf<EveryPublicType["length"]>().toEqualTypeOf<104>();
+    expectTypeOf<EveryPublicType["length"]>().toEqualTypeOf<107>();
   });
 
   it("exports the saved-view types from their own entry point", () => {
@@ -277,6 +289,33 @@ describe("public surface types", () => {
     expectTypeOf<
       ViewStore["create"]
     >().returns.resolves.toEqualTypeOf<ViewCreateResult>();
+  });
+
+  it("exports the virtual range types from their own entry point", () => {
+    expectTypeOf<
+      [MountedRange, MountedRun, VirtualRange, VirtualRangeConfig]
+    >().not.toBeAny();
+    expectTypeOf<MountedRange["runs"]>().toEqualTypeOf<readonly MountedRun[]>();
+    expectTypeOf<VirtualRange["measure"]>().returns.toEqualTypeOf<number>();
+  });
+
+  it("keeps display entries open to new kinds, heights and positions", () => {
+    // A kind joins the union, and the range then needs its estimate.
+    expectTypeOf<DisplayEntryKind>().toEqualTypeOf<"record" | "status">();
+    expectTypeOf<VirtualRangeConfig["estimates"]>().toEqualTypeOf<
+      Readonly<Record<DisplayEntryKind, number>>
+    >();
+    // Every kind carries its own logical position and owning group.
+    expectTypeOf<DisplayEntry>()
+      .toHaveProperty("index")
+      .toEqualTypeOf<number>();
+    expectTypeOf<DisplayEntry>()
+      .toHaveProperty("parent")
+      .toEqualTypeOf<string | null>();
+    // A status entry carries whatever status its renderer defines.
+    expectTypeOf<
+      Extract<DisplayEntry<"stale">, { readonly kind: "status" }>["status"]
+    >().toEqualTypeOf<"stale">();
   });
 
   it("exports the identity functions with the declared shapes", () => {

--- a/packages/runtime/dataviews/src/lib/rows/displayEntries.test.ts
+++ b/packages/runtime/dataviews/src/lib/rows/displayEntries.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import displayEntries from "./displayEntries.js";
+
+describe("displayEntries", () => {
+  it("displays one record entry per row, after the header row", () => {
+    expect(displayEntries({ rowIds: ["m-1", "m-2"], status: null })).toEqual([
+      {
+        kind: "record",
+        id: "record:m-1",
+        index: 2,
+        parent: null,
+        rowId: "m-1",
+      },
+      {
+        kind: "record",
+        id: "record:m-2",
+        index: 3,
+        parent: null,
+        rowId: "m-2",
+      },
+    ]);
+  });
+
+  it("displays a status alone in place of the rows", () => {
+    expect(displayEntries({ rowIds: [], status: "loading" })).toEqual([
+      {
+        kind: "status",
+        id: "status",
+        index: 2,
+        parent: null,
+        status: "loading",
+      },
+    ]);
+  });
+
+  it("puts a status ahead of the rows it describes", () => {
+    const entries = displayEntries({ rowIds: ["m-1"], status: "stale" });
+    expect(entries.map((entry) => [entry.id, entry.index])).toEqual([
+      ["status", 2],
+      ["record:m-1", 3],
+    ]);
+  });
+
+  it("never lets a row identity collide with the status row", () => {
+    const entries = displayEntries({ rowIds: ["status"], status: "stale" });
+    expect(new Set(entries.map((entry) => entry.id)).size).toBe(2);
+  });
+
+  it("freezes the list and every entry", () => {
+    const entries = displayEntries({ rowIds: ["m-1"], status: "stale" });
+    expect(Object.isFrozen(entries)).toBe(true);
+    expect(entries.every((entry) => Object.isFrozen(entry))).toBe(true);
+  });
+});

--- a/packages/runtime/dataviews/src/lib/rows/displayEntries.ts
+++ b/packages/runtime/dataviews/src/lib/rows/displayEntries.ts
@@ -1,0 +1,51 @@
+import type { DisplayEntry } from "./types.js";
+
+/** What one table body displays. */
+export type DisplayEntriesConfig<TStatus> = {
+  /** The rows shown, in result order: empty when a status replaces them. */
+  readonly rowIds: readonly string[];
+  /** The table's status, shown ahead of any rows, or null for none. */
+  readonly status: TStatus | null;
+};
+
+/** The table's header row is logical row 1; its entries follow it. */
+const headerRows = 1;
+
+/**
+ * The entries of one table body, in display order: the table's status row
+ * when it has one, then a row per record.
+ *
+ * Each entry's id is unique across kinds — a record's is prefixed, so no
+ * row identity can collide with the status row's — and each carries its
+ * logical row position. A renderer keys, measures and indexes rows by these
+ * entries rather than by array position.
+ */
+export default function displayEntries<TStatus>({
+  rowIds,
+  status,
+}: DisplayEntriesConfig<TStatus>): readonly DisplayEntry<TStatus>[] {
+  const entries: DisplayEntry<TStatus>[] = [];
+  if (status !== null) {
+    entries.push(
+      Object.freeze({
+        kind: "status",
+        id: "status",
+        index: headerRows + 1,
+        parent: null,
+        status,
+      }),
+    );
+  }
+  for (const rowId of rowIds) {
+    entries.push(
+      Object.freeze({
+        kind: "record",
+        id: `record:${rowId}`,
+        index: headerRows + entries.length + 1,
+        parent: null,
+        rowId,
+      }),
+    );
+  }
+  return Object.freeze(entries);
+}

--- a/packages/runtime/dataviews/src/lib/rows/index.ts
+++ b/packages/runtime/dataviews/src/lib/rows/index.ts
@@ -1,4 +1,6 @@
 export { default as createRowModel } from "./createRowModel.js";
 export type { RowScopes, RowScopesConfig } from "./createRowScopes.js";
 export { default as createRowScopes } from "./createRowScopes.js";
+export type { DisplayEntriesConfig } from "./displayEntries.js";
+export { default as displayEntries } from "./displayEntries.js";
 export type * from "./types.js";

--- a/packages/runtime/dataviews/src/lib/rows/types.ts
+++ b/packages/runtime/dataviews/src/lib/rows/types.ts
@@ -34,6 +34,57 @@ export type RowModel<TRow extends object> = {
   readonly byId: (id: string) => TRow | undefined;
 };
 
+/** What every display entry carries, whatever its kind. */
+type DisplayEntryBase = {
+  /**
+   * Unique across kinds and stable across rebuilds. Rendered rows,
+   * measurements and retained focus are keyed by it, never by position, so
+   * removing one entry moves nothing that belongs to another.
+   */
+  readonly id: string;
+  /**
+   * The entry's logical row position, as `aria-rowindex` reports it: the
+   * header row is 1 and the entries follow in display order. Worked out
+   * once, here, so every binding reports the same position. Forward seam:
+   * the rows of a collapsed group are not displayed, so they take none.
+   */
+  readonly index: number;
+  /**
+   * The entry id of the group the entry belongs to, or null at the top
+   * level. Forward seam: every entry is top-level until grouping lands, and
+   * an entry's owning group is read from here, never recomputed.
+   */
+  readonly parent: string | null;
+};
+
+/**
+ * One entry of a table body, in display order: a record's row, or a status
+ * row carrying a status of the renderer's own shape.
+ *
+ * Forward seam: a group's header row joins this union as `"group"`, with
+ * its group path and nesting level, spanning every track at a height of
+ * its own.
+ */
+export type DisplayEntry<TStatus = unknown> =
+  | (DisplayEntryBase & {
+      readonly kind: "record";
+      /** The identity of the row the entry displays. */
+      readonly rowId: string;
+    })
+  | (DisplayEntryBase & {
+      readonly kind: "status";
+      /**
+       * Why there are no rows, or why the rows after it are an earlier
+       * query's. Forward seam: the table's own status is the only one
+       * today; a group still loading is another entry of this kind, whose
+       * parent is that group.
+       */
+      readonly status: TStatus;
+    });
+
+/** The kinds of display entry. */
+export type DisplayEntryKind = DisplayEntry["kind"];
+
 /**
  * One row's observation scope. Minted once per row identity and shared by
  * every cell of that row: field channels notify only the cells whose value

--- a/packages/runtime/dataviews/src/lib/virtualization/createSizeIndex.test.ts
+++ b/packages/runtime/dataviews/src/lib/virtualization/createSizeIndex.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+import createSizeIndex from "./createSizeIndex.js";
+
+/** The offsets a plain running sum gives, for comparison. */
+const runningOffsets = (sizes: readonly number[]): number[] => {
+  const offsets = [0];
+  for (const size of sizes) {
+    offsets.push(offsets[offsets.length - 1] + size);
+  }
+  return offsets;
+};
+
+/** A deterministic sequence of sizes between 1 and 64. */
+const pseudoRandomSizes = (count: number, seed: number): number[] => {
+  let state = seed;
+  return Array.from({ length: count }, () => {
+    state = (state * 1103515245 + 12345) % 2147483648;
+    return 1 + (state % 64);
+  });
+};
+
+describe("createSizeIndex", () => {
+  it("answers an empty sequence with nothing", () => {
+    const index = createSizeIndex([]);
+    expect(index.offset(0)).toBe(0);
+    expect(index.at(100)).toBe(0);
+  });
+
+  it("finds where each entry starts and which entry covers an offset", () => {
+    const index = createSizeIndex([10, 20, 30]);
+    expect([0, 1, 2, 3].map(index.offset)).toEqual([0, 10, 30, 60]);
+    expect([0, 9.5, 10, 29, 30, 59].map(index.at)).toEqual([0, 0, 1, 1, 2, 2]);
+  });
+
+  it("holds an offset outside the sequence to its ends", () => {
+    const index = createSizeIndex([10, 20, 30]);
+    expect(index.at(-5)).toBe(0);
+    expect(index.at(1000)).toBe(2);
+  });
+
+  it("skips an entry that covers nothing", () => {
+    expect(createSizeIndex([10, 0, 10]).at(10)).toBe(2);
+  });
+
+  it("replaces one size and moves every offset after it", () => {
+    const index = createSizeIndex([10, 20, 30]);
+    index.set(1, 5);
+    expect(index.size(1)).toBe(5);
+    expect([1, 2, 3].map(index.offset)).toEqual([10, 15, 45]);
+    expect(index.at(15)).toBe(2);
+  });
+
+  it("agrees with a running sum through any series of replacements", () => {
+    const sizes = pseudoRandomSizes(1000, 7);
+    const index = createSizeIndex(sizes);
+    for (const [step, size] of pseudoRandomSizes(200, 11).entries()) {
+      const position = (step * 37) % sizes.length;
+      sizes[position] = size;
+      index.set(position, size);
+    }
+    const offsets = runningOffsets(sizes);
+    for (let position = 0; position <= sizes.length; position += 1) {
+      expect(index.offset(position)).toBe(offsets[position]);
+    }
+    for (let position = 0; position < sizes.length; position += 1) {
+      expect(index.at(offsets[position])).toBe(position);
+      expect(index.at(offsets[position + 1] - 0.5)).toBe(position);
+    }
+  });
+});

--- a/packages/runtime/dataviews/src/lib/virtualization/createSizeIndex.ts
+++ b/packages/runtime/dataviews/src/lib/virtualization/createSizeIndex.ts
@@ -1,0 +1,75 @@
+/** The sizes of one sequence of entries, summed in logarithmic time. */
+export type SizeIndex = {
+  /** The size of the entry at one position. */
+  readonly size: (position: number) => number;
+  /** Replace the size of the entry at one position. */
+  readonly set: (position: number, size: number) => void;
+  /**
+   * The summed size of every entry before one position: where it starts.
+   * At the sequence's length, the whole: read from the same tree, so it
+   * never drifts from the offsets beside it.
+   */
+  readonly offset: (position: number) => number;
+  /**
+   * The position of the entry covering one offset: the last whose start is
+   * at or before it, held to the sequence. An empty sequence answers 0.
+   */
+  readonly at: (offset: number) => number;
+};
+
+/**
+ * Index the sizes of one sequence as a Fenwick tree. Reading where an
+ * entry starts, finding the entry at an offset and replacing one size each
+ * cost O(log n), so neither a scroll nor a measurement walks the sequence.
+ * Building costs O(n), once per sequence.
+ */
+export default function createSizeIndex(sizes: readonly number[]): SizeIndex {
+  const count = sizes.length;
+  const own = Float64Array.from(sizes);
+  // tree[i] sums the `i & -i` sizes ending at position i - 1.
+  const tree = new Float64Array(count + 1);
+  for (let node = 1; node <= count; node += 1) {
+    tree[node] += own[node - 1];
+    const parent = node + (node & -node);
+    if (parent <= count) {
+      tree[parent] += tree[node];
+    }
+  }
+  // The largest power of two within the tree: where a descent starts.
+  let top = 1;
+  while (top * 2 <= count) {
+    top *= 2;
+  }
+
+  return {
+    size: (position) => own[position],
+    set(position, size) {
+      const delta = size - own[position];
+      own[position] = size;
+      for (let node = position + 1; node <= count; node += node & -node) {
+        tree[node] += delta;
+      }
+    },
+    offset(position) {
+      let sum = 0;
+      for (let node = position; node > 0; node -= node & -node) {
+        sum += tree[node];
+      }
+      return sum;
+    },
+    at(offset) {
+      // Descend from the top, taking every whole node that still ends at
+      // or before the offset: what is left is the entry covering it.
+      let position = 0;
+      let remaining = offset;
+      for (let step = top; step > 0; step >>= 1) {
+        const node = position + step;
+        if (node <= count && tree[node] <= remaining) {
+          position = node;
+          remaining -= tree[node];
+        }
+      }
+      return Math.min(position, Math.max(0, count - 1));
+    },
+  };
+}

--- a/packages/runtime/dataviews/src/lib/virtualization/createVirtualRange.test.ts
+++ b/packages/runtime/dataviews/src/lib/virtualization/createVirtualRange.test.ts
@@ -1,0 +1,347 @@
+import { describe, expect, it, vi } from "vitest";
+import displayEntries from "../rows/displayEntries.js";
+import createVirtualRange from "./createVirtualRange.js";
+
+/** Row identities `r-0` to `r-<count - 1>`. */
+const rowIds = (count: number, from = 0): string[] =>
+  Array.from({ length: count }, (_, position) => `r-${from + position}`);
+
+const records = (ids: readonly string[]) =>
+  displayEntries({ rowIds: ids, status: null });
+
+/** A range over a hundred 10px rows; a status row is estimated at 30px. */
+const hundredRows = () => {
+  const range = createVirtualRange({ estimates: { record: 10, status: 30 } });
+  const entries = records(rowIds(100));
+  range.setEntries(entries);
+  return { range, entries };
+};
+
+/** The runs as [start, end, before] triples, and the space after them. */
+const shape = (range: ReturnType<typeof hundredRows>["range"]) => ({
+  runs: range.get().runs.map((run) => [run.start, run.end, run.before]),
+  after: range.get().after,
+});
+
+describe("createVirtualRange", () => {
+  it("refuses an estimate that is not a positive size", () => {
+    for (const estimate of [0, -1, Number.NaN, Number.POSITIVE_INFINITY]) {
+      expect(() =>
+        createVirtualRange({ estimates: { record: estimate, status: 30 } }),
+      ).toThrow("record estimate must be a positive finite number");
+    }
+  });
+
+  it("mounts nothing while there are no entries", () => {
+    const range = createVirtualRange({ estimates: { record: 10, status: 30 } });
+    range.setViewport(100, 50);
+    expect(range.get()).toEqual({ runs: [], after: 0 });
+    expect(range.setEntries([])).toBe(0);
+    expect(range.get()).toEqual({ runs: [], after: 0 });
+  });
+
+  it("mounts the entries in view and a few past each edge", () => {
+    const { range } = hundredRows();
+    // Nothing in view yet: the overscan alone.
+    expect(shape(range)).toEqual({ runs: [[0, 5, 0]], after: 950 });
+    range.setViewport(0, 45);
+    expect(shape(range)).toEqual({ runs: [[0, 9, 0]], after: 910 });
+    range.setViewport(500, 45);
+    expect(shape(range)).toEqual({ runs: [[46, 59, 460]], after: 410 });
+  });
+
+  it("publishes a scroll only when it changes what is mounted", () => {
+    const { range } = hundredRows();
+    range.setViewport(500, 45);
+    const listener = vi.fn();
+    const unsubscribe = range.subscribe(listener);
+    range.setViewport(503, 45);
+    expect(listener).not.toHaveBeenCalled();
+    range.setViewport(520, 45);
+    expect(listener).toHaveBeenCalledTimes(1);
+    unsubscribe();
+    range.setViewport(0, 45);
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
+
+  it("takes new entries silently, since whoever sets them renders them", () => {
+    const { range } = hundredRows();
+    const listener = vi.fn();
+    range.subscribe(listener);
+    range.setEntries(records(rowIds(3)));
+    expect(listener).not.toHaveBeenCalled();
+    expect(shape(range)).toEqual({ runs: [[0, 3, 0]], after: 0 });
+  });
+
+  it("ignores the entries it already has", () => {
+    const { range, entries } = hundredRows();
+    range.setViewport(500, 45);
+    const before = range.get();
+    expect(range.setEntries(entries)).toBe(0);
+    expect(range.get()).toBe(before);
+  });
+
+  describe("measurement", () => {
+    it("scrolls by what an entry above the anchor grew", () => {
+      const { range } = hundredRows();
+      range.setViewport(500, 45);
+      expect(range.measure([["record:r-47", 25]])).toBe(15);
+      // The anchor kept its place, so the same entries stay mounted.
+      expect(shape(range)).toEqual({ runs: [[46, 59, 460]], after: 410 });
+    });
+
+    it("moves nothing on screen for an entry below the anchor", () => {
+      const { range } = hundredRows();
+      range.setViewport(500, 45);
+      const listener = vi.fn();
+      range.subscribe(listener);
+      expect(
+        range.measure([
+          ["record:r-55", 20],
+          ["record:r-70", 20],
+        ]),
+      ).toBe(0);
+      // The mounted r-55 grew inside its run; only r-70 is space after it.
+      expect(shape(range)).toEqual({ runs: [[46, 59, 460]], after: 420 });
+      expect(listener).toHaveBeenCalledTimes(1);
+    });
+
+    it("does nothing for a size it already has or an entry it lacks", () => {
+      const { range } = hundredRows();
+      range.setViewport(500, 45);
+      const listener = vi.fn();
+      range.subscribe(listener);
+      expect(range.measure([["record:r-50", 10]])).toBe(0);
+      expect(range.measure([["record:gone", 40]])).toBe(0);
+      expect(listener).not.toHaveBeenCalled();
+    });
+
+    it("keeps no anchor at the very top", () => {
+      const { range } = hundredRows();
+      range.setViewport(0, 45);
+      expect(range.measure([["record:r-2", 30]])).toBe(0);
+      expect(shape(range)).toEqual({ runs: [[0, 7, 0]], after: 930 });
+    });
+
+    it("keeps the measurements of entries that stay", () => {
+      const { range } = hundredRows();
+      range.measure([["record:r-99", 30]]);
+      range.setEntries(records([...rowIds(100), "r-100"]));
+      expect(range.get().after).toBe(1010 + 20 - 50);
+    });
+
+    it("drops the measurements of entries that leave", () => {
+      const { range } = hundredRows();
+      range.measure([["record:r-60", 30]]);
+      range.setEntries(records(rowIds(100).filter((id) => id !== "r-60")));
+      range.setEntries(records(rowIds(100)));
+      // Back at its estimate: a kept 30px would leave 970 after the run.
+      expect(range.get().after).toBe(950);
+    });
+
+    it("keeps a measurement with its entry when the entry moves", () => {
+      const { range } = hundredRows();
+      range.measure([["record:r-60", 30]]);
+      range.setEntries(records([...rowIds(5, 1000), ...rowIds(100)]));
+      range.setViewport(700, 45);
+      // r-60 now sits at position 65, still 30px: keyed by position, the
+      // 30px would have stayed at 60 and moved the run's start to 660.
+      expect(shape(range).runs).toEqual([[64, 77, 640]]);
+    });
+  });
+
+  describe("invalidation", () => {
+    it("keeps mounted entries' measurements, which are measured again", () => {
+      const { range } = hundredRows();
+      range.setViewport(500, 45);
+      range.measure([["record:r-55", 20]]);
+      expect(range.invalidate("all")).toBe(0);
+      // Scrolled back to the top, r-55 still counts its measured 20px.
+      range.setViewport(0, 45);
+      expect(range.get().after).toBe(920);
+    });
+
+    it("forgets unmounted ones and keeps the anchor in place", () => {
+      const { range } = hundredRows();
+      range.setViewport(500, 45);
+      range.measure([["record:r-47", 25]]);
+      range.setViewport(815, 45);
+      // r-47 is far above the viewport now; forgetting it moves the anchor
+      // up by the 15px it had grown, and the scroll with it.
+      expect(range.invalidate("all")).toBe(-15);
+      expect(range.invalidate("all")).toBe(0);
+    });
+
+    it("forgets only the entries named", () => {
+      const { range } = hundredRows();
+      range.measure([
+        ["record:r-80", 20],
+        ["record:r-90", 30],
+      ]);
+      range.setViewport(10, 45);
+      expect(
+        range.invalidate(["record:r-80", "record:gone", "record:r-70"]),
+      ).toBe(0);
+      // r-80 is back to its estimate; r-90 keeps its 30px.
+      expect(range.get().after).toBe(1020 - 100);
+    });
+
+    it("changes nothing for a measurement equal to the estimate", () => {
+      const { range } = hundredRows();
+      range.measure([["record:r-90", 10]]);
+      const listener = vi.fn();
+      range.subscribe(listener);
+      expect(range.invalidate(["record:r-90"])).toBe(0);
+      expect(listener).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("new entries", () => {
+    it("keeps the anchor in place when a status row appears above it", () => {
+      const { range } = hundredRows();
+      range.setViewport(500, 45);
+      const stale = displayEntries({ rowIds: rowIds(100), status: "stale" });
+      expect(range.setEntries(stale)).toBe(30);
+      // Entry 51 is r-50: the same rows stay mounted under the status row.
+      expect(shape(range)).toEqual({ runs: [[47, 60, 490]], after: 410 });
+    });
+
+    it("follows the anchor to wherever it moved", () => {
+      const { range } = hundredRows();
+      range.setViewport(505, 45);
+      expect(range.setEntries(records(["new", ...rowIds(100)]))).toBe(10);
+      // Reversed, r-50 lands at position 49: 20px earlier than it just was.
+      expect(range.setEntries(records(rowIds(100).reverse()))).toBe(-20);
+    });
+
+    it("stays put when the anchor left", () => {
+      const { range } = hundredRows();
+      range.setViewport(500, 45);
+      const without = rowIds(100).filter((id) => id !== "r-50");
+      expect(range.setEntries(records(without))).toBe(0);
+      // The entry now at the viewport's start is the new anchor.
+      expect(range.measure([["record:r-49", 20]])).toBe(10);
+    });
+
+    it("shows entries added at the very top rather than scrolling past them", () => {
+      const { range } = hundredRows();
+      range.setViewport(0, 45);
+      expect(range.setEntries(records(["new", ...rowIds(100)]))).toBe(0);
+    });
+  });
+
+  describe("retention", () => {
+    it("keeps an entry above the viewport mounted, with its neighbours", () => {
+      const { range } = hundredRows();
+      range.setViewport(500, 45);
+      range.retain("record:r-10");
+      expect(shape(range)).toEqual({
+        runs: [
+          [9, 12, 90],
+          [46, 59, 340],
+        ],
+        after: 410,
+      });
+    });
+
+    it("keeps an entry below the viewport mounted", () => {
+      const { range } = hundredRows();
+      range.setViewport(500, 45);
+      range.retain("record:r-90");
+      expect(shape(range)).toEqual({
+        runs: [
+          [46, 59, 460],
+          [89, 92, 300],
+        ],
+        after: 80,
+      });
+    });
+
+    it("joins the runs when the kept entry touches the viewport's", () => {
+      const { range } = hundredRows();
+      range.setViewport(500, 45);
+      for (const [id, run] of [
+        ["record:r-58", [46, 60, 460]],
+        ["record:r-60", [46, 62, 460]],
+        ["record:r-44", [43, 59, 430]],
+      ] as const) {
+        range.retain(id);
+        expect(shape(range).runs).toEqual([run]);
+      }
+    });
+
+    it("keeps the first and last entries, with the one neighbour each has", () => {
+      const { range } = hundredRows();
+      range.setViewport(500, 45);
+      range.retain("record:r-0");
+      expect(shape(range)).toEqual({
+        runs: [
+          [0, 2, 0],
+          [46, 59, 440],
+        ],
+        after: 410,
+      });
+      range.retain("record:r-99");
+      expect(shape(range)).toEqual({
+        runs: [
+          [46, 59, 460],
+          [98, 100, 390],
+        ],
+        after: 0,
+      });
+    });
+
+    it("lets go when asked, or when the entry is not displayed", () => {
+      const { range } = hundredRows();
+      range.setViewport(500, 45);
+      range.retain("record:r-10");
+      range.retain(null);
+      expect(shape(range).runs).toEqual([[46, 59, 460]]);
+      range.retain("record:gone");
+      expect(shape(range).runs).toEqual([[46, 59, 460]]);
+    });
+
+    it("lets go of an entry that leaves", () => {
+      const { range } = hundredRows();
+      range.setViewport(500, 45);
+      range.retain("record:r-10");
+      // One row fewer above the anchor: the viewport follows it up by one.
+      range.setEntries(records(rowIds(100).filter((id) => id !== "r-10")));
+      expect(shape(range).runs).toEqual([[45, 58, 450]]);
+      // Back again, r-10 is not retained any more.
+      range.setEntries(records(rowIds(100)));
+      expect(shape(range).runs).toEqual([[46, 59, 460]]);
+    });
+  });
+
+  it("accounts for every measured fraction, and leaves nothing after the last entry", () => {
+    const { range } = hundredRows();
+    for (let round = 0; round < 50; round += 1) {
+      const sizes = rowIds(100).map(
+        (id, position) =>
+          [`record:${id}`, 10 + ((position * 7 + round) % 13) * 0.2] as const,
+      );
+      range.measure(sizes);
+      const whole = sizes.reduce((total, [, size]) => total + size, 0);
+      range.setViewport(whole / 2, 100);
+      const [run] = range.get().runs;
+      const mounted = sizes
+        .slice(run.start, run.end)
+        .reduce((total, [, size]) => total + size, 0);
+      expect(run.before + mounted + range.get().after).toBeCloseTo(whole, 9);
+      range.setViewport(10_000, 100);
+      expect(range.get().after).toBe(0);
+    }
+  });
+
+  it("bounds what it mounts however many entries there are", () => {
+    const range = createVirtualRange({ estimates: { record: 32, status: 64 } });
+    range.setEntries(records(rowIds(1_000_000)));
+    range.setViewport(16_000_000, 640);
+    const [run] = range.get().runs;
+    expect(run.end - run.start).toBe(20 + 1 + 8);
+    expect(run.before + (run.end - run.start) * 32 + range.get().after).toBe(
+      32_000_000,
+    );
+  });
+});

--- a/packages/runtime/dataviews/src/lib/virtualization/createVirtualRange.ts
+++ b/packages/runtime/dataviews/src/lib/virtualization/createVirtualRange.ts
@@ -1,0 +1,225 @@
+import type { DisplayEntry } from "../rows/types.js";
+import type { SizeIndex } from "./createSizeIndex.js";
+import createSizeIndex from "./createSizeIndex.js";
+import type {
+  MountedRange,
+  MountedRun,
+  VirtualRange,
+  VirtualRangeConfig,
+} from "./types.js";
+
+/** Entries mounted past each edge of the viewport, so the next is ready. */
+const overscan = 4;
+
+const emptyRange: MountedRange = Object.freeze({
+  runs: Object.freeze([]),
+  after: 0,
+});
+
+const sameRange = (a: MountedRange, b: MountedRange): boolean =>
+  a.after === b.after &&
+  a.runs.length === b.runs.length &&
+  a.runs.every((run, position) => {
+    const other = b.runs[position];
+    return (
+      run.start === other.start &&
+      run.end === other.end &&
+      run.before === other.before
+    );
+  });
+
+/**
+ * Create one table's virtual range.
+ *
+ * It is pure arithmetic over entry sizes: estimates until entries are
+ * measured, then their measurements. It reads no DOM and schedules
+ * nothing, so every framework binding shares it; the binding reports the
+ * viewport and the measurements, and scrolls by the corrections returned.
+ *
+ * A scroll costs O(log n) and publishes only when the mounted entries or
+ * the space around them change.
+ */
+export default function createVirtualRange(
+  config: VirtualRangeConfig,
+): VirtualRange {
+  for (const [kind, estimate] of Object.entries(config.estimates)) {
+    if (!Number.isFinite(estimate) || estimate <= 0) {
+      throw new Error(`${kind} estimate must be a positive finite number`);
+    }
+  }
+  const listeners = new Set<() => void>();
+  const measured = new Map<string, number>();
+  let entries: readonly DisplayEntry[] = [];
+  let positions = new Map<string, number>();
+  let sizes: SizeIndex = createSizeIndex([]);
+  let start = 0;
+  let size = 0;
+  // The entry at the viewport's start, and how far into it the start is.
+  let anchor: { readonly id: string; readonly within: number } | null = null;
+  let retained: string | null = null;
+  let current = emptyRange;
+
+  // No anchor at the very top: new entries there are shown, not scrolled
+  // past, as the browser's own scroll anchoring leaves them.
+  const anchorAt = (offset: number): void => {
+    const position = sizes.at(offset);
+    anchor =
+      entries.length === 0 || offset <= 0
+        ? null
+        : { id: entries[position].id, within: offset - sizes.offset(position) };
+  };
+
+  // Move the viewport by however far the sizes or entries before its
+  // anchor moved the anchor, and report how far.
+  const followAnchor = (): number => {
+    const position = anchor === null ? undefined : positions.get(anchor.id);
+    const moved =
+      anchor === null || position === undefined
+        ? 0
+        : sizes.offset(position) + anchor.within - start;
+    start += moved;
+    return moved;
+  };
+
+  const compute = (): MountedRange => {
+    const count = entries.length;
+    if (count === 0) {
+      return emptyRange;
+    }
+    const spans: [number, number][] = [
+      [
+        Math.max(0, sizes.at(start) - overscan),
+        Math.min(count, sizes.at(start + size) + 1 + overscan),
+      ],
+    ];
+    const kept = retained === null ? undefined : positions.get(retained);
+    if (kept !== undefined) {
+      const span: [number, number] = [
+        Math.max(0, kept - 1),
+        Math.min(count, kept + 2),
+      ];
+      const [main] = spans;
+      if (span[1] < main[0]) {
+        spans.unshift(span);
+      } else if (span[0] > main[1]) {
+        spans.push(span);
+      } else {
+        spans[0] = [Math.min(span[0], main[0]), Math.max(span[1], main[1])];
+      }
+    }
+    let reached = 0;
+    const runs: MountedRun[] = [];
+    for (const [first, end] of spans) {
+      runs.push(
+        Object.freeze({
+          start: first,
+          end,
+          before: sizes.offset(first) - sizes.offset(reached),
+        }),
+      );
+      reached = end;
+    }
+    return Object.freeze({
+      runs: Object.freeze(runs),
+      after: sizes.offset(count) - sizes.offset(reached),
+    });
+  };
+
+  const publish = (notify: boolean): void => {
+    const next = compute();
+    if (sameRange(current, next)) {
+      return;
+    }
+    current = next;
+    if (notify) {
+      for (const listener of [...listeners]) {
+        listener();
+      }
+    }
+  };
+
+  // After sizes change: keep the anchor in place, then tell the binding.
+  const settle = (): number => {
+    const moved = followAnchor();
+    publish(true);
+    return moved;
+  };
+
+  const mounted = (position: number): boolean =>
+    current.runs.some((run) => run.start <= position && position < run.end);
+
+  return {
+    get: () => current,
+    subscribe(listener) {
+      listeners.add(listener);
+      return () => {
+        listeners.delete(listener);
+      };
+    },
+    setEntries(next) {
+      if (next === entries) {
+        return 0;
+      }
+      entries = next;
+      positions = new Map(next.map((entry, position) => [entry.id, position]));
+      for (const id of measured.keys()) {
+        if (!positions.has(id)) {
+          measured.delete(id);
+        }
+      }
+      sizes = createSizeIndex(
+        next.map(
+          (entry) => measured.get(entry.id) ?? config.estimates[entry.kind],
+        ),
+      );
+      if (retained !== null && !positions.has(retained)) {
+        retained = null;
+      }
+      const moved = followAnchor();
+      anchorAt(start);
+      publish(false);
+      return moved;
+    },
+    setViewport(nextStart, nextSize) {
+      start = nextStart;
+      size = Math.max(0, nextSize);
+      anchorAt(start);
+      publish(true);
+    },
+    measure(reported) {
+      let changed = false;
+      for (const [id, measuredSize] of reported) {
+        const position = positions.get(id);
+        if (position === undefined) {
+          continue;
+        }
+        measured.set(id, measuredSize);
+        if (sizes.size(position) !== measuredSize) {
+          sizes.set(position, measuredSize);
+          changed = true;
+        }
+      }
+      return changed ? settle() : 0;
+    },
+    invalidate(ids) {
+      let changed = false;
+      for (const id of ids === "all" ? [...measured.keys()] : ids) {
+        const position = positions.get(id);
+        if (position === undefined || mounted(position) || !measured.has(id)) {
+          continue;
+        }
+        measured.delete(id);
+        const estimate = config.estimates[entries[position].kind];
+        if (sizes.size(position) !== estimate) {
+          sizes.set(position, estimate);
+          changed = true;
+        }
+      }
+      return changed ? settle() : 0;
+    },
+    retain(id) {
+      retained = id !== null && positions.has(id) ? id : null;
+      publish(true);
+    },
+  };
+}

--- a/packages/runtime/dataviews/src/lib/virtualization/index.ts
+++ b/packages/runtime/dataviews/src/lib/virtualization/index.ts
@@ -1,0 +1,2 @@
+export { default as createVirtualRange } from "./createVirtualRange.js";
+export type * from "./types.js";

--- a/packages/runtime/dataviews/src/lib/virtualization/types.ts
+++ b/packages/runtime/dataviews/src/lib/virtualization/types.ts
@@ -1,0 +1,75 @@
+import type { ReadonlyChannel } from "../observable/createChannel.js";
+import type { DisplayEntry, DisplayEntryKind } from "../rows/types.js";
+
+/** Configuration of one table's virtual range. */
+export type VirtualRangeConfig = {
+  /**
+   * Each entry kind's size before it is measured, in pixels. An estimate
+   * places an entry and never clips one: every entry is measured once it
+   * is mounted. Keyed by kind, so no kind of entry joins without one.
+   */
+  readonly estimates: Readonly<Record<DisplayEntryKind, number>>;
+};
+
+/** One run of consecutive entries to mount. */
+export type MountedRun = {
+  /** The position of the run's first entry. */
+  readonly start: number;
+  /** The position after the run's last entry. */
+  readonly end: number;
+  /** The space of the entries skipped before the run, in pixels. */
+  readonly before: number;
+};
+
+/** Which entries to mount, and the space the others take. */
+export type MountedRange = {
+  /** Runs of consecutive entries, in display order. */
+  readonly runs: readonly MountedRun[];
+  /** The space of the entries after the last run, in pixels. */
+  readonly after: number;
+};
+
+/**
+ * One table's virtual range: which of its entries to mount for a viewport,
+ * published as a channel that notifies only when that answer changes.
+ *
+ * Everything is keyed by entry id — measurements, the scroll anchor and
+ * the retained entry — so an entry that moves or leaves takes nothing that
+ * belongs to another with it. Positions are the current entries' only.
+ */
+export type VirtualRange = ReadonlyChannel<MountedRange> & {
+  /**
+   * Replace the entries. Notifies nobody: whoever sets them is rendering
+   * them. Measurements of entries that left are dropped, so retention is
+   * bounded by the entries displayed. The anchor keeps its place when
+   * entries are added or removed before it, and the viewport stays put
+   * when the anchor itself left. Returns how far to scroll for that.
+   */
+  readonly setEntries: (entries: readonly DisplayEntry[]) => number;
+  /**
+   * Place the viewport, in the entries' own coordinates: where it starts,
+   * and how much it shows. The entry at its start becomes the anchor,
+   * except at the very top, where entries added before it are shown rather
+   * than scrolled past.
+   */
+  readonly setViewport: (start: number, size: number) => void;
+  /**
+   * Record mounted entries' measured sizes, by entry id. Returns how far
+   * to scroll so the anchor stays where it is on screen.
+   */
+  readonly measure: (
+    sizes: Iterable<readonly [id: string, size: number]>,
+  ) => number;
+  /**
+   * Forget the measurements of unmounted entries — those named, or `"all"`
+   * when a change such as a new width outdates every one. Mounted entries
+   * keep theirs: they are measured again when they change. Returns how far
+   * to scroll to keep the anchor in place.
+   */
+  readonly invalidate: (ids: Iterable<string> | "all") => number;
+  /**
+   * Keep one entry mounted, with a neighbour on each side, wherever the
+   * viewport is; null keeps none. An id not displayed is ignored.
+   */
+  readonly retain: (id: string | null) => void;
+};


### PR DESCRIPTION
## Done

Adds opt-in row windowing to `DataTable`: a table mounts only the rows near its viewport, however many its result window holds.

```tsx
import { virtualRows } from "@canonical/dataviews-react/virtualization";

<DataTable provider={provider} columns={columns} label="Machines"
  windowing={virtualRows({ estimatedRowHeight: 32 })} />
```

- **Opt-in and isolated.** `virtualRows` lives on its own entry point and returns an opaque descriptor, so a table that never imports it never ships it. A bundle test reads the output module graph to hold that.
- **Accessible counts.** The windowed root reports `aria-rowcount`, and each mounted row its `aria-rowindex`, so an unmounted row is still counted. Gaps are hidden from assistive technology.
- **Variable heights.** Mounted rows are measured, and the view holds still when rows above it are measured, replaced, added or removed.
- **Focus.** The row holding focus stays mounted, with a neighbour on each side, until focus leaves the table.
- **Selection** and select-all act on every row, mounted or not.
- **Without JavaScript** the server renders the whole result window; it hydrates without a mismatch and narrows to the rows in view.

**In the core**, two framework-neutral pieces a later Svelte binding can share:
- `displayEntries` lists what a table body shows, in order — the status row, then a row per record — each with an id unique across kinds, its logical row position and its owning group. Renderers key, measure and index by entry, not array position, and the entry type is open to future kinds such as group header rows.
- `createVirtualRange` (on `@canonical/dataviews-core/virtualization`) decides which entries to mount. Sizes live in a Fenwick tree, so a scroll costs O(log n); estimates are per entry kind and measurements per entry id. It reads no DOM. It is built in-house rather than on TanStack `virtual-core` (≈2 KB against 10.8 KB gzipped, no new dependency).

**A fix for every table:** row groups size by their tracks' minimums (`min-content`) instead of `max-content`, so the table no longer paints too wide before the column solver runs. In Chromium, 2,000 rows with one long value laid out at 4,880px in 22 ms before, and 600px in 0.4 ms after.

**Behaviour changes for a table without `windowing`:** before the solver runs, and without JavaScript, flexible tracks now fit the container instead of their content; `DataTable` watches row ids itself; while a status shows, the body re-renders only when `renderStatus` changes identity. Markup is otherwise unchanged.

**Specification first.** The windowed body's anatomy is committed before its code.

Merge order: #1241 must land first — this is based on it, so the diff here is only this change.

## QA

- `bun run check` green at the root (68 projects).
- `@canonical/dataviews-core`: 754 tests; `@canonical/dataviews-react`: 339 tests. Both at 100% branch/function/line/statement coverage; both builds and the Storybook build pass.
- All 50 stories render under `composeStories` in StrictMode with no console errors.
- In Chromium, 10,000 rows keep at most 21 row elements mounted while scrolling, each scroll step settles within two frames, and variable-height rows moved 0px over 60 upward steps.
- Not yet measured: Firefox and WebKit, reference hardware, and a screen-reader walkthrough.
- To look: `bun run storybook` in `packages/react/dataviews` — the windowed DataTable stories (10,000 rows, rows of different heights, focus retention) and the DataTable recipes.

### PR readiness check

- [x] PR title follows the Conventional Commits format.
- [x] The code follows the appropriate code standards.
- [x] The package defines `check`, `check:fix`, `test`, `build`, `build:all`.
- [x] Visual surface (windowed body, row-group sizing) — Chromatic runs.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0143BZrKuhi4j3YdemH5SbqD
