### PR TITLE
feat(dataviews): polymorphic collections in the core

### DIFF
--- a/packages/runtime/dataviews/README.md
+++ b/packages/runtime/dataviews/README.md
@@ -25,7 +25,7 @@ Under active development; the public surface grows change by change. The current
 - **Field interaction** — `createFieldInteraction`: text input and feedback for one filter field; invalid or incomplete edits retain the applied predicate; explicit `clear` is distinct from invalid input.
 - **Operation record** — `createOperation`: captures targets and selection revision immutably at construction so later selection changes never retarget execution; partial outcomes settle each target once; retry re-runs only failed targets.
 - **Collection coordinator** — `createCollectionCoordinator`: addressed commands as coherent query+window transitions (a query change resets the page), request identities whose superseded completions are ignored, atomic publication of rows, group summaries, counts, cursors and provenance, scope rotation, and `adopt` for externally authoritative state such as back/forward navigation. Provenance is the request the coordinator issued — the slice and window the rows answer — never anything the source says about them. A refusal or failure over retained rows reports `refreshFailed` while those rows still answer the current query, so a failed refresh is never silent; over rows an earlier query produced it reports `stale`; with no rows at all it reports `failed`.
-- **Rows** — `createRowModel`: the ordered model of one result, keyed by each record's stable identity rather than its position, carrying unchanged entries across reorders and republications; `createRowScopes`: one observation scope per row identity, shared by every cell of that row, with a channel per observed field so an unchanged value never notifies its cell.
+- **Rows** — `createRowModel`: the ordered model of one result, keyed by each record's stable identity rather than its position, carrying unchanged entries across reorders and republications, and answering with a result rather than throwing, so an ambiguous identity fails the completion the rows arrived in instead of the call that built them; `createRowScopes`: one observation scope per row identity, shared by every cell of that row, with a channel per observed field so an unchanged value never notifies its cell.
 - **Geometry** — `resolveColumns`: fixed columns reserve their declared width, flexible ones share what is left by weight until capped, and declared widths survive an overflow (the container scrolls); `createColumnLayout`: declared sizing plus user-fixed overrides; `createGridInteraction`: one clamped live resize preview that never touches the authority until it commits; `columnTemplate`: the resolved geometry as the one CSS track list a renderer publishes.
 - **Save race** — `createSaveSession`: a save completion updates only the submitted baseline, so edits made while saving remain dirty; delayed external reads never overwrite newer local state.
 - **Sources** — `createSourceBinding` binds a source to the coordinator's request lifecycle: it executes exactly the newest request identity, drops completions from released or superseded executions, refuses — before execution, so a refusal costs no round trip — a request the source has not declared support for, holds every count to what the declaration allows, and republishes a later delivery of the same query under a fresh identity so retained rows never carry another request's provenance. It throws at construction when a declared capability has no port to serve it, so a declaration is never a promise the source cannot keep. Construction subscribes to nothing: `observe()` starts and the release it returns stops. `createArraySource` is the default and recommended source — complete local input, so all three of its counts are exact rather than one loaded page's, and it serves record lookup by identity locally. `createQuerySource` runs over an observable query client such as TanStack Query, reached through a structural observer surface so no query library is imported here or forced on consumers. `createRelaySource` runs over a forward-paginating Relay connection through a structural environment surface that Relay's own `Environment` satisfies: each request retains its operation, delivers a page already in the store at once, fetches it, and follows every later store change — a mutation or a local update — so Relay's store stays the only cache. It pages forward from each page's end cursor or from a token the window carries, and refuses — structurally, with `code: "unreachable-page"` — a page it can reach neither way, as after a reload onto page three, instead of inventing one. The query pages by its own `first` and `after` arguments: one paging through `@connection` is refused, since Relay merges such a connection's pages into one list. A missing `totalCount` counts nothing, never zero, and a page with a missing record fails rather than being delivered shorter. `supportsRequest` and `executeSlice` are the pure pieces underneath: the declared-capability check, which returns one structured refusal per unexecutable term, and local execution over complete input. A control holding the binding reads `binding.supports(query)` before offering a destination — it composes that check with the source's own, which the declaration cannot express — and `binding.capabilities` is the frozen declaration the binding compared, for a source whose own object was never frozen.
@@ -59,6 +59,71 @@ The scope — database, collection and partition — is fixed at construction; s
 - **Across tabs** — `subscribe` hears this tab's writes and, through a `BroadcastChannel` where the platform has one, other tabs'; it says only that something changed, and IndexedDB stays the authority to read again.
 
 A REST-backed store is the application's own: it implements the same `ViewStore` contract, the revision preconditions and per-key patches included, and no REST adapter ships here.
+
+## Records of several types
+
+One collection may hold records of several types — an LXD list of containers
+and virtual machines, a Juju list of machines and units. The collection names
+one `choices` field of its schema as the discriminator, and every row carries
+it:
+
+```ts
+const schema = createSchema([
+  { field: "type", kind: "choices", options: ["container", "virtual-machine"] },
+  { field: "status", kind: "choices", options: ["Running", "Stopped"] },
+  {
+    field: "secureboot",
+    kind: "choices",
+    options: ["true", "false"],
+    types: ["virtual-machine"],
+  },
+  { field: "processes", kind: "number", min: 0, types: ["container"] },
+]);
+
+const provider = createDataViewsProvider<typeof schema.fields, Instance>({
+  schema,
+  capabilities: source.capabilities,
+  identify: (row) => row.name, // unique across both types
+  types: { field: "type" }, // a choices field every Instance carries
+});
+```
+
+- **Declared, never derived.** A source whose backend sends no such field
+  writes it when it builds its rows, as GraphQL servers materialise
+  `__typename` and JSON:API requires `type`. A row carrying a value that is
+  not one of the field's options fails the completion and is never displayed:
+  the rows already on screen stay, reporting `refreshFailed` or `stale` as the
+  coordinator does for any other failure, which is the treatment an ambiguous
+  identity gets too. The row type is checked against the field's
+  options at compile time, and the field's existence at construction.
+- **The discriminator is an ordinary field.** It is filtered, sorted and
+  grouped under the source's declared capabilities, with no new grammar and no
+  reserved name.
+- **Scoping and the not-applicable state.** `types` on a field names the
+  record types it applies to; absent means every one of them. For a row of
+  another type the field is *not applicable* — a third state beside value and
+  empty. It satisfies no predicate, `isSet` included, and reads as absent to
+  ordering, so filtering on a scoped field restricts the result to that field's
+  types by meaning: nothing is added to the query, the URL or a saved view.
+  `provider.applicability(field, row)` answers which state a cell is in. This
+  rests on the source writing no value at a scoped key for a row the field
+  does not apply to — the source's obligation, not something checked here.
+- **Identities stay opaque strings**, unique across types within the
+  provider's scope and minted by the source, which prefixes with the type only
+  where its own backend's identities collide. The UI never parses one.
+- **Type memory.** `provider.recordType(id)` answers the type of a selected
+  identity, taken while the row was displayed and kept until the rows are next
+  replaced after it leaves the selection, so an action's applicability to
+  records selected on an earlier page is decidable without a lookup. The row on display always
+  answers for itself, so this never contradicts `provider.applicability`, and
+  it changes only with a `rows` or a `selection` publication. An identity a
+  host restored over rows this provider never modelled while they were
+  selected answers null: not loaded, never assumed.
+
+**A monomorphic collection declares no `types`, and none of this reaches it.**
+`provider.types` is null, `provider.applicability` answers `"applies"` for
+every field, `provider.recordType` answers null, no row is ever read for a
+type, and nothing costs anything.
 
 ## Words this package uses twice
 

--- a/packages/runtime/dataviews/src/index.test.ts
+++ b/packages/runtime/dataviews/src/index.test.ts
@@ -56,9 +56,10 @@ describe("public surface", () => {
     expect(dataviews.applyWindow(["a"], dataviews.DEFAULT_WINDOW)).toEqual([
       "a",
     ]);
-    expect(dataviews.createRowModel({ rows: [{ id: "a" }] }).ids).toEqual([
-      "a",
-    ]);
+    expect(dataviews.createRowModel({ rows: [{ id: "a" }] })).toMatchObject({
+      status: "built",
+      model: { ids: ["a"] },
+    });
     expect(
       dataviews.columnTemplate(
         [{ id: "a", sizing: { kind: "fixed", px: 8 } }],

--- a/packages/runtime/dataviews/src/index.types.test.ts
+++ b/packages/runtime/dataviews/src/index.types.test.ts
@@ -13,6 +13,7 @@ import type {
   ActionCapabilities,
   ActionInvocation,
   ActionTargets,
+  Applicability,
   AppliedOf,
   AppliedValues,
   ArraySource,
@@ -34,8 +35,10 @@ import type {
   DataViewsProvider,
   DataViewsProviderConfig,
   DateField,
+  DeclaredRecordTypes,
   DecodedQuery,
   DecodeQueryConfig,
+  DiscriminatorField,
   DispatchResult,
   DisplayEntriesConfig,
   DisplayEntry,
@@ -95,6 +98,7 @@ import type {
   QueryObserverFactory,
   QuerySourceConfig,
   ReadonlyChannel,
+  RecordTypes,
   RelayConnection,
   RelayEnvironment,
   RelayOperation,
@@ -111,6 +115,7 @@ import type {
   RowIdentifier,
   RowModel,
   RowModelConfig,
+  RowModelResult,
   RowRecord,
   RowScope,
   RowScopes,
@@ -186,6 +191,7 @@ type EveryPublicType = [
   ActionCapabilities,
   ActionInvocation,
   ActionTargets,
+  Applicability,
   AppliedOf<FlagField>,
   AppliedValues<readonly SchemaFieldDefinition[]>,
   ArraySource,
@@ -208,8 +214,10 @@ type EveryPublicType = [
   DataViewsProviderConfig<readonly SchemaFieldDefinition[]>,
   DateField,
   DecodedQuery,
+  DeclaredRecordTypes,
   DecodeQueryConfig,
   DispatchResult,
+  DiscriminatorField<readonly SchemaFieldDefinition[], RowRecord>,
   DisplayEntriesConfig<unknown>,
   DisplayEntry,
   DisplayEntryKind,
@@ -268,6 +276,7 @@ type EveryPublicType = [
   QueryObserverFactory<SourcePage>,
   QuerySourceConfig,
   ReadonlyChannel<unknown>,
+  RecordTypes<readonly SchemaFieldDefinition[], RowRecord>,
   RelayConnection,
   RelayEnvironment,
   RelayOperation,
@@ -284,6 +293,7 @@ type EveryPublicType = [
   RowIdentifier<RowRecord>,
   RowModel<RowRecord>,
   RowModelConfig<RowRecord>,
+  RowModelResult<RowRecord>,
   RowRecord,
   RowScope<RowRecord>,
   RowScopes<RowRecord>,
@@ -396,7 +406,7 @@ describe("public surface types", () => {
       ...new Set(surfaceOf(path.resolve("src/lib/index.ts"))),
     ].sort();
     expect(surface).toEqual(pinned().sort());
-    expectTypeOf<EveryPublicType["length"]>().toEqualTypeOf<152>();
+    expectTypeOf<EveryPublicType["length"]>().toEqualTypeOf<157>();
   });
 
   it("keeps only the saved-view store behind its own entry point", () => {

--- a/packages/runtime/dataviews/src/lib/provider/createDataViewsProvider.test.ts
+++ b/packages/runtime/dataviews/src/lib/provider/createDataViewsProvider.test.ts
@@ -5,6 +5,7 @@ import type { Completion } from "../result/types.js";
 import createSchema from "../schema/createSchema.js";
 import { declaring, sorting } from "../source/capabilities.fixtures.js";
 import createDataViewsProvider from "./createDataViewsProvider.js";
+import type { RecordTypes } from "./types.js";
 
 const machinesSchema = () =>
   createSchema([
@@ -350,14 +351,37 @@ describe("createDataViewsProvider", () => {
     expect(p.rows.get()).toBe(first);
   });
 
-  it("rejects the whole completion when a record has no usable identity", () => {
+  it("fails the whole completion when a record has no usable identity", () => {
     const p = provider();
     const requestId = refreshRequest(p);
-    expect(() =>
-      p.complete(requestId, delivered([{ name: "unidentified" }])),
-    ).toThrow("row record has no non-empty string id");
+    expect(p.complete(requestId, delivered([{ name: "unidentified" }]))).toBe(
+      true,
+    );
     expect(p.rows.get().ids).toEqual([]);
-    expect(p.state.get().result.status).toBe("refreshing");
+    const { result } = p.state.get();
+    expect(result.status).toBe("failed");
+    expect(result.problem).toMatchObject({
+      status: "failed",
+      failure: {
+        reason: "row record has no non-empty string id",
+        transient: false,
+      },
+    });
+  });
+
+  it("fails a completion whose records claim one identity", () => {
+    const p = provider();
+    p.complete(refreshRequest(p), delivered([{ id: "m-1" }]));
+    const retained = p.rows.get();
+    p.complete(refreshRequest(p), delivered([{ id: "m-2" }, { id: "m-2" }]));
+    // The rows still answer the query, so they are kept and the refresh is
+    // reported as failed over them — never replaced by rows nothing can key.
+    expect(p.rows.get()).toBe(retained);
+    expect(p.state.get().result.status).toBe("refreshFailed");
+    expect(p.state.get().result.problem).toMatchObject({
+      status: "failed",
+      failure: { reason: 'duplicate row id "m-2"' },
+    });
   });
 
   it("identifies records through a declared identifier", () => {
@@ -446,5 +470,210 @@ describe("createDataViewsProvider", () => {
     expect(p.capabilities).not.toBe(declared);
     expect(Object.isFrozen(p.capabilities)).toBe(true);
     expect(Object.isFrozen(p.capabilities?.filter.status)).toBe(true);
+  });
+});
+
+describe("createDataViewsProvider record types", () => {
+  type Container = { readonly id: string; readonly type: "container" };
+  type VirtualMachine = {
+    readonly id: string;
+    readonly type: "virtual-machine";
+    readonly secureboot?: string;
+  };
+  type Instance = Container | VirtualMachine;
+
+  const instancesSchema = () =>
+    createSchema([
+      {
+        field: "type",
+        kind: "choices",
+        options: ["container", "virtual-machine"],
+      },
+      {
+        field: "secureboot",
+        kind: "choices",
+        options: ["true", "false"],
+        types: ["virtual-machine"],
+      },
+    ]);
+
+  const instances = () =>
+    createDataViewsProvider<
+      ReturnType<typeof instancesSchema>["fields"],
+      Instance
+    >({ schema: instancesSchema(), types: { field: "type" } });
+
+  const container = (id: string): Container => ({ id, type: "container" });
+  const machine = (id: string): VirtualMachine => ({
+    id,
+    type: "virtual-machine",
+  });
+
+  it("publishes the declared types, and null without them", () => {
+    const declared = instances().types;
+    expect(declared).toEqual({
+      field: "type",
+      names: ["container", "virtual-machine"],
+    });
+    expect(Object.isFrozen(declared)).toBe(true);
+    expect(provider().types).toBeNull();
+  });
+
+  it("takes only a field that can name a record's type", () => {
+    type Declaration = RecordTypes<
+      ReturnType<typeof instancesSchema>["fields"],
+      Instance
+    >;
+    const legal: Declaration = { field: "type" };
+    // @ts-expect-error a choices field, but not the key this row union
+    // carries its type in
+    const illegal: Declaration = { field: "secureboot" };
+    expect([legal.field, illegal.field]).toEqual(["type", "secureboot"]);
+  });
+
+  it("refuses a discriminator the types could not see", () => {
+    expect(() =>
+      createDataViewsProvider({
+        schema: machinesSchema(),
+        // As a provider whose row type was erased would reach it.
+        types: { field: "owner" } as { field: never },
+      }),
+    ).toThrow('discriminator field "owner" must be a choices field');
+  });
+
+  it("answers whether a field applies to a row", () => {
+    const p = instances();
+    expect(p.applicability("secureboot", machine("v-1"))).toBe("applies");
+    expect(p.applicability("secureboot", container("c-1"))).toBe(
+      "not-applicable",
+    );
+  });
+
+  it("fails a completion carrying a row of an undeclared type", () => {
+    const p = instances();
+    p.complete(refreshRequest(p), delivered([machine("v-1")]));
+    const retained = p.rows.get();
+    const rogue = { id: "x-1", type: "sandbox" } as unknown as Instance;
+    expect(p.complete(refreshRequest(p), delivered([rogue]))).toBe(true);
+    // Never displayed: the rows already on screen stay, and the refresh is
+    // reported as failed over them.
+    expect(p.rows.get()).toBe(retained);
+    expect(p.state.get().result.status).toBe("refreshFailed");
+    expect(p.state.get().result.problem).toMatchObject({
+      status: "failed",
+      failure: {
+        reason: 'record type "sandbox" of row "x-1" is not declared',
+        transient: false,
+      },
+    });
+  });
+
+  it("reads no row for a type when the same records come back", () => {
+    let reads = 0;
+    const counted = new Proxy(
+      { id: "v-1", type: "virtual-machine" },
+      {
+        get(target, key) {
+          if (key === "type") {
+            reads += 1;
+          }
+          return Reflect.get(target, key);
+        },
+      },
+    ) as Instance;
+    const p = instances();
+    p.complete(refreshRequest(p), delivered([counted]));
+    const checked = reads;
+    expect(checked).toBeGreaterThan(0);
+    p.complete(refreshRequest(p), delivered([counted]));
+    // The model came back whole, so its rows were checked once and are not
+    // read again: they were already accepted and have not changed since.
+    expect(reads).toBe(checked);
+  });
+
+  it("remembers the type of a record selected on an earlier page", () => {
+    const p = instances();
+    p.complete(
+      refreshRequest(p),
+      delivered([machine("v-1"), container("c-1")]),
+    );
+    p.selection.set(["v-1", "c-1"]);
+    p.complete(refreshRequest(p), delivered([machine("v-2")]));
+    expect(p.rows.get().byId("v-1")).toBeUndefined();
+    expect(p.recordType("v-1")).toBe("virtual-machine");
+    expect(p.recordType("c-1")).toBe("container");
+  });
+
+  it("knows no type for a selection restored over rows it never saw", () => {
+    const p = instances();
+    p.selection.set(["unseen"]);
+    expect(p.recordType("unseen")).toBeNull();
+  });
+
+  it("forgets every remembered type when the scope rotates", () => {
+    const p = instances();
+    p.complete(refreshRequest(p), delivered([machine("v-1")]));
+    p.selection.set(["v-1"]);
+    p.complete(refreshRequest(p), delivered([]));
+    expect(p.recordType("v-1")).toBe("virtual-machine");
+    p.rotateScope();
+    p.selection.set(["v-1"]);
+    expect(p.recordType("v-1")).toBeNull();
+  });
+});
+
+describe("a monomorphic collection", () => {
+  // Nothing in the record-type work reaches a collection that declares no
+  // discriminator: no row is read for a type, no memory is kept, and every
+  // field applies to every row.
+  it("declares no types, remembers nothing and applies every field", () => {
+    const p = provider();
+    expect(p.types).toBeNull();
+    p.complete(refreshRequest(p), delivered([{ id: "m-1" }]));
+    p.selection.set(["m-1"]);
+    expect(p.recordType("m-1")).toBeNull();
+    expect(p.applicability("status", { id: "m-1" })).toBe("applies");
+    expect(p.applicability("anything", { id: "m-1" })).toBe("applies");
+  });
+
+  it("leaves a scoped field applying to every row", () => {
+    const scoped = createDataViewsProvider({
+      schema: createSchema([
+        { field: "type", kind: "choices", options: ["container"] },
+        { field: "secureboot", kind: "flag", types: ["container"] },
+      ]),
+    });
+    // No discriminator: there is one record type, so a field scoped to it
+    // has nothing to exclude and the scoping never fires.
+    expect(scoped.types).toBeNull();
+    expect(scoped.applicability("secureboot", { id: "m-1" })).toBe("applies");
+  });
+
+  it("never reads a row for a type", () => {
+    // The discriminator is the only reason a provider reads a row for
+    // anything but its identity. A record that answers to no read at all
+    // still completes, so nothing here touches it.
+    const p = createDataViewsProvider<
+      ReturnType<typeof machinesSchema>["fields"],
+      { readonly uuid: string }
+    >({ schema: machinesSchema(), identify: (row) => row.uuid });
+    const record = new Proxy(
+      // The record carries a key that looks like a discriminator, so a
+      // provider that read one would reach the trap rather than an absent
+      // key, which no read of any kind can be told from.
+      { uuid: "m-1", type: "container" },
+      {
+        get(target, key) {
+          if (key !== "uuid") {
+            throw new Error(`read of ${String(key)} on a monomorphic row`);
+          }
+          return Reflect.get(target, key);
+        },
+      },
+    );
+    expect(p.complete(refreshRequest(p), delivered([record]))).toBe(true);
+    expect(p.state.get().result.status).toBe("ready");
+    p.selection.set(["m-1"]);
+    expect(p.recordType("m-1")).toBeNull();
   });
 });

--- a/packages/runtime/dataviews/src/lib/provider/createDataViewsProvider.ts
+++ b/packages/runtime/dataviews/src/lib/provider/createDataViewsProvider.ts
@@ -25,7 +25,13 @@ import type {
 } from "../query/types.js";
 import type { Completion } from "../result/types.js";
 import createRowModel from "../rows/createRowModel.js";
-import type { RowIdentifier, RowModel, RowRecord } from "../rows/types.js";
+import EMPTY_ROW_MODEL from "../rows/emptyRowModel.js";
+import type {
+  Applicability,
+  RowIdentifier,
+  RowModel,
+  RowRecord,
+} from "../rows/types.js";
 import type { Schema } from "../schema/createSchema.js";
 import type { EmptyOr, SchemaFieldDefinition } from "../schema/types.js";
 import createSelection from "../selection/createSelection.js";
@@ -33,7 +39,8 @@ import copyCapabilities from "../source/copyCapabilities.js";
 import type { SourceCapabilities } from "../source/types.js";
 import createProviderViews from "../views/createProviderViews.js";
 import type { ViewStore } from "../views/types.js";
-import type { DataViewsProvider, FieldHandle } from "./types.js";
+import createRecordTyping from "./createRecordTyping.js";
+import type { DataViewsProvider, FieldHandle, RecordTypes } from "./types.js";
 
 /** The legal operators of a field kind, in display order. */
 const operatorsFor = (
@@ -116,6 +123,14 @@ export type DataViewsProviderConfig<
    * store of the application's own. Left out, the collection has no views.
    */
   readonly views?: ViewStore;
+  /**
+   * How this collection's records declare their type: one `choices` field of
+   * the schema, carried by every row. Left out, the collection is
+   * monomorphic — no memory is kept, no row is read for a type, and nothing
+   * else here behaves differently. A field scoped to record types is then
+   * inert, since there is only the one type for it to apply to.
+   */
+  readonly types?: RecordTypes<TFields, TRow>;
 };
 
 /** One field record with its address, for re-syncing after external changes. */
@@ -152,8 +167,16 @@ export default function createDataViewsProvider<
   const state = createChannel<CollectionState<TRow>>(coordinator.state, {
     equals: (a, b) => a === b,
   });
-  const emptyRows = createRowModel<TRow>({ rows: [], identify });
-  const rows = createChannel<RowModel<TRow>>(emptyRows);
+  const rows = createChannel<RowModel<TRow>>(EMPTY_ROW_MODEL);
+  const recordTyping =
+    config.types === undefined
+      ? null
+      : createRecordTyping<TFields, TRow>({
+          schema,
+          field: config.types.field,
+          selection,
+          rows,
+        });
 
   const publishState = (): void => {
     state.set(coordinator.state);
@@ -310,6 +333,13 @@ export default function createDataViewsProvider<
     // own literal keys and their operators; the map type is what the walk
     // can say, and this is what the walk in fact produced.
     fields: fields as DataViewsProvider<TFields>["fields"],
+    types: recordTyping?.declared ?? null,
+    applicability(field: string, row: TRow): Applicability {
+      return recordTyping?.applicability(field, row) ?? "applies";
+    },
+    recordType(id: string): string | null {
+      return recordTyping?.recordType(id) ?? null;
+    },
     navigateWindow(window: WindowNavigation): void {
       dispatchCommand({ kind: "navigateWindow", ...window });
     },
@@ -339,20 +369,48 @@ export default function createDataViewsProvider<
       if (coordinator.state.pendingRequestId !== requestId) {
         return false;
       }
-      // The model is built before the coordinator publishes, so a record
-      // with an ambiguous identity rejects the whole completion instead of
-      // leaving displayed rows the table cannot key.
-      const model =
-        completion.status === "succeeded"
-          ? createRowModel({
-              rows: completion.page.rows,
-              identify,
-              previous: rows.get(),
-            })
-          : null;
-      const published = coordinator.complete(requestId, completion);
+      // The model is built before the coordinator publishes, so rows with
+      // an ambiguous identity, or with a type the schema does not declare,
+      // fail the request instead of replacing rows that can still be keyed
+      // and displayed. Those rows then report `refreshFailed`, or `stale`
+      // once the query has moved on from the one they answer.
+      let model: RowModel<TRow> | null = null;
+      let rejection: string | null = null;
+      if (completion.status === "succeeded") {
+        const built = createRowModel({
+          rows: completion.page.rows,
+          identify,
+          previous: rows.get(),
+        });
+        // A model handed back whole was checked when it was accepted and
+        // holds the same records still, so there is nothing to read again
+        // and nothing about to leave the display.
+        if (built.status === "built" && built.model !== rows.get()) {
+          rejection = recordTyping?.rejectionOf(built.model) ?? null;
+          model = rejection === null ? built.model : null;
+        } else if (built.status === "rejected") {
+          rejection = built.reason;
+        }
+      }
+      const reported: Completion<TRow> =
+        rejection === null
+          ? completion
+          : {
+              status: "failed",
+              failure: {
+                reason: rejection,
+                // Retrying the same request delivers the same rows.
+                transient: false,
+                // No library raised anything: the rows themselves are wrong.
+                cause: null,
+              },
+            };
+      const published = coordinator.complete(requestId, reported);
       if (published) {
         if (model !== null) {
+          // The outgoing model is the last one these rows were displayed
+          // in, so the memory is taken from it before it is let go.
+          recordTyping?.remember(rows.get());
           rows.set(model);
         }
         publishState();
@@ -368,8 +426,9 @@ export default function createDataViewsProvider<
     },
     rotateScope(): void {
       coordinator.rotateScope();
-      rows.set(emptyRows);
+      rows.set(EMPTY_ROW_MODEL);
       selection.clear();
+      recordTyping?.forget();
       views?.forget();
       syncFields();
       publishState();

--- a/packages/runtime/dataviews/src/lib/provider/createRecordTyping.test.ts
+++ b/packages/runtime/dataviews/src/lib/provider/createRecordTyping.test.ts
@@ -1,0 +1,310 @@
+/**
+ * Record typing is the whole of what a polymorphic collection knows about
+ * its types: the discriminator checked against the schema, which fields
+ * apply to which type, and what type each selected identity was displayed
+ * as. Every case is mutation-tested — dropping a guard, the scope index or
+ * the memory's prune fails one.
+ */
+import { describe, expect, it } from "vitest";
+import createChannel from "../observable/createChannel.js";
+import EMPTY_ROW_MODEL from "../rows/emptyRowModel.js";
+import { builtRowModel } from "../rows/rowModel.fixtures.js";
+import type { RowModel } from "../rows/types.js";
+import createSchema from "../schema/createSchema.js";
+import createSelection from "../selection/createSelection.js";
+import createRecordTyping from "./createRecordTyping.js";
+
+type Container = {
+  readonly id: string;
+  readonly type: "container";
+  readonly processes?: number;
+};
+type VirtualMachine = {
+  readonly id: string;
+  readonly type: "virtual-machine";
+  readonly secureboot?: string;
+};
+type Instance = Container | VirtualMachine;
+
+const instances = () =>
+  createSchema([
+    {
+      field: "type",
+      kind: "choices",
+      options: ["container", "virtual-machine"],
+    },
+    {
+      field: "secureboot",
+      kind: "choices",
+      options: ["true", "false"],
+      types: ["virtual-machine"],
+    },
+    { field: "processes", kind: "number", min: 0, types: ["container"] },
+    { field: "name", kind: "flag" },
+  ]);
+
+const container = (id: string): Container => ({ id, type: "container" });
+const machine = (id: string): VirtualMachine => ({
+  id,
+  type: "virtual-machine",
+});
+
+/** One typing over a model and a selection the case drives directly. */
+const typing = (model: RowModel<Instance> = EMPTY_ROW_MODEL) => {
+  const selection = createSelection();
+  const rows = createChannel<RowModel<Instance>>(model);
+  const record = createRecordTyping<
+    ReturnType<typeof instances>["fields"],
+    Instance
+  >({ schema: instances(), field: "type", selection, rows });
+  return { record, rows, selection };
+};
+
+const modelOf = (rows: readonly Instance[]): RowModel<Instance> =>
+  builtRowModel({ rows });
+
+describe("createRecordTyping", () => {
+  it("publishes the discriminator and its names in declaration order", () => {
+    const { declared } = typing().record;
+    expect(declared).toEqual({
+      field: "type",
+      names: ["container", "virtual-machine"],
+    });
+    // Handed to every consumer of the provider, so nothing can rewrite the
+    // collection's own type list through it.
+    expect(Object.isFrozen(declared)).toBe(true);
+    expect(Object.isFrozen(declared.names)).toBe(true);
+  });
+
+  it("refuses a discriminator the schema does not describe", () => {
+    const schema = instances();
+    expect(() =>
+      createRecordTyping({
+        schema,
+        field: "kind",
+        selection: createSelection(),
+        rows: createChannel<RowModel<Instance>>(EMPTY_ROW_MODEL),
+      }),
+    ).toThrow('unknown discriminator field "kind"');
+  });
+
+  it("refuses a discriminator that is not a closed set of names", () => {
+    expect(() =>
+      createRecordTyping({
+        schema: instances(),
+        field: "name",
+        selection: createSelection(),
+        rows: createChannel<RowModel<Instance>>(EMPTY_ROW_MODEL),
+      }),
+    ).toThrow('discriminator field "name" must be a choices field, not a flag');
+  });
+
+  it("refuses a discriminator whose options are not names", () => {
+    expect(() =>
+      createRecordTyping({
+        schema: createSchema([
+          { field: "type", kind: "choices", options: [1] },
+        ]),
+        field: "type",
+        selection: createSelection(),
+        rows: createChannel<RowModel<object>>(EMPTY_ROW_MODEL),
+      }),
+    ).toThrow('discriminator field "type" requires string options');
+  });
+
+  it("refuses a field scoped to a type the discriminator does not offer", () => {
+    expect(() =>
+      createRecordTyping({
+        schema: createSchema([
+          { field: "type", kind: "choices", options: ["container"] },
+          { field: "secureboot", kind: "flag", types: ["virtual-machine"] },
+        ]),
+        field: "type",
+        selection: createSelection(),
+        rows: createChannel<RowModel<object>>(EMPTY_ROW_MODEL),
+      }),
+    ).toThrow(
+      'field "secureboot" is scoped to "virtual-machine", which is not a type of "type"',
+    );
+  });
+
+  describe("applicability", () => {
+    it("applies an unscoped field to every type", () => {
+      const { record } = typing();
+      expect(record.applicability("type", container("c-1"))).toBe("applies");
+      expect(record.applicability("type", machine("v-1"))).toBe("applies");
+    });
+
+    it("applies a field the schema does not describe at all", () => {
+      // A column showing something outside the schema has no scoping, and
+      // absent scoping is every type.
+      expect(typing().record.applicability("uptime", container("c-1"))).toBe(
+        "applies",
+      );
+    });
+
+    it("withholds a scoped field from a row of another type", () => {
+      const { record } = typing();
+      expect(record.applicability("secureboot", machine("v-1"))).toBe(
+        "applies",
+      );
+      expect(record.applicability("secureboot", container("c-1"))).toBe(
+        "not-applicable",
+      );
+      expect(record.applicability("processes", container("c-1"))).toBe(
+        "applies",
+      );
+      expect(record.applicability("processes", machine("v-1"))).toBe(
+        "not-applicable",
+      );
+    });
+
+    it("withholds a scoped field from a row carrying no declared type", () => {
+      const { record } = typing();
+      const untyped = { id: "x", type: "sandbox" } as unknown as Instance;
+      expect(record.applicability("secureboot", untyped)).toBe(
+        "not-applicable",
+      );
+    });
+  });
+
+  describe("rejectionOf", () => {
+    it("accepts a model whose every row carries a declared type", () => {
+      const { record } = typing();
+      expect(record.rejectionOf(modelOf([container("c-1"), machine("v-1")]))) //
+        .toBeNull();
+    });
+
+    it("names the row and the value a model cannot be displayed for", () => {
+      const { record } = typing();
+      const rogue = { id: "x-1", type: "sandbox" } as unknown as Instance;
+      expect(record.rejectionOf(modelOf([container("c-1"), rogue]))).toBe(
+        'record type "sandbox" of row "x-1" is not declared',
+      );
+    });
+
+    it("names a row carrying no discriminator value at all", () => {
+      const { record } = typing();
+      const rogue = { id: "x-1" } as unknown as Instance;
+      expect(record.rejectionOf(modelOf([rogue]))).toBe(
+        'record type undefined of row "x-1" is not declared',
+      );
+    });
+  });
+
+  describe("type memory", () => {
+    it("reads a selected row's type from the rows on display", () => {
+      const { record, selection } = typing(modelOf([machine("v-1")]));
+      selection.set(["v-1"]);
+      expect(record.recordType("v-1")).toBe("virtual-machine");
+    });
+
+    it("knows no type for an identity that is not selected", () => {
+      const { record } = typing(modelOf([machine("v-1")]));
+      expect(record.recordType("v-1")).toBeNull();
+    });
+
+    it("knows no type for a selected identity it never modelled", () => {
+      // A selection a host restored over rows this provider has not seen:
+      // "not loaded", never a type assumed from nothing.
+      const displayed = modelOf([machine("v-1")]);
+      const { record, rows, selection } = typing(displayed);
+      selection.set(["gone", "v-1"]);
+      record.remember(displayed);
+      rows.set(EMPTY_ROW_MODEL);
+      expect(record.recordType("gone")).toBeNull();
+      expect(record.recordType("v-1")).toBe("virtual-machine");
+    });
+
+    it("keeps a selected row's type once its page is replaced", () => {
+      const first = modelOf([machine("v-1"), container("c-1")]);
+      const { record, rows, selection } = typing(first);
+      selection.set(["v-1", "c-1"]);
+      record.remember(first);
+      rows.set(modelOf([machine("v-2")]));
+      expect(record.recordType("v-1")).toBe("virtual-machine");
+      expect(record.recordType("c-1")).toBe("container");
+    });
+
+    it("takes the type of a row selected on the page being left", () => {
+      const first = modelOf([machine("v-1")]);
+      const { record, rows, selection } = typing(first);
+      selection.set(["v-1"]);
+      // No read while it was displayed: the memory is taken on the way out.
+      record.remember(first);
+      rows.set(EMPTY_ROW_MODEL);
+      expect(record.recordType("v-1")).toBe("virtual-machine");
+    });
+
+    it("answers from the row on display, never from an older memory", () => {
+      const first = modelOf([machine("v-1")]);
+      const { record, rows, selection } = typing(first);
+      selection.set(["v-1"]);
+      record.remember(first);
+      // The identity comes back as a record of another type. Memory is for
+      // the rows that are not displayed; it never overrules one that is.
+      rows.set(modelOf([container("v-1")]));
+      expect(record.recordType("v-1")).toBe("container");
+    });
+
+    it("re-takes the memory from the row displayed now", () => {
+      const first = modelOf([machine("v-1")]);
+      const { record, rows, selection } = typing(first);
+      selection.set(["v-1"]);
+      record.remember(first);
+      const second = modelOf([container("v-1")]);
+      rows.set(second);
+      record.remember(second);
+      rows.set(EMPTY_ROW_MODEL);
+      expect(record.recordType("v-1")).toBe("container");
+    });
+
+    it("carries a remembered type through the pages that follow", () => {
+      const first = modelOf([machine("v-1")]);
+      const { record, rows, selection } = typing(first);
+      selection.set(["v-1"]);
+      record.remember(first);
+      const second = modelOf([container("c-1")]);
+      rows.set(second);
+      // A second page the row is not on: the memory is not re-taken from a
+      // model that never held it, it is carried.
+      record.remember(second);
+      rows.set(EMPTY_ROW_MODEL);
+      expect(record.recordType("v-1")).toBe("virtual-machine");
+    });
+
+    it("drops the type of an identity that left the selection", () => {
+      const first = modelOf([machine("v-1")]);
+      const { record, rows, selection } = typing(first);
+      selection.set(["v-1"]);
+      record.remember(first);
+      rows.set(EMPTY_ROW_MODEL);
+      selection.remove(["v-1"]);
+      expect(record.recordType("v-1")).toBeNull();
+      // And the deselected identity is not carried into the next memory.
+      record.remember(EMPTY_ROW_MODEL);
+      selection.set(["v-1"]);
+      expect(record.recordType("v-1")).toBeNull();
+    });
+
+    it("remembers nothing for a row whose type is not declared", () => {
+      const rogue = { id: "x-1", type: "sandbox" } as unknown as Instance;
+      const first = modelOf([rogue]);
+      const { record, rows, selection } = typing(first);
+      selection.set(["x-1"]);
+      record.remember(first);
+      rows.set(EMPTY_ROW_MODEL);
+      expect(record.recordType("x-1")).toBeNull();
+    });
+
+    it("forgets everything when the scope rotates", () => {
+      const first = modelOf([machine("v-1")]);
+      const { record, rows, selection } = typing(first);
+      selection.set(["v-1"]);
+      record.remember(first);
+      rows.set(EMPTY_ROW_MODEL);
+      record.forget();
+      expect(record.recordType("v-1")).toBeNull();
+    });
+  });
+});

--- a/packages/runtime/dataviews/src/lib/provider/createRecordTyping.ts
+++ b/packages/runtime/dataviews/src/lib/provider/createRecordTyping.ts
@@ -1,0 +1,159 @@
+import type { ReadonlyChannel } from "../observable/createChannel.js";
+import readField from "../rows/readField.js";
+import type { Applicability, RowModel, RowRecord } from "../rows/types.js";
+import type { Schema } from "../schema/createSchema.js";
+import type { SchemaFieldDefinition } from "../schema/types.js";
+import type { Selection } from "../selection/createSelection.js";
+import type { DeclaredRecordTypes } from "./types.js";
+
+/** Configuration of one collection's record typing. */
+export type RecordTypingConfig<
+  TFields extends readonly SchemaFieldDefinition[],
+  TRow extends object = RowRecord,
+> = {
+  readonly schema: Schema<TFields>;
+  /** The discriminator: the schema field every row carries its type in. */
+  readonly field: string;
+  /** The selection whose identities are the ones worth remembering. */
+  readonly selection: Selection;
+  /** The displayed rows, read for a type the memory has not taken yet. */
+  readonly rows: ReadonlyChannel<RowModel<TRow>>;
+};
+
+/** One collection's record typing: what the provider answers about types. */
+export type RecordTyping<TRow extends object = RowRecord> = {
+  /** The discriminator and its type names, as the provider publishes them. */
+  readonly declared: DeclaredRecordTypes;
+  /** Why a model cannot be displayed, or null when every row is typed. */
+  readonly rejectionOf: (model: RowModel<TRow>) => string | null;
+  /** Whether a schema field applies to a row. */
+  readonly applicability: (field: string, row: TRow) => Applicability;
+  /** The remembered type of a selected identity. */
+  readonly recordType: (id: string) => string | null;
+  /** Take the type of every selected row of a model about to be replaced. */
+  readonly remember: (model: RowModel<TRow>) => void;
+  /** Drop the memory: the scope rotated, so nothing displayed survives. */
+  readonly forget: () => void;
+};
+
+const valueLabel = (value: unknown): string =>
+  typeof value === "string" ? `"${value}"` : String(value);
+
+/**
+ * Create one collection's record typing: the discriminator checked against
+ * the schema, the type scoping of every field indexed, and the memory of
+ * what type each selected identity was displayed as.
+ *
+ * A monomorphic collection builds none of this; the provider holds null
+ * instead and answers from that.
+ */
+export default function createRecordTyping<
+  TFields extends readonly SchemaFieldDefinition[],
+  TRow extends object = RowRecord,
+>(config: RecordTypingConfig<TFields, TRow>): RecordTyping<TRow> {
+  const { schema, field: discriminator, selection, rows } = config;
+  const definition = schema.fields.find(
+    (candidate) => candidate.field === discriminator,
+  );
+  if (definition === undefined) {
+    throw new Error(`unknown discriminator field "${discriminator}"`);
+  }
+  if (definition.kind !== "choices") {
+    throw new Error(
+      `discriminator field "${discriminator}" must be a choices field, not a ${definition.kind} one`,
+    );
+  }
+  const names: string[] = [];
+  for (const option of definition.options) {
+    if (typeof option !== "string") {
+      throw new Error(
+        `discriminator field "${discriminator}" requires string options`,
+      );
+    }
+    names.push(option);
+  }
+  const declared = new Set(names);
+
+  // One scope per scoped field, indexed once: applicability is asked per
+  // cell, and walking the field list would be a walk per cell.
+  const scopes = new Map<string, ReadonlySet<string>>();
+  for (const scoped of schema.fields) {
+    if (scoped.types === undefined) {
+      continue;
+    }
+    for (const name of scoped.types) {
+      if (!declared.has(name)) {
+        throw new Error(
+          `field "${scoped.field}" is scoped to "${name}", which is not a type of "${discriminator}"`,
+        );
+      }
+    }
+    scopes.set(scoped.field, new Set(scoped.types));
+  }
+
+  /** A row's declared type name, or null when it carries no such name. */
+  const nameOf = (row: TRow): string | null => {
+    const value = readField(row, discriminator);
+    return typeof value === "string" && declared.has(value) ? value : null;
+  };
+
+  // Keyed by the selected identities alone, so it is bounded by the
+  // selection and never by how many rows have been displayed.
+  let remembered = new Map<string, string>();
+
+  return {
+    declared: Object.freeze({
+      field: discriminator,
+      names: Object.freeze(names),
+    }),
+    rejectionOf(model: RowModel<TRow>): string | null {
+      for (const entry of model.entries) {
+        const value = readField(entry.record, discriminator);
+        if (typeof value !== "string" || !declared.has(value)) {
+          return `record type ${valueLabel(value)} of row "${entry.id}" is not declared`;
+        }
+      }
+      return null;
+    },
+    applicability(field: string, row: TRow): Applicability {
+      const scope = scopes.get(field);
+      if (scope === undefined) {
+        return "applies";
+      }
+      const type = nameOf(row);
+      return type !== null && scope.has(type) ? "applies" : "not-applicable";
+    },
+    recordType(id: string): string | null {
+      // Memory is of identities while they are selected: an identity that
+      // left the selection is not one an action can be decided for.
+      if (!selection.state.get().ids.has(id)) {
+        return null;
+      }
+      // A row on display is the answer; memory answers for the rows that
+      // are not. Reading it the other way round would let a remembered
+      // type outlive the record it was taken from and contradict what
+      // `applicability` reads off that same record.
+      const record = rows.get().byId(id);
+      return record === undefined
+        ? (remembered.get(id) ?? null)
+        : nameOf(record);
+    },
+    remember(model: RowModel<TRow>): void {
+      // Rebuilt rather than added to: the pass that takes the types about
+      // to leave the display is the pass that drops the deselected ones.
+      const next = new Map<string, string>();
+      for (const id of selection.state.get().ids) {
+        const record = model.byId(id);
+        const name =
+          record === undefined ? (remembered.get(id) ?? null) : nameOf(record);
+        if (name !== null) {
+          next.set(id, name);
+        }
+      }
+      remembered = next;
+    },
+    forget(): void {
+      remembered = new Map();
+    },
+  };
+}

--- a/packages/runtime/dataviews/src/lib/provider/index.ts
+++ b/packages/runtime/dataviews/src/lib/provider/index.ts
@@ -2,6 +2,9 @@ export type { DataViewsProviderConfig } from "./createDataViewsProvider.js";
 export { default as createDataViewsProvider } from "./createDataViewsProvider.js";
 export type {
   DataViewsProvider,
+  DeclaredRecordTypes,
+  DiscriminatorField,
   FieldHandle,
   ProviderFields,
+  RecordTypes,
 } from "./types.js";

--- a/packages/runtime/dataviews/src/lib/provider/types.ts
+++ b/packages/runtime/dataviews/src/lib/provider/types.ts
@@ -15,7 +15,7 @@ import type {
   WindowNavigation,
 } from "../query/types.js";
 import type { Completion } from "../result/types.js";
-import type { RowModel, RowRecord } from "../rows/types.js";
+import type { Applicability, RowModel, RowRecord } from "../rows/types.js";
 import type { Schema } from "../schema/createSchema.js";
 import type {
   AppliedOf,
@@ -56,6 +56,68 @@ export type ProviderFields<TFields extends readonly SchemaFieldDefinition[]> = {
         : never;
 };
 
+/** Whether a row's value at one key can carry a field's options. */
+type CarriesOptions<TRow, TName, TOption> = TName extends keyof TRow
+  ? // The default row shape says nothing about its values, so it carries any.
+    unknown extends TRow[TName]
+    ? true
+    : // A key the row may not have carries no type, and such a row fails
+      // every completion: this is the case the check exists to catch.
+      undefined extends TRow[TName]
+      ? false
+      : [TRow[TName]] extends [TOption]
+        ? true
+        : // An adapter typing the key as the wider `string` carries them too.
+          [TOption] extends [TRow[TName]]
+          ? true
+          : false
+  : false;
+
+/**
+ * The schema fields that may declare a collection's record types: a
+ * `choices` field with string options, carried by the row at the same key
+ * with a value its options and the row agree on.
+ */
+export type DiscriminatorField<
+  TFields extends readonly SchemaFieldDefinition[],
+  TRow extends object = RowRecord,
+> = {
+  [TDefinition in TFields[number] as TDefinition["field"]]: TDefinition extends {
+    readonly kind: "choices";
+    readonly options: infer TOptions extends readonly string[];
+  }
+    ? CarriesOptions<TRow, TDefinition["field"], TOptions[number]> extends true
+      ? TDefinition["field"]
+      : never
+    : never;
+}[TFields[number]["field"]] &
+  /* The mapped type answers with field names, which the compiler cannot see
+     through an unresolved `TFields`; this says so. */
+  string;
+
+/**
+ * How a collection's records declare their type: one field of the schema,
+ * carried by every row. A source whose backend sends no such field writes it
+ * when it builds its rows. A row carrying a value outside the field's options
+ * fails the completion; it is never displayed.
+ *
+ * Declaring none makes the collection monomorphic, and nothing here applies.
+ */
+export type RecordTypes<
+  TFields extends readonly SchemaFieldDefinition[],
+  TRow extends object = RowRecord,
+> = {
+  readonly field: DiscriminatorField<TFields, TRow>;
+};
+
+/** A collection's record types as the provider publishes them. */
+export type DeclaredRecordTypes = {
+  /** The schema field every row carries its type in. */
+  readonly field: string;
+  /** Every type name the field declares, in declaration order. */
+  readonly names: readonly string[];
+};
+
 /** The provider: the one owner assembling core state for a collection. */
 export type DataViewsProvider<
   TFields extends
@@ -90,6 +152,38 @@ export type DataViewsProvider<
    */
   readonly views: ProviderViews | null;
   readonly fields: ProviderFields<TFields>;
+  /**
+   * The collection's record types, or null when it declares none and is
+   * therefore monomorphic.
+   *
+   * Seam for the actions unit, which reads `names` for an action's own
+   * types. A column's scope is narrower than the collection's — it is the
+   * `types` of that column's own schema field.
+   */
+  readonly types: DeclaredRecordTypes | null;
+  /**
+   * Whether a schema field applies to a row, by the field's type scoping.
+   * Always "applies" on a monomorphic collection, and on a field the schema
+   * does not scope.
+   *
+   * Seam for the cells unit: the not-applicable cell is the third state
+   * beside value and empty.
+   */
+  readonly applicability: (field: string, row: TRow) => Applicability;
+  /**
+   * The type remembered for a selected identity, or null when the provider
+   * never modelled it while it was selected — a selection restored by a host
+   * over rows this provider has not seen. A remembered type is let go when
+   * the rows are next replaced after its identity leaves the selection, so
+   * one reselected before then answers as before. It answers from the row on
+   * display whenever there is one, so it never contradicts `applicability`,
+   * and it changes only with a `rows` or a `selection` publication: watching
+   * those is watching this.
+   *
+   * Seam for the actions unit: an action's applicability to records selected
+   * on an earlier page is decidable from here, with no lookup.
+   */
+  readonly recordType: (id: string) => string | null;
   /** Bounded commands, not raw dispatch: */
   readonly navigateWindow: (window: WindowNavigation) => void;
   readonly setSort: (sort: readonly SortTerm[]) => void;

--- a/packages/runtime/dataviews/src/lib/provider/types.types.test.ts
+++ b/packages/runtime/dataviews/src/lib/provider/types.types.test.ts
@@ -1,0 +1,62 @@
+/**
+ * The discriminator's whole job is to refuse: a field that cannot name a
+ * record's type must not compile as one. Every rejection below is pinned
+ * with `@ts-expect-error`, which fails the build if the type starts
+ * accepting the case.
+ */
+import { describe, expect, it } from "vitest";
+import type { RowRecord } from "../rows/types.js";
+import createSchema from "../schema/createSchema.js";
+import type { DiscriminatorField } from "./types.js";
+
+const instances = createSchema([
+  { field: "type", kind: "choices", options: ["container", "virtual-machine"] },
+  { field: "rank", kind: "choices", options: [1, 2] },
+  { field: "status", kind: "flag" },
+]);
+
+type Fields = typeof instances.fields;
+type Discriminator<TRow extends object> = DiscriminatorField<Fields, TRow>;
+
+type Container = { readonly id: string; readonly type: "container" };
+type VirtualMachine = { readonly id: string; readonly type: "virtual-machine" };
+
+describe("DiscriminatorField", () => {
+  it("names a choices field the row carries with a matching value", () => {
+    const precise: Discriminator<Container | VirtualMachine> = "type";
+    // An adapter typing the key wider still carries the options.
+    const wide: Discriminator<{ readonly type: string }> = "type";
+    // The default row shape says nothing about its values, so it carries
+    // any of them.
+    const loose: Discriminator<RowRecord> = "type";
+    expect([precise, wide, loose]).toEqual(["type", "type", "type"]);
+  });
+
+  it("refuses a field the row does not carry", () => {
+    // @ts-expect-error the row has no "type" key to read a type from
+    const absent: Discriminator<{ readonly id: string }> = "type";
+    expect(absent).toBe("type");
+  });
+
+  it("refuses a key the row may not have", () => {
+    // A row that may carry no value at the key carries no type, and would
+    // fail every completion at runtime.
+    // @ts-expect-error "type" is optional on this row
+    const optional: Discriminator<{ readonly type?: "container" }> = "type";
+    expect(optional).toBe("type");
+  });
+
+  it("refuses a value outside the field's options", () => {
+    // @ts-expect-error "sandbox" is not one of the field's options
+    const outside: Discriminator<{ readonly type: "sandbox" }> = "type";
+    expect(outside).toBe("type");
+  });
+
+  it("refuses a field that is not a closed set of names", () => {
+    // @ts-expect-error a flag field has no options to name types with
+    const flag: Discriminator<{ readonly status: boolean }> = "status";
+    // @ts-expect-error a choices field of numbers names no types
+    const numeric: Discriminator<{ readonly rank: 1 | 2 }> = "rank";
+    expect([flag, numeric]).toEqual(["status", "rank"]);
+  });
+});

--- a/packages/runtime/dataviews/src/lib/rows/createRowModel.test.ts
+++ b/packages/runtime/dataviews/src/lib/rows/createRowModel.test.ts
@@ -4,48 +4,60 @@
  * identity guards, the entry carry or the whole-model carry fails one.
  */
 import { describe, expect, it } from "vitest";
+import type { RowModelConfig } from "./createRowModel.js";
 import createRowModel from "./createRowModel.js";
+import { builtRowModel as built } from "./rowModel.fixtures.js";
 import type { RowIdentifier, RowRecord } from "./types.js";
 
 type Machine = { readonly id: string; readonly status: string };
 
 const machine = (id: string, status = "running"): Machine => ({ id, status });
 
+/** The reason of a build the case expects to be rejected. */
+const rejection = <TRow extends object>(
+  config: RowModelConfig<TRow>,
+): string => {
+  const result = createRowModel(config);
+  return result.status === "rejected" ? result.reason : "";
+};
+
 describe("createRowModel", () => {
+  it("answers with the built model, never the model itself", () => {
+    expect(createRowModel({ rows: [machine("m-1")] })).toEqual({
+      status: "built",
+      model: expect.objectContaining({ ids: ["m-1"] }),
+    });
+  });
+
   it("orders entries and identities as the result did", () => {
-    const model = createRowModel({ rows: [machine("m-2"), machine("m-1")] });
+    const model = built({ rows: [machine("m-2"), machine("m-1")] });
     expect(model.ids).toEqual(["m-2", "m-1"]);
     expect(model.entries.map((entry) => entry.id)).toEqual(["m-2", "m-1"]);
   });
 
   it("addresses records by identity, not position", () => {
     const rows = [machine("m-1"), machine("m-2")];
-    const model = createRowModel({ rows });
+    const model = built({ rows });
     expect(model.byId("m-2")).toBe(rows[1]);
     expect(model.byId("absent")).toBeUndefined();
   });
 
   it("freezes the entries, the identities and each entry", () => {
-    const model = createRowModel({ rows: [machine("m-1")] });
+    const model = built({ rows: [machine("m-1")] });
     expect(Object.isFrozen(model.entries)).toBe(true);
     expect(Object.isFrozen(model.ids)).toBe(true);
     expect(Object.isFrozen(model.entries[0])).toBe(true);
   });
 
   it("rejects a record with no usable default identity", () => {
-    expect(() => createRowModel({ rows: [{ name: "no id" }] })).toThrow(
-      "row record has no non-empty string id",
-    );
-    expect(() => createRowModel({ rows: [{ id: "" }] })).toThrow(
-      "row record has no non-empty string id",
-    );
-    expect(() => createRowModel({ rows: [{ id: 7 }] })).toThrow(
-      "row record has no non-empty string id",
-    );
+    const reason = "row record has no non-empty string id";
+    expect(rejection({ rows: [{ name: "no id" }] })).toBe(reason);
+    expect(rejection({ rows: [{ id: "" }] })).toBe(reason);
+    expect(rejection({ rows: [{ id: 7 }] })).toBe(reason);
   });
 
   it("uses a declared identifier instead of the record's id", () => {
-    const model = createRowModel({
+    const model = built({
       rows: [{ uuid: "a" }, { uuid: "b" }],
       identify: (row: { readonly uuid: string }) => row.uuid,
     });
@@ -54,33 +66,33 @@ describe("createRowModel", () => {
 
   it("rejects a declared identifier that answers with a non-string", () => {
     const broken = ((): unknown => 42) as RowIdentifier<RowRecord>;
-    expect(() =>
-      createRowModel({ rows: [{ id: "m-1" }], identify: broken }),
-    ).toThrow("row identity must be a non-empty string");
+    expect(rejection({ rows: [{ id: "m-1" }], identify: broken })).toBe(
+      "row identity must be a non-empty string",
+    );
   });
 
   it("rejects a declared identifier that answers with an empty string", () => {
-    expect(() =>
-      createRowModel({ rows: [{ id: "m-1" }], identify: () => "" }),
-    ).toThrow("row identity must be a non-empty string");
+    expect(rejection({ rows: [{ id: "m-1" }], identify: () => "" })).toBe(
+      "row identity must be a non-empty string",
+    );
   });
 
   it("rejects two records claiming one identity", () => {
-    expect(() =>
-      createRowModel({ rows: [machine("m-1"), machine("m-1")] }),
-    ).toThrow('duplicate row id "m-1"');
+    expect(rejection({ rows: [machine("m-1"), machine("m-1")] })).toBe(
+      'duplicate row id "m-1"',
+    );
   });
 
   it("returns the previous model whole when nothing moved", () => {
     const rows = [machine("m-1"), machine("m-2")];
-    const first = createRowModel({ rows });
-    expect(createRowModel({ rows: [...rows], previous: first })).toBe(first);
+    const first = built({ rows });
+    expect(built({ rows: [...rows], previous: first })).toBe(first);
   });
 
   it("carries the entries of unchanged records past a replaced one", () => {
     const kept = machine("m-1");
-    const first = createRowModel({ rows: [kept, machine("m-2")] });
-    const second = createRowModel({
+    const first = built({ rows: [kept, machine("m-2")] });
+    const second = built({
       rows: [kept, machine("m-2", "stopped")],
       previous: first,
     });
@@ -92,8 +104,8 @@ describe("createRowModel", () => {
   it("carries entries across a reorder, keying by identity", () => {
     const one = machine("m-1");
     const two = machine("m-2");
-    const first = createRowModel({ rows: [one, two] });
-    const second = createRowModel({ rows: [two, one], previous: first });
+    const first = built({ rows: [one, two] });
+    const second = built({ rows: [two, one], previous: first });
     expect(second).not.toBe(first);
     expect(second.entries[0]).toBe(first.entries[1]);
     expect(second.entries[1]).toBe(first.entries[0]);
@@ -101,20 +113,17 @@ describe("createRowModel", () => {
 
   it("carries surviving entries when the result grows or shrinks", () => {
     const one = machine("m-1");
-    const first = createRowModel({ rows: [one, machine("m-2")] });
-    const shorter = createRowModel({ rows: [one], previous: first });
+    const first = built({ rows: [one, machine("m-2")] });
+    const shorter = built({ rows: [one], previous: first });
     expect(shorter.entries[0]).toBe(first.entries[0]);
     expect(shorter.ids).toEqual(["m-1"]);
-    const longer = createRowModel({
-      rows: [one, machine("m-3")],
-      previous: shorter,
-    });
+    const longer = built({ rows: [one, machine("m-3")], previous: shorter });
     expect(longer.entries[0]).toBe(first.entries[0]);
     expect(longer.ids).toEqual(["m-1", "m-3"]);
   });
 
   it("builds a fresh model when no predecessor is offered", () => {
     const rows = [machine("m-1")];
-    expect(createRowModel({ rows })).not.toBe(createRowModel({ rows }));
+    expect(built({ rows })).not.toBe(built({ rows }));
   });
 });

--- a/packages/runtime/dataviews/src/lib/rows/createRowModel.ts
+++ b/packages/runtime/dataviews/src/lib/rows/createRowModel.ts
@@ -1,5 +1,10 @@
 import defaultRowIdentifier from "./defaultRowIdentifier.js";
-import type { RowEntry, RowIdentifier, RowModel } from "./types.js";
+import type {
+  RowEntry,
+  RowIdentifier,
+  RowModel,
+  RowModelResult,
+} from "./types.js";
 
 /** Configuration of one row model build. */
 export type RowModelConfig<TRow extends object> = {
@@ -22,14 +27,25 @@ export type RowModelConfig<TRow extends object> = {
  * and returns `previous` itself when the whole model is unchanged, so an
  * unrelated republication recreates nothing.
  *
- * Empty, duplicate and non-string identities throw: an ambiguous row identity
- * would silently key selection, focus and actions to the wrong record.
+ * Empty, duplicate and non-string identities reject the build rather than
+ * throwing: an ambiguous row identity would silently key selection, focus and
+ * actions to the wrong record, and the caller that asked for the model is the
+ * one that can report it — the provider fails the completion the rows came in.
  */
 export default function createRowModel<TRow extends object>(
   config: RowModelConfig<TRow>,
-): RowModel<TRow> {
+): RowModelResult<TRow> {
   const { rows, previous } = config;
-  const identify = config.identify ?? defaultRowIdentifier;
+  const identify: (row: TRow) => unknown =
+    config.identify ?? defaultRowIdentifier;
+  // Named once, not per row: a declared identifier that answered with a
+  // non-identity is a different mistake from a record with no `id` at all.
+  // Both are fragments a renderer composes into a sentence, so neither
+  // tells the developer what to do about it; `identify` says that.
+  const identityRejection =
+    config.identify === undefined
+      ? "row record has no non-empty string id"
+      : "row identity must be a non-empty string";
   const reusable = new Map<string, RowEntry<TRow>>();
   for (const entry of previous?.entries ?? []) {
     reusable.set(entry.id, entry);
@@ -48,10 +64,10 @@ export default function createRowModel<TRow extends object>(
   for (const [position, record] of rows.entries()) {
     const id = identify(record);
     if (typeof id !== "string" || id === "") {
-      throw new Error("row identity must be a non-empty string");
+      return { status: "rejected", reason: identityRejection };
     }
     if (index.has(id)) {
-      throw new Error(`duplicate row id "${id}"`);
+      return { status: "rejected", reason: `duplicate row id "${id}"` };
     }
     const carried = reusable.get(id);
     const entry =
@@ -67,11 +83,14 @@ export default function createRowModel<TRow extends object>(
   }
 
   if (unmoved !== undefined) {
-    return unmoved;
+    return { status: "built", model: unmoved };
   }
-  return Object.freeze({
-    entries: Object.freeze(entries),
-    ids: Object.freeze(ids),
-    byId: (id: string): TRow | undefined => index.get(id),
-  });
+  return {
+    status: "built",
+    model: Object.freeze({
+      entries: Object.freeze(entries),
+      ids: Object.freeze(ids),
+      byId: (id: string): TRow | undefined => index.get(id),
+    }),
+  };
 }

--- a/packages/runtime/dataviews/src/lib/rows/createRowScopes.test.ts
+++ b/packages/runtime/dataviews/src/lib/rows/createRowScopes.test.ts
@@ -7,8 +7,8 @@
 import { describe, expect, it, vi } from "vitest";
 import createChannel from "../observable/createChannel.js";
 import createSelection from "../selection/createSelection.js";
-import createRowModel from "./createRowModel.js";
 import createRowScopes from "./createRowScopes.js";
+import { builtRowModel } from "./rowModel.fixtures.js";
 import type { RowModel } from "./types.js";
 
 type Machine = {
@@ -27,13 +27,13 @@ const harness = (
   rows: readonly Machine[],
   fields: readonly string[] = ["status", "cpu"],
 ) => {
-  const model = createRowModel({ rows });
+  const model = builtRowModel({ rows });
   const channel = createChannel<RowModel<Machine>>(model);
   const selection = createSelection();
   const scopes = createRowScopes({ rows: channel, selection, fields });
   const detach = scopes.observe();
   const publish = (next: readonly Machine[]): void => {
-    channel.set(createRowModel({ rows: next, previous: channel.get() }));
+    channel.set(builtRowModel({ rows: next, previous: channel.get() }));
   };
   return { channel, selection, scopes, publish, detach };
 };
@@ -128,7 +128,7 @@ describe("createRowScopes", () => {
       },
     });
     const unchanged = counted("running");
-    const channel = createChannel(createRowModel({ rows: [unchanged] }));
+    const channel = createChannel(builtRowModel({ rows: [unchanged] }));
     const selection = createSelection();
     const scopes = createRowScopes({
       rows: channel,
@@ -139,11 +139,11 @@ describe("createRowScopes", () => {
     const minted = reads;
     // The same record object comes back for an unchanged row, and records
     // are immutable, so nothing is re-read.
-    channel.set(createRowModel({ rows: [unchanged], previous: channel.get() }));
+    channel.set(builtRowModel({ rows: [unchanged], previous: channel.get() }));
     expect(reads).toBe(minted);
     // A replaced record is read once per observed field.
     channel.set(
-      createRowModel({ rows: [counted("stopped")], previous: channel.get() }),
+      builtRowModel({ rows: [counted("stopped")], previous: channel.get() }),
     );
     expect(reads).toBe(minted + 1);
     expect(scopes.scope("m-1").fields.status.get()).toBe("stopped");
@@ -171,7 +171,7 @@ describe("createRowScopes", () => {
   });
 
   it("observes nothing until it is asked to, then catches up", () => {
-    const model = createRowModel({ rows: [machine("m-1")] });
+    const model = builtRowModel({ rows: [machine("m-1")] });
     const channel = createChannel<RowModel<Machine>>(model);
     const selection = createSelection();
     const scopes = createRowScopes({
@@ -182,7 +182,7 @@ describe("createRowScopes", () => {
     // A registry nobody attached — a discarded render's, or a server
     // render's — subscribed to nothing, so this publication reaches it only
     // when it starts observing.
-    channel.set(createRowModel({ rows: [machine("m-1"), machine("m-2")] }));
+    channel.set(builtRowModel({ rows: [machine("m-1"), machine("m-2")] }));
     selection.set(["m-1"]);
     expect(scopes.ids.get()).toEqual(["m-1"]);
     scopes.observe();

--- a/packages/runtime/dataviews/src/lib/rows/defaultRowIdentifier.ts
+++ b/packages/runtime/dataviews/src/lib/rows/defaultRowIdentifier.ts
@@ -2,17 +2,10 @@ import readField from "./readField.js";
 
 /**
  * The identifier used where none is declared: the record's own `id`, which
- * must be a non-empty string. A record without one is a configuration
- * error, not a row with an unknown identity.
+ * must be a non-empty string. A record without one is a configuration error,
+ * not a row with an unknown identity, and the model rejects it — the read
+ * itself answers with whatever the record carried.
  */
-export default function defaultRowIdentifier<TRow extends object>(
-  row: TRow,
-): string {
-  const id = readField(row, "id");
-  if (typeof id !== "string" || id === "") {
-    throw new Error(
-      "row record has no non-empty string id; declare identify to name one",
-    );
-  }
-  return id;
+export default function defaultRowIdentifier(row: object): unknown {
+  return readField(row, "id");
 }

--- a/packages/runtime/dataviews/src/lib/rows/emptyRowModel.test.ts
+++ b/packages/runtime/dataviews/src/lib/rows/emptyRowModel.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+import EMPTY_ROW_MODEL from "./emptyRowModel.js";
+
+describe("EMPTY_ROW_MODEL", () => {
+  it("holds no entries and addresses no identity", () => {
+    expect(EMPTY_ROW_MODEL.entries).toEqual([]);
+    expect(EMPTY_ROW_MODEL.ids).toEqual([]);
+    expect(EMPTY_ROW_MODEL.byId("anything")).toBeUndefined();
+  });
+
+  it("is frozen, so the collections sharing it cannot change it", () => {
+    expect(Object.isFrozen(EMPTY_ROW_MODEL)).toBe(true);
+    expect(Object.isFrozen(EMPTY_ROW_MODEL.entries)).toBe(true);
+    expect(Object.isFrozen(EMPTY_ROW_MODEL.ids)).toBe(true);
+  });
+});

--- a/packages/runtime/dataviews/src/lib/rows/emptyRowModel.ts
+++ b/packages/runtime/dataviews/src/lib/rows/emptyRowModel.ts
@@ -1,0 +1,13 @@
+import type { RowModel } from "./types.js";
+
+/**
+ * The model of no rows. A model with no records holds no identities and no
+ * records to carry, so every empty collection can share this one.
+ */
+const EMPTY_ROW_MODEL: RowModel<never> = Object.freeze({
+  entries: Object.freeze([]),
+  ids: Object.freeze([]),
+  byId: () => undefined,
+});
+
+export default EMPTY_ROW_MODEL;

--- a/packages/runtime/dataviews/src/lib/rows/rowModel.fixtures.ts
+++ b/packages/runtime/dataviews/src/lib/rows/rowModel.fixtures.ts
@@ -1,0 +1,17 @@
+import type { RowModelConfig } from "./createRowModel.js";
+import createRowModel from "./createRowModel.js";
+import type { RowModel } from "./types.js";
+
+/**
+ * The model of a build the case expects to succeed, so a case about
+ * something else states its rows once and reads the model directly.
+ */
+export const builtRowModel = <TRow extends object>(
+  config: RowModelConfig<TRow>,
+): RowModel<TRow> => {
+  const result = createRowModel<TRow>(config);
+  if (result.status !== "built") {
+    throw new Error(`expected a built row model, got: ${result.reason}`);
+  }
+  return result.model;
+};

--- a/packages/runtime/dataviews/src/lib/rows/types.ts
+++ b/packages/runtime/dataviews/src/lib/rows/types.ts
@@ -34,6 +34,26 @@ export type RowModel<TRow extends object> = {
   readonly byId: (id: string) => TRow | undefined;
 };
 
+/**
+ * Whether a schema field applies to a row, by the field's type scoping.
+ * Value and empty are the field's own states; this is the third.
+ *
+ * Seam for the cells unit: a not-applicable cell draws a dash with the
+ * accessible text "not applicable", where an empty one still draws nothing.
+ */
+export type Applicability = "applies" | "not-applicable";
+
+/**
+ * What one model build produced. Building never throws: rows the table
+ * could not key reject the completion they arrived in, which the provider
+ * publishes as a failure, so the rows already displayed stay — reporting
+ * `refreshFailed`, or `stale` once the query has moved on — rather than being
+ * replaced by rows nothing can address.
+ */
+export type RowModelResult<TRow extends object> =
+  | { readonly status: "built"; readonly model: RowModel<TRow> }
+  | { readonly status: "rejected"; readonly reason: string };
+
 /** What every display entry carries, whatever its kind. */
 type DisplayEntryBase = {
   /**

--- a/packages/runtime/dataviews/src/lib/schema/createSchema.test.ts
+++ b/packages/runtime/dataviews/src/lib/schema/createSchema.test.ts
@@ -31,6 +31,34 @@ describe("createSchema", () => {
     ).toThrow("duplicate");
   });
 
+  it("keeps a field's record-type scoping as a frozen copy", () => {
+    const types = ["virtual-machine"];
+    const scoped = createSchema([
+      { field: "type", kind: "choices", options: ["container"], types },
+      { field: "secureboot", kind: "flag", types },
+    ]);
+    types.push("container");
+    // The copy answers, not the caller's array: a schema whose scoping
+    // could change under it would scope a field one way per read.
+    expect(scoped.fields[0].types).toEqual(["virtual-machine"]);
+    expect(scoped.fields[1].types).toEqual(["virtual-machine"]);
+    expect(Object.isFrozen(scoped.fields[0].types)).toBe(true);
+    expect(scoped.fields[0].options).toEqual(["container"]);
+  });
+
+  it("leaves an unscoped field with no scoping at all", () => {
+    expect(schema.fields[0]).not.toHaveProperty("types");
+    expect(schema.fields[1]).not.toHaveProperty("types");
+  });
+
+  it("rejects a field scoped to no record type", () => {
+    // The names themselves are the provider's to check against the
+    // discriminator; an empty list is the one mistake only the schema sees.
+    expect(() =>
+      createSchema([{ field: "secureboot", kind: "flag", types: [] }]),
+    ).toThrow('field "secureboot" is scoped to no record type');
+  });
+
   it("rejects a field name the flat query grammar cannot spell", () => {
     // A field is addressed on the wire by its own name, so a name carrying
     // the operator delimiter or colliding with a reserved parameter is

--- a/packages/runtime/dataviews/src/lib/schema/createSchema.ts
+++ b/packages/runtime/dataviews/src/lib/schema/createSchema.ts
@@ -166,15 +166,20 @@ export default function createSchema<
   // input cannot desynchronize the public list from the lookups: the
   // lookups answer from the frozen copies, not the originals.
   const storedFields = Object.freeze(
-    fields.map((definition) =>
-      definition.kind === "choices"
+    fields.map((definition) => {
+      const scoping =
+        definition.types === undefined
+          ? {}
+          : { types: Object.freeze([...definition.types]) };
+      return definition.kind === "choices"
         ? Object.freeze({
             field: definition.field,
             kind: definition.kind,
             options: Object.freeze([...definition.options]),
+            ...scoping,
           })
-        : Object.freeze({ ...definition }),
-    ),
+        : Object.freeze({ ...definition, ...scoping });
+    }),
   ) as TFields;
   const fieldNames = Object.freeze(
     storedFields.map((definition) => definition.field),
@@ -194,6 +199,14 @@ export default function createSchema<
     const unspellable = wireNameRejection(definition.field);
     if (unspellable !== null) {
       throw new Error(`schema ${unspellable}`);
+    }
+    // A field scoped to no type applies to no row at all. The provider
+    // checks the names themselves against the discriminator's options; an
+    // empty list is the one mistake only the schema can see.
+    if (definition.types !== undefined && definition.types.length === 0) {
+      throw new Error(
+        `field "${definition.field}" is scoped to no record type`,
+      );
     }
     if (definition.kind === "number") {
       const { min, max } = definition;

--- a/packages/runtime/dataviews/src/lib/schema/types.ts
+++ b/packages/runtime/dataviews/src/lib/schema/types.ts
@@ -31,12 +31,29 @@ export type DateField = {
   readonly kind: "date";
 };
 
-/** One schema field definition. */
-export type SchemaFieldDefinition =
-  | ChoicesField
-  | NumberField
-  | FlagField
-  | DateField;
+/**
+ * Which record types a field applies to; absent means every one of them.
+ *
+ * For a row of another type the field is *not applicable* — a third state
+ * beside value and empty. It never satisfies a predicate, `isSet` included,
+ * and it reads as absent to ordering, so a predicate on a scoped field
+ * restricts the result to that field's types by meaning and never by
+ * spelling: nothing is added to the query, the wire or a saved view.
+ *
+ * That holds because a source writes no value at a scoped key for a row the
+ * field does not apply to, which is the source's obligation and not checked
+ * here: a row carrying one anyway is filtered and ordered by it.
+ *
+ * A collection declaring no discriminator has one record type, so scoping
+ * has nothing to exclude and every field applies to every row.
+ */
+type TypeScoped = {
+  readonly types?: readonly string[];
+};
+
+/** One schema field definition; any kind may be scoped to record types. */
+export type SchemaFieldDefinition = TypeScoped &
+  (ChoicesField | NumberField | FlagField | DateField);
 
 /** The applied semantic value a field's predicate carries. */
 export type AppliedOf<TField extends SchemaFieldDefinition> = TField extends {

--- a/packages/runtime/dataviews/src/lib/source/createArraySource.test.ts
+++ b/packages/runtime/dataviews/src/lib/source/createArraySource.test.ts
@@ -298,6 +298,20 @@ describe("createArraySource", () => {
     ]);
   });
 
+  it("reports a record with no usable identity as missing", async () => {
+    // A record nothing can address is a record no lookup can name: it never
+    // enters the index, rather than keying it under a value that is not one.
+    const live = createArraySource<RowRecord>({
+      rows: [{ id: "a" }, { name: "unidentified" }, { id: "" }],
+      fields: ["id"],
+    });
+    await expect(live.lookup?.(["a", "unidentified", ""])).resolves.toEqual([
+      { id: "a", status: "found", record: { id: "a" } },
+      { id: "unidentified", status: "missing" },
+      { id: "", status: "missing" },
+    ]);
+  });
+
   it("looks up against the replacement records after a write", async () => {
     const live = source();
     // The identity index is kept between lookups, so the write is what has

--- a/packages/runtime/dataviews/src/lib/source/createArraySource.ts
+++ b/packages/runtime/dataviews/src/lib/source/createArraySource.ts
@@ -69,7 +69,8 @@ export default function createArraySource<TRow extends object = RowRecord>(
   config: ArraySourceConfig<TRow>,
 ): ArraySource<TRow> {
   const read = config.read ?? readProperty;
-  const identify = config.identify ?? defaultRowIdentifier;
+  const identify: (row: TRow) => unknown =
+    config.identify ?? defaultRowIdentifier;
   const searchFields = config.searchFields ?? [];
   const capabilities = copyCapabilities({
     filter: Object.fromEntries(
@@ -143,7 +144,12 @@ export default function createArraySource<TRow extends object = RowRecord>(
       if (index === null) {
         index = new Map<string, TRow>();
         for (const row of rows) {
-          index.set(identify(row), row);
+          const id = identify(row);
+          // A record with no usable identity cannot be addressed by one, so
+          // it never enters the index and a lookup of it answers "missing".
+          if (typeof id === "string" && id !== "") {
+            index.set(id, row);
+          }
         }
       }
       const built = index;


### PR DESCRIPTION
## Done

Lets one collection hold records of several types — LXD containers and virtual machines in one instance list, say — without changing anything for a collection that holds one.

**A record declares its type through one schema field, and nothing else.** The provider is told which `choices` field is the discriminator:

```ts
createDataViewsProvider({ schema, capabilities, types: { field: "type" } });
```

Every row carries that field. A source whose backend sends none writes it while building its rows. A row whose value is not one of the field's options fails the completion instead of being displayed, the same way an ambiguous identity does — a row the schema cannot describe has no columns to show it in.

**A field can apply to only some types.** A schema field may list the types it belongs to:

```ts
{ field: "secureboot", kind: "choices", options: ["true", "false"], types: ["virtual-machine"] }
```

For a row of any other type the field is *not applicable* — a third state, distinct from empty. It never satisfies a filter, "is set" included, so filtering on secure boot narrows the list to virtual machines by meaning rather than by rewriting the query. Ordering already treats it as an absent value, so nothing there changes. `provider.applicability(field, row)` answers which state a cell is in.

**The provider remembers selected types.** `provider.recordType(id)` returns the type of any selected record that has been on screen, so a later action can tell which selected records it applies to without looking anything up. The row currently displayed always outranks what was remembered.

**A single-type collection pays nothing.** With no `types` declared, no typing object exists, no row is read for a type, `applicability` answers "applies" and `recordType` answers null. A test proves it by completing records whose type key throws on read.

**Changed:** `createRowModel` returns `{ status: "built", model } | { status: "rejected", reason }` instead of throwing, so the provider can publish a rejected page as a failure the table explains.

Rendering the not-applicable state and acting on mixed selections are the next units; the seams they need are in place and named in the types.

Merge order: #1249 must land first — this is based on it, so the diff here is only this change.

## QA

- `bun run check` green at the root (68 projects).
- `@canonical/dataviews-core`: 927 tests; `@canonical/dataviews-react`: 359 tests, unchanged. Both at 100% branch/function/line/statement coverage, both builds green, Storybook builds, all 50 stories render in StrictMode with no console output.
- Mutation-checked: 15 mutants against the typing, scoping and memory rules, all killed.
- Review found and fixed a real ordering bug: the remembered type answered ahead of the row on screen.

### PR readiness check

- [x] PR title follows the Conventional Commits format.
- [x] The code follows the appropriate code standards.
- [x] The package defines `check`, `check:fix`, `test`, `build`, `build:all`.
- [x] No visual change — Chromatic skipped.

---

https://claude.ai/code/session_0143BZrKuhi4j3YdemH5SbqD
